### PR TITLE
Decide phase

### DIFF
--- a/f3/granite.go
+++ b/f3/granite.go
@@ -329,6 +329,9 @@ func (i *instance) isJustified(msg *GMessage) bool {
 		// COMMIT for bottom is always justified.
 		round := i.roundState(msg.Round)
 		return msg.Value.IsZero() || round.prepared.HasStrongQuorumAgreement(msg.Value.HeadCIDOrZero())
+	} else if msg.Step == DECIDE {
+		// DECIDE needs no justification
+		return !msg.Value.IsZero()
 	}
 	return false
 }

--- a/f3/granite.go
+++ b/f3/granite.go
@@ -492,7 +492,7 @@ func (i *instance) tryDecide(value ECChain) {
 	}
 
 	if strongQuorum {
-		i.decide(value, 0)
+		i.decide(value, i.round)
 	}
 }
 

--- a/f3/granite.go
+++ b/f3/granite.go
@@ -264,7 +264,7 @@ func (i *instance) receiveOne(msg *GMessage) {
 	// Every COMMIT phase stays open to new messages even after the protocol moves on to
 	// a new round. Late-arriving COMMITS can still (must) cause a local decision, *in that round*.
 	// DECIDE messages are also independent of current phase or round.
-	if msg.Step == COMMIT {
+	if msg.Step == COMMIT && i.phase != DECIDE {
 		i.tryCommit(msg.Round)
 	} else if msg.Step == DECIDE {
 		i.tryDecide(msg.Value)

--- a/f3/granite.go
+++ b/f3/granite.go
@@ -452,7 +452,7 @@ func (i *instance) tryCommit(round uint32) {
 	timeoutExpired := i.host.Time() >= i.phaseTimeout
 
 	if len(foundQuorum) > 0 && !foundQuorum[0].IsZero() && i.phase != DECIDE && i.phase != TERMINATED {
-		// A participant may be forced to terminate a value that's not its preferred chain.
+		// A participant may be forced to decide a value that's not its preferred chain.
 		// The participant isn't influencing that decision against their interest, just accepting it.
 		i.value = foundQuorum[0]
 		i.beginDecide()

--- a/f3/granite.go
+++ b/f3/granite.go
@@ -459,7 +459,7 @@ func (i *instance) tryCommit(round uint32) {
 	} else if i.round == round && i.phase == COMMIT && timeoutExpired && committed.ReceivedFromStrongQuorum() {
 		// Adopt any non-empty value committed by another participant (there can only be one).
 		// This node has observed the strong quorum of PREPARE messages that justify it,
-		// and mean that some other nodes may terminate that value (if they observe more COMMITs).
+		// and mean that some other nodes may decide that value (if they observe more COMMITs).
 		for _, v := range committed.ListAllValues() {
 			if !v.IsZero() {
 				if !i.isAcceptable(v) {

--- a/f3/granite.go
+++ b/f3/granite.go
@@ -264,7 +264,7 @@ func (i *instance) receiveOne(msg *GMessage) {
 	// Try to complete the current phase.
 	// Every COMMIT phase stays open to new messages even after the protocol moves on to
 	// a new round. Late-arriving COMMITS can still (must) cause a local decision, *in that round*.
-	if msg.Step == COMMIT && i.phase != TERMINATED {
+	if msg.Step == COMMIT && i.phase != DECIDE {
 		i.tryCommit(msg.Round)
 	} else {
 		i.tryCompletePhase()

--- a/f3/granite.go
+++ b/f3/granite.go
@@ -446,7 +446,7 @@ func (i *instance) beginCommit() {
 func (i *instance) tryCommit(round uint32) {
 	// Unlike all other phases, the COMMIT phase stays open to new messages even after an initial quorum is reached,
 	// and the algorithm moves on to the next round.
-	// A subsequent COMMIT message can cause the node to terminate, so there is no check on the current phase.
+	// A subsequent COMMIT message can cause the node to decide, so there is no check on the current phase.
 	committed := i.roundState(round).committed
 	foundQuorum := committed.ListStrongQuorumAgreedValues()
 	timeoutExpired := i.host.Time() >= i.phaseTimeout

--- a/f3/participant.go
+++ b/f3/participant.go
@@ -14,9 +14,9 @@ type Participant struct {
 	nextInstance uint32
 	// Current Granite instance.
 	granite *instance
-	// The output from the last decided Granite instance.
+	// The output from the last terminated Granite instance.
 	finalised TipSet
-	// The round number at which the last instance was decided.
+	// The round number at which the last instance was terminated.
 	finalisedRound uint32
 }
 
@@ -82,15 +82,15 @@ func (p *Participant) ReceiveAlarm(payload string) {
 }
 
 func (p *Participant) handleDecision() {
-	if p.decided() {
+	if p.terminated() {
 		p.finalised = *p.granite.value.Head()
 		p.finalisedRound = p.granite.round
 		p.granite = nil
 	}
 }
 
-func (p *Participant) decided() bool {
-	return p.granite != nil && p.granite.phase == DECIDE
+func (p *Participant) terminated() bool {
+	return p.granite != nil && p.granite.phase == TERMINATED
 }
 
 func (p *Participant) Describe() string {


### PR DESCRIPTION
Extending #29, (new PR as I have no pushing rights on @matejpavlovic 's fork). From @matejpavlovic :
> Resolves #2 .
> 
> Implements the DECIDE phase in Granite.
> As created, this PR is incomplete. The round numbers of the DECIDE messages should be consolidated. Currently, 0 is always output as the decision round (which is the most probable reason for the tests failing).

