### PR TITLE
Remove tipset weights, panic on multiple strong quora

### DIFF
--- a/f3/chain.go
+++ b/f3/chain.go
@@ -13,35 +13,19 @@ type TipSet struct {
 	Epoch int64
 	// The CID of the tipset.
 	CID TipSetID
-	// The EC consensus weight of the tipset.
-	Weight uint64
 }
 
 // Creates a new tipset.
-func NewTipSet(epoch int64, cid TipSetID, weight uint64) TipSet {
+func NewTipSet(epoch int64, cid TipSetID) TipSet {
 	return TipSet{
-		Epoch:  epoch,
-		CID:    cid,
-		Weight: weight,
+		Epoch: epoch,
+		CID:   cid,
 	}
-}
-
-// Compares two tipsets by weight, breaking ties with CID.
-// Note that the real weight function breaks ties with VRF tickets.
-func (t *TipSet) Compare(other *TipSet) int {
-	if t.Weight == other.Weight {
-		return t.CID.Compare(other.CID)
-	} else if t.Weight < other.Weight {
-		return -1
-	}
-	return 1
 }
 
 // Compares tipsets for equality.
 func (t *TipSet) Eq(other *TipSet) bool {
-	return t.Epoch == other.Epoch &&
-		t.CID == other.CID &&
-		t.Weight == other.Weight
+	return t.Epoch == other.Epoch && t.CID == other.CID
 }
 
 func (t *TipSet) String() string {
@@ -113,9 +97,8 @@ func (c ECChain) BaseChain() ECChain {
 // The new tipset is given an epoch and weight one greater than the previous head.
 func (c ECChain) Extend(cid TipSetID) ECChain {
 	return append(c, TipSet{
-		Epoch:  c[0].Epoch + 1,
-		CID:    cid,
-		Weight: c[0].Weight + 1,
+		Epoch: c[0].Epoch + 1,
+		CID:   cid,
 	})
 }
 

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -48,7 +48,7 @@ func NewSimulation(simConfig Config, graniteConfig f3.GraniteConfig, traceLevel 
 	}
 
 	// Create genesis tipset, which all participants are expected to agree on as a base.
-	genesis := f3.NewTipSet(100, f3.NewTipSetIDFromString("genesis"), 1)
+	genesis := f3.NewTipSet(100, f3.NewTipSetIDFromString("genesis"))
 	baseChain, err := f3.NewChain(genesis)
 	if err != nil {
 		panic(fmt.Errorf("failed creating new chain: %w", err))


### PR DESCRIPTION
Remove weight from tipsets.

For QUALITY phase, chains with strong quorum are ordered by length and there cannot be strong quorum for more than one at the same length. For other phases, there cannot be strong quorum for multiple values at all. Panic if these assumptions are broken. (This panic should later be caught #11).

This is a subset of and alternative to #60.