### PR TITLE
Remove unnecessary wrapping of GMessage fields.

### DIFF
--- a/adversary/equiv.go
+++ b/adversary/equiv.go
@@ -56,44 +56,36 @@ func (w *WitholdCommit) Begin() {
 	// All victims need to see QUALITY and PREPARE in order to send their COMMIT,
 	// but only the one victim will see our COMMIT.
 	w.host.BroadcastSynchronous(w.id, f3.GMessage{
-		Sender: w.id,
-		Current: f3.SignedMessage{
-			Instance: 0,
-			Round:    0,
-			Step:     f3.QUALITY_PHASE,
-			Value:    w.victimValue,
-		},
+		Sender:    w.id,
+		Instance:  0,
+		Round:     0,
+		Phase:     f3.QUALITY_PHASE,
+		Value:     w.victimValue,
 		Signature: w.host.Sign(w.id, f3.SignaturePayload(0, 0, f3.QUALITY_PHASE, w.victimValue)),
 	})
 	w.host.BroadcastSynchronous(w.id, f3.GMessage{
-		Sender: w.id,
-		Current: f3.SignedMessage{
-			Instance: 0,
-			Round:    0,
-			Step:     f3.PREPARE_PHASE,
-			Value:    w.victimValue,
-		},
+		Sender:    w.id,
+		Instance:  0,
+		Round:     0,
+		Phase:     f3.PREPARE_PHASE,
+		Value:     w.victimValue,
 		Signature: w.host.Sign(w.id, f3.SignaturePayload(0, 0, f3.PREPARE_PHASE, w.victimValue)),
 	})
 
 	message := f3.GMessage{
-		Sender: w.id,
-		Current: f3.SignedMessage{
-			Instance: 0,
-			Round:    0,
-			Step:     f3.COMMIT_PHASE,
-			Value:    w.victimValue,
-		},
+		Sender:    w.id,
+		Instance:  0,
+		Round:     0,
+		Phase:     f3.COMMIT_PHASE,
+		Value:     w.victimValue,
 		Signature: w.host.Sign(w.id, f3.SignaturePayload(0, 0, f3.COMMIT_PHASE, w.victimValue)),
 	}
 	payload := f3.SignaturePayload(0, 0, f3.PREPARE_PHASE, w.victimValue)
 	justification := f3.Justification{
-		Payload: f3.SignedMessage{
-			Step:     f3.PREPARE_PHASE,
-			Value:    w.victimValue,
-			Instance: 0,
-			Round:    0,
-		},
+		Instance: 0,
+		Round:    0,
+		Phase:    f3.PREPARE_PHASE,
+		Value:    w.victimValue,
 		QuorumSignature: f3.QuorumSignature{
 			Signers:   bitfield.New(),
 			Signature: nil,
@@ -121,23 +113,23 @@ func (w *WitholdCommit) AllowMessage(_ f3.ActorID, to f3.ActorID, msg f3.Message
 				toAnyVictim = true
 			}
 		}
-		if gmsg.Current.Step == f3.QUALITY_PHASE {
+		if gmsg.Phase == f3.QUALITY_PHASE {
 			// Don't allow victims to see dissenting QUALITY.
-			if toAnyVictim && !gmsg.Current.Value.Eq(w.victimValue) {
+			if toAnyVictim && !gmsg.Value.Eq(w.victimValue) {
 				return false
 			}
-		} else if gmsg.Current.Step == f3.PREPARE_PHASE {
+		} else if gmsg.Phase == f3.PREPARE_PHASE {
 			// Don't allow victims to see dissenting PREPARE.
-			if toAnyVictim && !gmsg.Current.Value.Eq(w.victimValue) {
+			if toAnyVictim && !gmsg.Value.Eq(w.victimValue) {
 				return false
 			}
-		} else if gmsg.Current.Step == f3.COMMIT_PHASE {
+		} else if gmsg.Phase == f3.COMMIT_PHASE {
 			// Allow only the main victim to see our COMMIT.
 			if !toMainVictim && gmsg.Sender == w.id {
 				return false
 			}
 			// Don't allow the main victim to see any dissenting COMMIts.
-			if toMainVictim && !gmsg.Current.Value.Eq(w.victimValue) {
+			if toMainVictim && !gmsg.Value.Eq(w.victimValue) {
 				return false
 			}
 		}

--- a/f3/participant.go
+++ b/f3/participant.go
@@ -68,12 +68,12 @@ func (p *Participant) ReceiveECChain(chain ECChain) error {
 // Receives a Granite message from some other participant.
 // The message is delivered to the Granite instance if it is for the current instance.
 func (p *Participant) ReceiveMessage(msg *GMessage) error {
-	if p.granite != nil && msg.Current.Instance == p.granite.instanceID {
+	if p.granite != nil && msg.Instance == p.granite.instanceID {
 		if err := p.granite.Receive(msg); err != nil {
 			return fmt.Errorf("error receiving message: %w", err)
 		}
 		p.handleDecision()
-	} else if msg.Current.Instance >= p.nextInstance {
+	} else if msg.Instance >= p.nextInstance {
 		// Queue messages for later instances
 		p.mpool = append(p.mpool, msg)
 	}


### PR DESCRIPTION
Removes the `SignedMessage` type which wrapped the non-self-certifying fields of GMessage. I think this was introduced to foster some sort of re-use, but it resulted in a lot of noise of `.Current` and `.Payload` throughout all code that looks at messages. It turns out to be more code to handle the wrapping than just use the four fields directly.