### PR TITLE
Add API for participant to notify host of decisions, with signed justification.

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -72,3 +72,10 @@ type Host interface {
 	// Logs a message at the "logic" level
 	Log(format string, args ...interface{})
 }
+
+type DecisionReceiver interface {
+	// Receives a finality decision from the instance, with signatures from a strong quorum
+	// of participants justifying it.
+	// The decision payload always has round = 0 and step = DECIDE.
+	ReceiveDecision(participant ActorID, decision Justification)
+}

--- a/sim/fakesig.go
+++ b/sim/fakesig.go
@@ -36,7 +36,7 @@ func (_ *FakeSigner) Verify(signer gpbft.PubKey, msg, sig []byte) error {
 	hash.Write(msg)
 
 	if !bytes.Equal(hash.Sum(nil), sig) {
-		return xerrors.Errorf("signature miss-match: %x != %x", hash.Sum(nil), sig)
+		return xerrors.Errorf("signature mismatch: %x != %x", hash.Sum(nil), sig)
 	}
 	return nil
 }
@@ -69,7 +69,7 @@ func (_ *FakeSigner) VerifyAggregate(payload, aggSig []byte, signers []gpbft.Pub
 		aggHash.Write(sig)
 	}
 	if !bytes.Equal(aggSig, aggHash.Sum(nil)) {
-		return xerrors.Errorf("aggregate signature miss-match")
+		return xerrors.Errorf("aggregate signature mismatch")
 	}
 
 	return nil

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -18,7 +18,7 @@ func TestWitholdCommit1(t *testing.T) {
 		LatencySeed: int64(i),
 		LatencyMean: 10 * time.Millisecond, // Near-synchrony
 	}, GraniteConfig(), sim.TraceNone)
-	adv := adversary.NewWitholdCommit(99, sm.Network, &sm.PowerTable)
+	adv := adversary.NewWitholdCommit(99, sm.Network, sm.PowerTable)
 	sm.SetAdversary(adv, 3) // Adversary has 30% of 10 total power.
 
 	a := sm.Base.Extend(sm.CIDGen.Sample())
@@ -40,6 +40,7 @@ func TestWitholdCommit1(t *testing.T) {
 	}
 	// The adversary could convince the victim to decide a, so all must decide a.
 	require.NoError(t, err)
-	decision, _ := sm.Participants[0].Finalised()
-	require.Equal(t, a.Head(), decision)
+	decision, ok := sm.GetDecision(0, 0)
+	require.True(t, ok)
+	require.Equal(t, a, decision)
 }


### PR DESCRIPTION
This is a part of extending to multiple instances #27. Adds a callback API for the GPBFT participant to notify the host of a finality decision. Internally, the instance still terminates by setting appropriate state, and the outer participant checks for termination after each message/alarm. This prevents unintended re-entrancy into the instance.

Following this change through to the simulation framework was surprisingly involved. It now better represents what the real host integration might look like, but still only handles a single instance.