### PR TITLE
Remove self participant ID from some host methods.

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -49,7 +49,7 @@ type Clock interface {
 	// Returns the current network time.
 	Time() time.Time
 	// Sets an alarm to fire at the given timestamp.
-	SetAlarm(sender ActorID, at time.Time)
+	SetAlarm(at time.Time)
 }
 
 type Signer interface {
@@ -68,6 +68,13 @@ type Verifier interface {
 	VerifyAggregate(payload, aggSig []byte, signers []PubKey) error
 }
 
+type DecisionReceiver interface {
+	// Receives a finality decision from the instance, with signatures from a strong quorum
+	// of participants justifying it.
+	// The decision payload always has round = 0 and step = DECIDE.
+	ReceiveDecision(decision Justification)
+}
+
 // Participant interface to the host system resources.
 type Host interface {
 	Chain
@@ -75,13 +82,7 @@ type Host interface {
 	Clock
 	Signer
 	Verifier
+	DecisionReceiver
 	// Logs a message at the "logic" level
 	Log(format string, args ...interface{})
-}
-
-type DecisionReceiver interface {
-	// Receives a finality decision from the instance, with signatures from a strong quorum
-	// of participants justifying it.
-	// The decision payload always has round = 0 and step = DECIDE.
-	ReceiveDecision(participant ActorID, decision Justification)
 }

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -315,7 +315,7 @@ func (i *instance) receiveOne(msg *GMessage) error {
 		if err := i.tryDecide(); err != nil {
 			return fmt.Errorf("failed to decide: %w", err)
 		}
-		
+
 	default:
 		i.log("unexpected message %v", msg)
 	}
@@ -765,7 +765,7 @@ func (i *instance) alarmAfterSynchrony() time.Time {
 	delta := time.Duration(float64(i.config.Delta) *
 		math.Pow(i.config.DeltaBackOffExponent, float64(i.round)))
 	timeout := i.host.Time().Add(2 * delta)
-	i.host.SetAlarm(i.participantID, timeout)
+	i.host.SetAlarm(timeout)
 	return timeout
 }
 

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -7,10 +7,9 @@ import (
 
 // An F3 participant runs repeated instances of Granite to finalise longer chains.
 type Participant struct {
-	id        ActorID
-	config    GraniteConfig
-	host      Host
-	decisions DecisionReceiver
+	id     ActorID
+	config GraniteConfig
+	host   Host
 
 	// Instance identifier for the next Granite instance.
 	nextInstance uint64
@@ -37,8 +36,8 @@ func (e *PanicError) Unwrap() error {
 	return e.Err
 }
 
-func NewParticipant(id ActorID, config GraniteConfig, host Host, decisions DecisionReceiver) *Participant {
-	return &Participant{id: id, config: config, host: host, decisions: decisions}
+func NewParticipant(id ActorID, config GraniteConfig, host Host) *Participant {
+	return &Participant{id: id, config: config, host: host}
 }
 
 func (p *Participant) ID() ActorID {
@@ -157,7 +156,7 @@ func (p *Participant) handleDecision() {
 		p.finalised = p.granite.terminationValue
 		p.terminatedDuringRound = p.granite.round
 		p.granite = nil
-		p.decisions.ReceiveDecision(p.id, *p.finalised)
+		p.host.ReceiveDecision(*p.finalised)
 	}
 }
 

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -82,11 +82,12 @@ func NewSimulation(simConfig Config, graniteConfig gpbft.GraniteConfig, traceLev
 	for i := 0; i < len(participants); i++ {
 		id := gpbft.ActorID(i)
 		host := &SimHost{
-			Network: ntwk,
-			EC:      ec,
-			id:      id,
+			Network:     ntwk,
+			EC:          ec,
+			DecisionLog: decisions,
+			id:          id,
 		}
-		participants[i] = gpbft.NewParticipant(id, graniteConfig, host, decisions)
+		participants[i] = gpbft.NewParticipant(id, graniteConfig, host)
 		pubKey := ntwk.GenerateKey()
 		ntwk.AddParticipant(participants[i], pubKey)
 		ec.AddParticipant(id, gpbft.NewStoragePower(1), pubKey)
@@ -200,6 +201,7 @@ func (s *Simulation) Describe() string {
 type SimHost struct {
 	*Network
 	*EC
+	*DecisionLog
 	id gpbft.ActorID
 }
 
@@ -212,6 +214,14 @@ func (v *SimHost) GetCanonicalChain() (chain gpbft.ECChain, power gpbft.PowerTab
 	power = *v.PowerTable
 	beacon = v.Beacon
 	return
+}
+
+func (v *SimHost) SetAlarm(at time.Time) {
+	v.Network.SetAlarm(v.id, at)
+}
+
+func (v *SimHost) ReceiveDecision(decision gpbft.Justification) {
+	v.DecisionLog.ReceiveDecision(v.id, decision)
 }
 
 // Receives and validates finality decisions


### PR DESCRIPTION
The API presented by the host to the participant shouldn't require the participant to echo back its ID in method calls. This cleans up most of them. @Kubuxu FYI.

One still remaining is that the `Signer` API requires a node to extracts its own public key from the power table to pass as a parameter. This is convenient for testing Signer, but somewhat awkward for the node (it's a bit of a fluke that it can get its public key this way). 

- [x] Merge #107 and rebase