### PR TITLE
Serialize phase as an integer for signatures.

### DIFF
--- a/f3/granite.go
+++ b/f3/granite.go
@@ -109,7 +109,7 @@ func (p Payload) MarshalForSigning(nn NetworkName) []byte {
 	buf.WriteString(":")
 	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
-	_ = binary.Write(&buf, binary.BigEndian, []byte(p.Step.String()))
+	_ = binary.Write(&buf, binary.BigEndian, p.Step)
 	for _, t := range p.Value {
 		t.MarshalForSigning(&buf)
 	}


### PR DESCRIPTION
The existing was a bit wierd.

CBOR-gen already serializes the value as an integer in messages.