### PR TITLE
Fix message validation to check the justification signers have strong quorum

### DIFF
--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -445,7 +445,7 @@ func (i *instance) validateMessage(msg *GMessage) error {
 			return fmt.Errorf("message %v has unexpected phase for justification", msg)
 		}
 
-		// Check justification signature.
+		// Check justification power and signature.
 		justificationPower := NewStoragePower(0)
 		signers := make([]PubKey, 0)
 		if err := msg.Justification.Signers.ForEach(func(bit uint64) error {
@@ -457,6 +457,10 @@ func (i *instance) validateMessage(msg *GMessage) error {
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to iterate over signers: %w", err)
+		}
+
+		if !hasStrongQuorum(justificationPower, i.powerTable.Total) {
+			return fmt.Errorf("message %v has justification with insufficient power: %v", msg, justificationPower)
 		}
 
 		payload := msg.Justification.Vote.MarshalForSigning(i.host.NetworkName())


### PR DESCRIPTION
This is highlighting our embarassing lack of unit testing, stemming from origins as just a simulation.