### PR TITLE
Remove abstraction noise around VRF construction and verification

### DIFF
--- a/blssig/signer.go
+++ b/blssig/signer.go
@@ -17,6 +17,7 @@ type Signer struct {
 	scheme   sign.AggregatableScheme
 	keyGroup kyber.Group
 
+	// Maps public keys to private keys.
 	keys map[string]kyber.Scalar
 }
 

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -50,7 +50,7 @@ type Clock interface {
 type Signer interface {
 	// GenerateKey is used for testing
 	GenerateKey() PubKey
-	// Signs a message for the given sender ID.
+	// Signs a message with the secret key corresponding to a public key.
 	Sign(sender PubKey, msg []byte) ([]byte, error)
 }
 

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -19,11 +19,6 @@ type GraniteConfig struct {
 	DeltaBackOffExponent float64
 }
 
-type VRFer interface {
-	VRFTicketSource
-	VRFTicketVerifier
-}
-
 type Phase uint8
 
 const (
@@ -124,7 +119,6 @@ func (m GMessage) String() string {
 type instance struct {
 	config        GraniteConfig
 	host          Host
-	vrf           VRFer
 	participantID ActorID
 	instanceID    uint64
 	// The EC chain input to this instance.
@@ -163,7 +157,6 @@ type instance struct {
 func newInstance(
 	config GraniteConfig,
 	host Host,
-	vrf VRFer,
 	participantID ActorID,
 	instanceID uint64,
 	input ECChain,
@@ -175,7 +168,6 @@ func newInstance(
 	return &instance{
 		config:        config,
 		host:          host,
-		vrf:           vrf,
 		participantID: participantID,
 		instanceID:    instanceID,
 		input:         input,
@@ -372,7 +364,7 @@ func (i *instance) validateMessage(msg *GMessage) error {
 		if msg.Vote.Value.IsZero() {
 			return xerrors.Errorf("unexpected zero value for converge phase")
 		}
-		if !i.vrf.VerifyTicket(i.beacon, i.instanceID, msg.Vote.Round, senderPubKey, i.host.NetworkName(), msg.Ticket) {
+		if !VerifyTicket(i.beacon, i.instanceID, msg.Vote.Round, senderPubKey, i.host, msg.Ticket) {
 			return xerrors.Errorf("failed to verify ticket from %v", msg.Sender)
 		}
 	case DECIDE_PHASE:
@@ -528,7 +520,8 @@ func (i *instance) beginConverge() {
 			panic("beginConverge called but no justification for proposal")
 		}
 	}
-	ticket, err := i.vrf.MakeTicket(i.beacon, i.instanceID, i.round, i.host.NetworkName())
+	_, pubkey := i.powerTable.Get(i.participantID)
+	ticket, err := MakeTicket(i.beacon, i.instanceID, i.round, pubkey, i.host)
 	if err != nil {
 		i.log("error while creating VRF ticket: %v", err)
 		return

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -10,7 +10,6 @@ type Participant struct {
 	id     ActorID
 	config GraniteConfig
 	host   Host
-	vrf    VRFer
 
 	// Chain to use as input for the next Granite instance.
 	nextChain ECChain
@@ -24,8 +23,8 @@ type Participant struct {
 	finalisedRound uint64
 }
 
-func NewParticipant(id ActorID, config GraniteConfig, host Host, vrf VRFer) *Participant {
-	return &Participant{id: id, config: config, host: host, vrf: vrf}
+func NewParticipant(id ActorID, config GraniteConfig, host Host) *Participant {
+	return &Participant{id: id, config: config, host: host}
 }
 
 func (p *Participant) ID() ActorID {
@@ -48,7 +47,7 @@ func (p *Participant) ReceiveCanonicalChain(chain ECChain, power PowerTable, bea
 	p.nextChain = chain
 	if p.granite == nil {
 		var err error
-		p.granite, err = newInstance(p.config, p.host, p.vrf, p.id, p.nextInstance, chain, power, beacon)
+		p.granite, err = newInstance(p.config, p.host, p.id, p.nextInstance, chain, power, beacon)
 		if err != nil {
 			return fmt.Errorf("failed creating new granite instance: %w", err)
 		}

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -77,8 +77,7 @@ func NewSimulation(simConfig Config, graniteConfig gpbft.GraniteConfig, traceLev
 	participants := make([]*gpbft.Participant, simConfig.HonestCount)
 	for i := 0; i < len(participants); i++ {
 		pubKey := ntwk.GenerateKey()
-		vrf := gpbft.NewVRF(pubKey, ntwk.Signer, ntwk.Verifier)
-		participants[i] = gpbft.NewParticipant(gpbft.ActorID(i), graniteConfig, ntwk, vrf)
+		participants[i] = gpbft.NewParticipant(gpbft.ActorID(i), graniteConfig, ntwk)
 		ntwk.AddParticipant(participants[i], pubKey)
 		if err := genesisPower.Add(participants[i].ID(), gpbft.NewStoragePower(1), pubKey); err != nil {
 			panic(fmt.Errorf("failed adding participant to power table: %w", err))


### PR DESCRIPTION
The VRF interfaces were intially created before we had any signing (even fake). The ticket payload creation need not be abstracted, and the signing can be directly invoked on the abstract host Signer.