### PR TITLE
Replace panics where relevant

### DIFF
--- a/f3/powertable.go
+++ b/f3/powertable.go
@@ -36,10 +36,7 @@ func NewPowerTable(entries []PowerEntry) *PowerTable {
 		lookup[entry.ID] = i
 		total.Add(total, entry.Power)
 	}
-
-	if len(entries) != len(lookup) {
-		panic("duplicate power entries")
-	}
+	
 	return &PowerTable{
 		Entries: entries,
 		Lookup:  lookup,


### PR DESCRIPTION
See #11 

Notice that the removed errors/panics are because (by the execution of the code within the same function) it is impossible for the error/panic to ever occur (either because of the size of slices created or because the error has been checked for previously in the function). 

Also, left panics that reflect a situation of the state of f3 that should never happen (and thus a panic is what suits the code IMO). 