### PR TITLE
Add a test exercising multiple instances under ideal conditions

### DIFF
--- a/sim/sim.go
+++ b/sim/sim.go
@@ -199,7 +199,10 @@ func (s *Simulation) Run(instanceCount uint64, maxRounds uint64) error {
 // Returns the decision for a participant in an instance.
 func (s *Simulation) GetDecision(instance uint64, participant gpbft.ActorID) (gpbft.ECChain, bool) {
 	v, ok := s.Decisions.Decisions[instance][participant]
-	return v.Vote.Value, ok
+	if ok {
+		return v.Vote.Value, ok
+	}
+	return gpbft.ECChain{}, ok
 }
 
 func (s *Simulation) PrintResults() {

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"fmt"
+	"github.com/filecoin-project/go-f3/sim"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+///// Tests for multiple chained instances of the protocol.
+
+func TestMultiInstanceAgreement(t *testing.T) {
+	sm := sim.NewSimulation(sim.Config{
+		HonestCount: 10,
+		LatencyMean: LATENCY_ASYNC,
+	}, GraniteConfig(), sim.TraceNone)
+
+	// All nodes start with the same chain and will observe the same extensions of that chain
+	// in subsequent instances.
+	sm.SetChains(sim.ChainCount{Count: 10, Chain: sm.Base(0).Extend(sm.CIDGen.Sample())})
+
+	// NOTE: This test fails with values much higher than this as the participants
+	// get too far out of sync.
+	// See https://github.com/filecoin-project/go-f3/issues/113
+	instances := uint64(1750)
+	lastInstance := instances - 1
+	err := sm.Run(instances, MAX_ROUNDS)
+	if err != nil {
+		fmt.Printf("%s", sm.Describe())
+		sm.PrintResults()
+	}
+	require.NoError(t, err)
+
+	// The expected decision is the base for the next instance.
+	expected := sm.EC.Instances[lastInstance+1].Base
+	for _, participant := range sm.Participants {
+		decision, ok := sm.GetDecision(lastInstance, participant.ID())
+		require.True(t, ok, "no decision for participant %d", participant.ID())
+		require.Equal(t, expected.Head(), decision.Head())
+	}
+}


### PR DESCRIPTION
This test fails if the instance count is pushed far above about 1750. I think this is because instances get too far out of sync. This may be resolved by #113.

Note that the immediate instance-based chain visibility is also unrealistic. A better chain model would be timestamp based.