### PR TITLE
Remove unused payload from alarm callback

### DIFF
--- a/adversary/absent.go
+++ b/adversary/absent.go
@@ -33,7 +33,7 @@ func (a *Absent) ReceiveMessage(_ *f3.GMessage) error {
 	return nil
 }
 
-func (a *Absent) ReceiveAlarm(_ string) error {
+func (a *Absent) ReceiveAlarm() error {
 	return nil
 }
 

--- a/adversary/withhold.go
+++ b/adversary/withhold.go
@@ -50,7 +50,7 @@ func (w *WithholdCommit) ReceiveMessage(_ *f3.GMessage) error {
 	return nil
 }
 
-func (w *WithholdCommit) ReceiveAlarm(_ string) error {
+func (w *WithholdCommit) ReceiveAlarm() error {
 	return nil
 }
 

--- a/f3/api.go
+++ b/f3/api.go
@@ -20,7 +20,7 @@ type MessageReceiver interface {
 	// Receives a message from another participant.
 	// No validation may be assumed to have been performed on the message.
 	ReceiveMessage(msg *GMessage) error
-	ReceiveAlarm(payload string) error
+	ReceiveAlarm() error
 }
 
 // Interface which network participants must implement.
@@ -41,7 +41,7 @@ type Clock interface {
 	// Returns the current network time.
 	Time() float64
 	// Sets an alarm to fire at the given timestamp.
-	SetAlarm(sender ActorID, payload string, at float64)
+	SetAlarm(sender ActorID, at float64)
 }
 
 type Signer interface {

--- a/f3/participant.go
+++ b/f3/participant.go
@@ -81,10 +81,10 @@ func (p *Participant) ReceiveMessage(msg *GMessage) error {
 	return nil
 }
 
-func (p *Participant) ReceiveAlarm(payload string) error {
+func (p *Participant) ReceiveAlarm() error {
 	// TODO include instance ID in alarm message, and filter here.
 	if p.granite != nil {
-		if err := p.granite.ReceiveAlarm(payload); err != nil {
+		if err := p.granite.ReceiveAlarm(); err != nil {
 			return fmt.Errorf("failed receiving alarm: %w", err)
 		}
 		p.handleDecision()

--- a/sim/network.go
+++ b/sim/network.go
@@ -99,11 +99,11 @@ func (n *Network) Time() float64 {
 	return n.clock
 }
 
-func (n *Network) SetAlarm(sender f3.ActorID, payload string, at float64) {
+func (n *Network) SetAlarm(sender f3.ActorID, at float64) {
 	n.queue.Insert(messageInFlight{
 		source:    sender,
 		dest:      sender,
-		payload:   "ALARM:" + payload,
+		payload:   "ALARM",
 		deliverAt: at,
 	})
 }
@@ -150,9 +150,9 @@ func (n *Network) Tick(adv AdversaryReceiver) (bool, error) {
 	msg := n.queue.Remove(i)
 	n.clock = msg.deliverAt
 	payloadStr, ok := msg.payload.(string)
-	if ok && strings.HasPrefix(payloadStr, "ALARM:") {
+	if ok && strings.HasPrefix(payloadStr, "ALARM") {
 		n.log(TraceRecvd, "P%d %s", msg.source, payloadStr)
-		if err := n.participants[msg.dest].ReceiveAlarm(strings.TrimPrefix(payloadStr, "ALARM:")); err != nil {
+		if err := n.participants[msg.dest].ReceiveAlarm(); err != nil {
 			return false, fmt.Errorf("failed receiving alarm: %w", err)
 		}
 	} else {


### PR DESCRIPTION
Alarm handling is idempotent. We no longer need to know which phase an alarm is targetting. Extra alarms, e.g. from a prior instance which since terminated, will not cause any problems.

The code assumes that a participant can have multiple alarms pending. We could probably make this tighter with a "replace alarm" semantic if we think about it, and if it's too difficult to implement multiple alarm.s