### PR TITLE
Change alarm semantics to support at most one at a time

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -49,6 +49,8 @@ type Clock interface {
 	// Returns the current network time.
 	Time() time.Time
 	// Sets an alarm to fire at the given timestamp.
+	// At most one alarm can be set at a time.
+	// Setting an alarm replaces any previous alarm that has not yet fired.
 	SetAlarm(at time.Time)
 }
 


### PR DESCRIPTION
The protocol only needs one timeout at a time. Supporting many was merely simple in simulation. 

Replacing old alarms will be helpful when implementing multiple instances. I expect it also to be simpler in the production implementation, even if more involved in simulation.