### PR TITLE
Participant begins new instance after terminating the previous one

### DIFF
--- a/cmd/f3sim/f3sim.go
+++ b/cmd/f3sim/f3sim.go
@@ -38,10 +38,10 @@ func main() {
 		sm := sim.NewSimulation(simConfig, graniteConfig, *traceLevel)
 
 		// Same chain for everyone.
-		candidate := sm.Base().Extend(sm.CIDGen.Sample())
+		candidate := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: *participantCount, Chain: candidate})
 
-		err := sm.Run(*maxRounds)
+		err := sm.Run(1, *maxRounds)
 		if err != nil {
 			sm.PrintResults()
 		}

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -74,7 +74,7 @@ type DecisionReceiver interface {
 	// Receives a finality decision from the instance, with signatures from a strong quorum
 	// of participants justifying it.
 	// The decision payload always has round = 0 and step = DECIDE.
-	ReceiveDecision(decision Justification)
+	ReceiveDecision(decision *Justification)
 }
 
 // Participant interface to the host system resources.

--- a/gpbft/powertable.go
+++ b/gpbft/powertable.go
@@ -79,10 +79,27 @@ func (p *PowerTable) Get(id ActorID) (*StoragePower, PubKey) {
 	return nil, nil
 }
 
-// Has returns true iff the ActorID is part of the power table with positive power
+// Has returns true iff the ActorID is part of the power table with positive power.
 func (p *PowerTable) Has(id ActorID) bool {
 	index, ok := p.Lookup[id]
 	return ok && p.Entries[index].Power.Cmp(NewStoragePower(0)) > 0
+}
+
+// Creates a deep copy of the PowerTable.
+func (p *PowerTable) Copy() *PowerTable {
+	entries := make([]PowerEntry, len(p.Entries))
+	copy(entries, p.Entries)
+	lookup := make(map[ActorID]int, len(p.Lookup))
+	for k, v := range p.Lookup {
+		lookup[k] = v
+	}
+	total := NewStoragePower(0)
+	total.Add(total, p.Total)
+	return &PowerTable{
+		Entries: entries,
+		Lookup:  lookup,
+		Total:   total,
+	}
 }
 
 ///// General helpers /////

--- a/test/absent_test.go
+++ b/test/absent_test.go
@@ -19,9 +19,9 @@ func TestAbsent(t *testing.T) {
 		// Adversary has 1/4 of power.
 		sm.SetAdversary(adversary.NewAbsent(99, sm.HostFor(99)), 1)
 
-		a := sm.Base().Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
-		require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	}
 }

--- a/test/decide_test.go
+++ b/test/decide_test.go
@@ -15,16 +15,16 @@ func TestImmediateDecide(t *testing.T) {
 	}, GraniteConfig(), sim.TraceNone)
 
 	// Create adversarial node
-	value := sm.Base().Extend(sm.CIDGen.Sample())
-	adv := adversary.NewImmediateDecide(99, sm.HostFor(99), sm.PowerTable(), value)
+	value := sm.Base(0).Extend(sm.CIDGen.Sample())
+	adv := adversary.NewImmediateDecide(99, sm.HostFor(99), sm.PowerTable(0), value)
 
 	// Add the adversary to the simulation with 3/4 of total power.
 	sm.SetAdversary(adv, 3)
 
 	// The honest node starts with a different chain (on the same base).
-	sm.SetChains(sim.ChainCount{Count: 1, Chain: sm.Base().Extend(sm.CIDGen.Sample())})
+	sm.SetChains(sim.ChainCount{Count: 1, Chain: sm.Base(0).Extend(sm.CIDGen.Sample())})
 	adv.Begin()
-	err := sm.Run(MAX_ROUNDS)
+	err := sm.Run(1, MAX_ROUNDS)
 	if err != nil {
 		fmt.Printf("%s", sm.Describe())
 		sm.PrintResults()

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -13,28 +13,28 @@ import (
 
 func TestSingleton(t *testing.T) {
 	sm := sim.NewSimulation(newSyncConfig(1), GraniteConfig(), sim.TraceNone)
-	a := sm.Base().Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a})
 
-	require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	expectDecision(t, sm, a.Head())
 }
 
 func TestSyncPair(t *testing.T) {
 	sm := sim.NewSimulation(newSyncConfig(2), GraniteConfig(), sim.TraceNone)
-	a := sm.Base().Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
-	require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	expectDecision(t, sm, a.Head())
 }
 
 func TestSyncPairBLS(t *testing.T) {
 	sm := sim.NewSimulation(newSyncConfig(2).UseBLS(), GraniteConfig(), sim.TraceNone)
-	a := sm.Base().Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
-	require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	expectDecision(t, sm, a.Head())
 }
 
@@ -42,56 +42,56 @@ func TestASyncPair(t *testing.T) {
 	for i := 0; i < ASYNC_ITERS; i++ {
 		//fmt.Println("i =", i)
 		sm := sim.NewSimulation(newAsyncConfig(2, i), GraniteConfig(), sim.TraceNone)
-		a := sm.Base().Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
-		require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
-		expectDecision(t, sm, a.Head(), sm.Base().Head())
+		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
+		expectDecision(t, sm, a.Head(), sm.Base(0).Head())
 	}
 }
 
 func TestSyncPairDisagree(t *testing.T) {
 	sm := sim.NewSimulation(newSyncConfig(2), GraniteConfig(), sim.TraceNone)
-	a := sm.Base().Extend(sm.CIDGen.Sample())
-	b := sm.Base().Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.CIDGen.Sample())
+	b := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
 
-	require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	// Decide base chain as the only common value.
-	expectDecision(t, sm, sm.Base().Head())
+	expectDecision(t, sm, sm.Base(0).Head())
 }
 
 func TestSyncPairDisagreeBLS(t *testing.T) {
 	sm := sim.NewSimulation(newSyncConfig(2).UseBLS(), GraniteConfig(), sim.TraceNone)
-	a := sm.Base().Extend(sm.CIDGen.Sample())
-	b := sm.Base().Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.CIDGen.Sample())
+	b := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
 
-	require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	// Decide base chain as the only common value.
-	expectDecision(t, sm, sm.Base().Head())
+	expectDecision(t, sm, sm.Base(0).Head())
 }
 
 func TestAsyncPairDisagree(t *testing.T) {
 	for i := 0; i < ASYNC_ITERS; i++ {
 		//fmt.Println("i =", i)
 		sm := sim.NewSimulation(newAsyncConfig(2, i), GraniteConfig(), sim.TraceNone)
-		a := sm.Base().Extend(sm.CIDGen.Sample())
-		b := sm.Base().Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
 
-		require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 		// Decide base chain as the only common value.
-		expectDecision(t, sm, sm.Base().Head())
+		expectDecision(t, sm, sm.Base(0).Head())
 	}
 }
 
 func TestSyncAgreement(t *testing.T) {
 	for n := 3; n <= 50; n++ {
 		sm := sim.NewSimulation(newSyncConfig(n), GraniteConfig(), sim.TraceNone)
-		a := sm.Base().Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
-		require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 		// Synchronous, agreeing groups always decide the candidate.
 		expectDecision(t, sm, a.Head())
 	}
@@ -104,11 +104,11 @@ func TestAsyncAgreement(t *testing.T) {
 		for i := 0; i < ASYNC_ITERS; i++ {
 			//fmt.Println("n =", n, "i =", i)
 			sm := sim.NewSimulation(newAsyncConfig(n, i), GraniteConfig(), sim.TraceNone)
-			a := sm.Base().Extend(sm.CIDGen.Sample())
+			a := sm.Base(0).Extend(sm.CIDGen.Sample())
 			sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
-			require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
-			expectDecision(t, sm, sm.Base().Head(), a.Head())
+			require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
+			expectDecision(t, sm, sm.Base(0).Head(), a.Head())
 		}
 	}
 }
@@ -116,26 +116,26 @@ func TestAsyncAgreement(t *testing.T) {
 func TestSyncHalves(t *testing.T) {
 	for n := 4; n <= 50; n += 2 {
 		sm := sim.NewSimulation(newSyncConfig(n), GraniteConfig(), sim.TraceNone)
-		a := sm.Base().Extend(sm.CIDGen.Sample())
-		b := sm.Base().Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: n / 2, Chain: a}, sim.ChainCount{Count: n / 2, Chain: b})
 
-		require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 		// Groups split 50/50 always decide the base.
-		expectDecision(t, sm, sm.Base().Head())
+		expectDecision(t, sm, sm.Base(0).Head())
 	}
 }
 
 func TestSyncHalvesBLS(t *testing.T) {
 	for n := 4; n <= 10; n += 2 {
 		sm := sim.NewSimulation(newSyncConfig(n).UseBLS(), GraniteConfig(), sim.TraceNone)
-		a := sm.Base().Extend(sm.CIDGen.Sample())
-		b := sm.Base().Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: n / 2, Chain: a}, sim.ChainCount{Count: n / 2, Chain: b})
 
-		require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 		// Groups split 50/50 always decide the base.
-		expectDecision(t, sm, sm.Base().Head())
+		expectDecision(t, sm, sm.Base(0).Head())
 	}
 }
 
@@ -144,13 +144,13 @@ func TestAsyncHalves(t *testing.T) {
 	for n := 4; n <= 2; n += 2 {
 		for i := 0; i < ASYNC_ITERS; i++ {
 			sm := sim.NewSimulation(newAsyncConfig(n, i), GraniteConfig(), sim.TraceNone)
-			a := sm.Base().Extend(sm.CIDGen.Sample())
-			b := sm.Base().Extend(sm.CIDGen.Sample())
+			a := sm.Base(0).Extend(sm.CIDGen.Sample())
+			b := sm.Base(0).Extend(sm.CIDGen.Sample())
 			sm.SetChains(sim.ChainCount{Count: n / 2, Chain: a}, sim.ChainCount{Count: n / 2, Chain: b})
 
-			require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+			require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 			// Groups split 50/50 always decide the base.
-			expectDecision(t, sm, sm.Base().Head())
+			expectDecision(t, sm, sm.Base(0).Head())
 		}
 	}
 }
@@ -159,14 +159,14 @@ func TestRequireStrongQuorumToProgress(t *testing.T) {
 	t.Parallel()
 	for i := 0; i < ASYNC_ITERS; i++ {
 		sm := sim.NewSimulation(newAsyncConfig(30, i), GraniteConfig(), sim.TraceNone)
-		a := sm.Base().Extend(sm.CIDGen.Sample())
-		b := sm.Base().Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		// No strict > quorum.
 		sm.SetChains(sim.ChainCount{Count: 20, Chain: a}, sim.ChainCount{Count: 10, Chain: b})
 
-		require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 		// Must decide base.
-		expectDecision(t, sm, sm.Base().Head())
+		expectDecision(t, sm, sm.Base(0).Head())
 	}
 }
 
@@ -174,7 +174,7 @@ func TestLongestCommonPrefix(t *testing.T) {
 	// This test uses a synchronous configuration to ensure timely message delivery.
 	// If async, it is possible to decide the base chain if QUALITY messages are delayed.
 	sm := sim.NewSimulation(newSyncConfig(4), GraniteConfig(), sim.TraceAll)
-	ab := sm.Base().Extend(sm.CIDGen.Sample())
+	ab := sm.Base(0).Extend(sm.CIDGen.Sample())
 	abc := ab.Extend(sm.CIDGen.Sample())
 	abd := ab.Extend(sm.CIDGen.Sample())
 	abe := ab.Extend(sm.CIDGen.Sample())
@@ -186,7 +186,7 @@ func TestLongestCommonPrefix(t *testing.T) {
 		sim.ChainCount{Count: 1, Chain: abf},
 	)
 
-	require.NoErrorf(t, sm.Run(MAX_ROUNDS), "%s", sm.Describe())
+	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	// Must decide ab, the longest common prefix.
 	expectDecision(t, sm, ab.Head())
 }

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -18,11 +18,11 @@ func TestWitholdCommit1(t *testing.T) {
 		LatencySeed: int64(i),
 		LatencyMean: 10 * time.Millisecond, // Near-synchrony
 	}, GraniteConfig(), sim.TraceNone)
-	adv := adversary.NewWitholdCommit(99, sm.HostFor(99), sm.PowerTable())
+	adv := adversary.NewWitholdCommit(99, sm.HostFor(99), sm.PowerTable(0))
 	sm.SetAdversary(adv, 3) // Adversary has 30% of 10 total power.
 
-	a := sm.Base().Extend(sm.CIDGen.Sample())
-	b := sm.Base().Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.CIDGen.Sample())
+	b := sm.Base(0).Extend(sm.CIDGen.Sample())
 	// Of 7 nodes, 4 victims will prefer chain A, 3 others will prefer chain B.
 	// The adversary will target the first to decide, and withhold COMMIT from the rest.
 	// After the victim decides in round 0, the adversary stops participating.
@@ -33,7 +33,7 @@ func TestWitholdCommit1(t *testing.T) {
 
 	adv.Begin()
 	sm.SetChains(sim.ChainCount{Count: 4, Chain: a}, sim.ChainCount{Count: 3, Chain: b})
-	err := sm.Run(MAX_ROUNDS)
+	err := sm.Run(1, MAX_ROUNDS)
 	if err != nil {
 		fmt.Printf("%s", sm.Describe())
 		sm.PrintResults()


### PR DESCRIPTION
The participant now immediately starts a new instance after terminating the previous one. The simulator generates chains to provide to these subsequent instances, though for now is limited to supplying all participants with the same chain after the first instance.

~One API change to support this is was adding instance as a parameter when pulling the next chain. It should be possible to do without this, which I might attempt.~

Closes #27, with some follow-up work in #113