### PR TITLE
Move message signature validation into instance, and document the message attestation properties.

### DIFF
--- a/f3/api.go
+++ b/f3/api.go
@@ -18,7 +18,7 @@ type Message interface{}
 // Receives a Granite protocol message.
 type MessageReceiver interface {
 	// Receives a message from another participant.
-	// The message is assumed to have been validated as being sent by `msg.Sender`.
+	// No validation may be assumed to have been performed on the message.
 	ReceiveMessage(msg *GMessage)
 	ReceiveAlarm(payload string)
 }

--- a/f3/granite.go
+++ b/f3/granite.go
@@ -28,6 +28,12 @@ const TERMINATED = "TERMINATED"
 
 const DOMAIN_SEPARATION_TAG = "GPBFT"
 
+// A message in the Granite protocol.
+// The same message structure is used for all rounds and phases.
+// Note that the message is self-attesting so no separate envelope or signature is needed.
+// - The signature field fixes the included sender ID via the implied public key;
+// - The signature payload includes all fields a sender can freely choose;
+// - The ticket field is a signature of the same public key, so also self-attesting.
 type GMessage struct {
 	// ID of the sender/signer of this message (a miner actor ID).
 	Sender ActorID
@@ -291,6 +297,12 @@ func (i *instance) isValid(msg *GMessage) bool {
 	} else if msg.Step == DECIDE {
 		// DECIDE needs no justification
 		return !msg.Value.IsZero()
+	}
+
+	sigPayload := SignaturePayload(msg.Instance, msg.Round, msg.Step, msg.Value)
+	if !i.host.Verify(msg.Sender, sigPayload, msg.Signature) {
+		i.log("invalid signature on %v", msg)
+		return false
 	}
 
 	return true

--- a/f3/participant.go
+++ b/f3/participant.go
@@ -58,12 +58,8 @@ func (p *Participant) ReceiveECChain(chain ECChain) {
 }
 
 // Receives a Granite message from some other participant.
+// The message is delivered to the Granite instance if it is for the current instance.
 func (p *Participant) ReceiveMessage(msg *GMessage) {
-	sigPayload := SignaturePayload(msg.Instance, msg.Round, msg.Step, msg.Value)
-	if !p.host.Verify(msg.Sender, sigPayload, msg.Signature) {
-		p.host.Log("P%d: invalid signature on %v", p.id, msg)
-		return
-	}
 	if p.granite != nil && msg.Instance == p.granite.instanceID {
 		p.granite.Receive(msg)
 		p.handleDecision()


### PR DESCRIPTION
The public key to use to verify signatures will come from the power table being used as the base for the specific Granite instance. So the verification needs to be done there.

See also #40 for propagating validation results back out to the network layer.