### PR TITLE
Use full TipSet object as map key, avoid using CIDs

### DIFF
--- a/f3/chain.go
+++ b/f3/chain.go
@@ -73,7 +73,7 @@ func (c ECChain) IsZero() bool {
 	return len(c) == 0
 }
 
-// Returns a pointer to the base tipset.
+// Returns the base tipset.
 func (c ECChain) Base() TipSet {
 	return c[0]
 }

--- a/f3/chain.go
+++ b/f3/chain.go
@@ -1,13 +1,18 @@
 package f3
 
 import (
+	"encoding/binary"
 	"fmt"
+	"io"
 	"reflect"
 	"strconv"
 	"strings"
 )
 
 // Information about a tipset that is relevant to the F3 protocol.
+// This is a lightweight value type comprising 3 machine words.
+// Fields are exported for CBOR generation, but are opqaue and should not be accessed
+// within the protocol implementation.
 type TipSet struct {
 	// The epoch of the blocks in the tipset.
 	Epoch int64
@@ -23,17 +28,27 @@ func NewTipSet(epoch int64, cid TipSetID) TipSet {
 	}
 }
 
-// Compares tipsets for equality.
-func (t *TipSet) Eq(other *TipSet) bool {
-	return t.Epoch == other.Epoch && t.CID == other.CID
+// Returns a zero value tipset.
+// The zero value is not a meaningful tipset and may be used to represent bottom.
+func ZeroTipSet() TipSet {
+	return TipSet{}
 }
 
-func (t *TipSet) String() string {
+func (t TipSet) IsZero() bool {
+	return t.Epoch == 0 && t.CID.IsZero()
+}
+
+func (t TipSet) String() string {
 	var b strings.Builder
 	b.Write(t.CID.Bytes())
 	b.WriteString("@")
 	b.WriteString(strconv.FormatInt(t.Epoch, 10))
 	return b.String()
+}
+
+func (t TipSet) MarshalForSigning(w io.Writer) {
+	_ = binary.Write(w, binary.BigEndian, t.Epoch)
+	_, _ = w.Write(t.CID.Bytes())
 }
 
 // A chain of tipsets comprising a base (the last finalised tipset from which the chain extends).
@@ -59,8 +74,8 @@ func (c ECChain) IsZero() bool {
 }
 
 // Returns a pointer to the base tipset.
-func (c ECChain) Base() *TipSet {
-	return &c[0]
+func (c ECChain) Base() TipSet {
+	return c[0]
 }
 
 // Returns the suffix of the chain after the base.
@@ -75,16 +90,16 @@ func (c ECChain) Suffix() []TipSet {
 // Returns a pointer to the last tipset in the chain.
 // This could be the base tipset if there is no suffix.
 // This will panic on a zero value.
-func (c ECChain) Head() *TipSet {
-	return &c[len(c)-1]
+func (c ECChain) Head() TipSet {
+	return c[len(c)-1]
 }
 
 // Returns the CID of the head tipset, or empty string for a zero value
-func (c ECChain) HeadCIDOrZero() TipSetID {
+func (c ECChain) HeadOrZero() TipSet {
 	if c.IsZero() {
-		return ZeroTipSetID()
+		return ZeroTipSet()
 	}
-	return c.Head().CID
+	return c.Head()
 }
 
 // Returns a new chain with the same base and no suffix.
@@ -120,16 +135,16 @@ func (c ECChain) SameBase(other ECChain) bool {
 	if c.IsZero() {
 		return false
 	}
-	return c[0].Eq(&other[0])
+	return c[0] == other[0]
 }
 
 // Check whether a chain has a specific base tipset.
 // Always false for a zero value.
-func (c ECChain) HasBase(t *TipSet) bool {
+func (c ECChain) HasBase(t TipSet) bool {
 	if c.IsZero() {
 		return false
 	}
-	return c[0].Eq(t)
+	return c[0] == t
 }
 
 // Checks whether a chain has some prefix (including the base).
@@ -142,7 +157,7 @@ func (c ECChain) HasPrefix(other ECChain) bool {
 		return false
 	}
 	for i := range other {
-		if !c[i].Eq(&other[i]) {
+		if c[i] != other[i] {
 			return false
 		}
 	}
@@ -150,9 +165,9 @@ func (c ECChain) HasPrefix(other ECChain) bool {
 }
 
 // Checks whether a chain has some tipset (including as its base).
-func (c ECChain) HasTipset(t *TipSet) bool {
+func (c ECChain) HasTipset(t TipSet) bool {
 	for _, t2 := range c {
-		if t2.Eq(t) {
+		if t2 == t {
 			return true
 		}
 	}

--- a/f3/chain.go
+++ b/f3/chain.go
@@ -87,7 +87,7 @@ func (c ECChain) Suffix() []TipSet {
 	return c[1:]
 }
 
-// Returns a pointer to the last tipset in the chain.
+// Returns the last tipset in the chain.
 // This could be the base tipset if there is no suffix.
 // This will panic on a zero value.
 func (c ECChain) Head() TipSet {

--- a/f3/participant.go
+++ b/f3/participant.go
@@ -94,7 +94,7 @@ func (p *Participant) ReceiveAlarm() error {
 
 func (p *Participant) handleDecision() {
 	if p.terminated() {
-		p.finalised = *p.granite.value.Head()
+		p.finalised = p.granite.value.Head()
 		p.finalisedRound = p.granite.round
 		p.granite = nil
 	}

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -164,10 +164,10 @@ func (s *Simulation) Run(maxRounds uint64) error {
 	first, _ := s.Participants[0].Finalised()
 	for i, p := range s.Participants {
 		f, _ := p.Finalised()
-		if f.Eq(&f3.TipSet{}) {
+		if f.IsZero() {
 			return fmt.Errorf("participant %d finalized empty tipset", i)
 		}
-		if !f.Eq(&first) {
+		if f != first {
 			return fmt.Errorf("finalized tipset mismatch between first participant and participant %d", i)
 		}
 	}
@@ -178,12 +178,12 @@ func (s *Simulation) PrintResults() {
 	var firstFin f3.TipSet
 	for _, p := range s.Participants {
 		thisFin, _ := p.Finalised()
-		if firstFin.Eq(&f3.TipSet{}) {
+		if firstFin.IsZero() {
 			firstFin = thisFin
 		}
-		if thisFin.Eq(&f3.TipSet{}) {
+		if thisFin.IsZero() {
 			fmt.Printf("‼️ Participant %d did not decide\n", p.ID())
-		} else if !thisFin.Eq(&firstFin) {
+		} else if thisFin != firstFin {
 			fmt.Printf("‼️ Participant %d decided %v, but %d decided %v\n", p.ID(), thisFin, s.Participants[0].ID(), firstFin)
 		}
 	}

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -210,22 +210,22 @@ func newAsyncConfig(honestCount int, latencySeed int) sim.Config {
 	}
 }
 
-func expectRoundDecision(t *testing.T, sm *sim.Simulation, expectedRound uint64, expected ...*f3.TipSet) {
+func expectRoundDecision(t *testing.T, sm *sim.Simulation, expectedRound uint64, expected ...f3.TipSet) {
 	decision, round := sm.Participants[0].Finalised()
 	require.Equal(t, expectedRound, round)
 
 	for _, e := range expected {
-		if decision.CID == e.CID {
+		if decision == e {
 			return
 		}
 	}
 	require.Fail(t, fmt.Sprintf("decided %s, expected one of %s", &decision, expected))
 }
 
-func expectEventualDecision(t *testing.T, sm *sim.Simulation, expected ...*f3.TipSet) {
+func expectEventualDecision(t *testing.T, sm *sim.Simulation, expected ...f3.TipSet) {
 	decision, _ := sm.Participants[0].Finalised()
 	for _, e := range expected {
-		if decision.CID == e.CID {
+		if decision == e {
 			return
 		}
 	}

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -40,5 +40,5 @@ func TestWitholdCommit1(t *testing.T) {
 	// The adversary could convince the victim to decide a, so all must decide a.
 	require.NoError(t, err)
 	decision, _ := sm.Participants[0].Finalised()
-	require.Equal(t, *a.Head(), decision)
+	require.Equal(t, a.Head(), decision)
 }


### PR DESCRIPTION
The existing code has a subtle bug where some participants could disagree about which epoch a tipset is for, and the correspondence between CID and epoch never checked. We now use the full TipSet object as a map key and for all other uses, and never look at either the CID or Epoch individually. Two nodes are only proposing the same thing if the TipSet fields fully match.

Closes #10