### PR TITLE
Make message validate an exported API of instance and participant, to be called before receiving a message.

### DIFF
--- a/adversary/absent.go
+++ b/adversary/absent.go
@@ -29,8 +29,12 @@ func (a *Absent) ReceiveECChain(_ gpbft.ECChain) error {
 	return nil
 }
 
-func (a *Absent) ReceiveMessage(_ *gpbft.GMessage) error {
-	return nil
+func (a *Absent) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
+	return true, nil
+}
+
+func (a *Absent) ReceiveMessage(_ *gpbft.GMessage) (bool, error) {
+	return true, nil
 }
 
 func (a *Absent) ReceiveAlarm() error {

--- a/adversary/withhold.go
+++ b/adversary/withhold.go
@@ -46,8 +46,12 @@ func (w *WithholdCommit) ReceiveECChain(_ gpbft.ECChain) error {
 	return nil
 }
 
-func (w *WithholdCommit) ReceiveMessage(_ *gpbft.GMessage) error {
-	return nil
+func (a *WithholdCommit) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
+	return true, nil
+}
+
+func (a *WithholdCommit) ReceiveMessage(_ *gpbft.GMessage) (bool, error) {
+	return true, nil
 }
 
 func (w *WithholdCommit) ReceiveAlarm() error {

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -19,9 +19,12 @@ type Message interface{}
 
 // Receives a Granite protocol message.
 type MessageReceiver interface {
+	// Validates a message received from another participant, if possible.
+	// Returns whether the message could be validated, and an error if it was invalid.
+	ValidateMessage(msg *GMessage) (bool, error)
 	// Receives a message from another participant.
-	// No validation may be assumed to have been performed on the message.
-	ReceiveMessage(msg *GMessage) error
+	// The message must already have been validated.
+	ReceiveMessage(msg *GMessage) (bool, error)
 	ReceiveAlarm() error
 }
 


### PR DESCRIPTION
@Kubuxu please let me know if this will likely work for your integration.

A complication is that message can only be validated for the currently executing instance. Messages for prior instances can be ignored by this one (but should probably still propagate up to some bound). Messages for future instances can't be validated but must be held and re-delivered when the appropriate Granite instance begins. The Participant used to have a message pool in anticipation of this, but I think that responsibility should be pushed out to the integration instead.

Closes #40. 