### PR TITLE
Scale power in the range 0-0xffff

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -154,7 +154,13 @@ func verifyFinalityCertificateSignature(verifier gpbft.Verifier, powerTable gpbf
 				"finality certificate for instance %d specifies a signer %d but we only have %d entries in the power table",
 				cert.GPBFTInstance, i, len(powerTable))
 		}
-		signerPowers += scaled[i]
+		power := scaled[i]
+		if power == 0 {
+			return xerrors.Errorf(
+				"finality certificate for instance %d specifies a signer %d but they have no effective power after scaling",
+				cert.GPBFTInstance, powerTable[i].ID)
+		}
+		signerPowers += power
 		signers = append(signers, powerTable[i].PubKey)
 		return nil
 	}); err != nil {

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -141,29 +141,28 @@ func ValidateFinalityCertificates(verifier gpbft.Verifier, network gpbft.Network
 // any other parts of the certificate, just that the _value_ has been signed by a majority of the
 // power.
 func verifyFinalityCertificateSignature(verifier gpbft.Verifier, powerTable gpbft.PowerEntries, nn gpbft.NetworkName, cert FinalityCertificate) error {
-	totalPower := new(gpbft.StoragePower)
-	for i := range powerTable {
-		totalPower = totalPower.Add(totalPower, powerTable[i].Power)
+	scaled, totalScaled, err := powerTable.Scaled()
+	if err != nil {
+		return xerrors.Errorf("failed to scale power table: %w", err)
 	}
 
 	signers := make([]gpbft.PubKey, 0, len(powerTable))
-	signerPowers := new(gpbft.StoragePower)
+	var signerPowers uint16
 	if err := cert.Signers.ForEach(func(i uint64) error {
 		if i >= uint64(len(powerTable)) {
 			return xerrors.Errorf(
 				"finality certificate for instance %d specifies a signer %d but we only have %d entries in the power table",
 				cert.GPBFTInstance, i, len(powerTable))
 		}
-		signer := &powerTable[i]
-		signerPowers = signerPowers.Add(signerPowers, signer.Power)
-		signers = append(signers, signer.PubKey)
+		signerPowers += scaled[i]
+		signers = append(signers, powerTable[i].PubKey)
 		return nil
 	}); err != nil {
 		return err
 	}
 
-	if !gpbft.IsStrongQuorum(signerPowers, totalPower) {
-		return xerrors.Errorf("finality certificate for instance %d has insufficient power: %s < 2/3 %s", cert.GPBFTInstance, signerPowers, totalPower)
+	if !gpbft.IsStrongQuorum(signerPowers, totalScaled) {
+		return xerrors.Errorf("finality certificate for instance %d has insufficient power: %d < 2/3 %d", cert.GPBFTInstance, signerPowers, totalScaled)
 	}
 
 	payload := &gpbft.Payload{

--- a/f3.go
+++ b/f3.go
@@ -3,6 +3,7 @@ package f3
 import (
 	"bytes"
 	"context"
+	"errors"
 
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/gpbft"
@@ -47,6 +48,9 @@ type clientImpl struct {
 func (mc clientImpl) BroadcastMessage(ctx context.Context, mb *gpbft.MessageBuilder) error {
 	msg, err := mb.Build(mc.nn, mc.SignerWithMarshaler, mc.id)
 	if err != nil {
+		if errors.Is(err, gpbft.ErrNoPower) {
+			return nil
+		}
 		mc.Log("building message for: %d: %+v", mc.id, err)
 		return err
 	}

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -911,7 +911,7 @@ func (i *instance) broadcast(round uint64, step Phase, value ECChain, createTick
 		mb.SetBeaconForTicket(i.beacon)
 	}
 
-	_ = i.participant.host.RequestBroadcast(&mb)
+	_ = i.participant.host.RequestBroadcast(mb)
 }
 
 // Sets an alarm to be delivered after a synchrony delay.

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -561,7 +561,11 @@ func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMes
 			if int(bit) >= len(powerTable.Entries) {
 				return fmt.Errorf("invalid signer index: %d", bit)
 			}
-			justificationPower += powerTable.ScaledPower[bit]
+			power := powerTable.ScaledPower[bit]
+			if power == 0 {
+				return xerrors.Errorf("signer %d has no power", powerTable.Entries[bit].ID)
+			}
+			justificationPower += power
 			signers = append(signers, powerTable.Entries[bit].PubKey)
 			return nil
 		}); err != nil {

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -1338,16 +1338,23 @@ func scalePower(power, total *StoragePower) (uint16, error) {
 	return uint16(scaled.Uint64()), nil
 }
 
+func divCeil(a, b uint16) uint16 {
+	quo := a / b
+	rem := a % b
+	if rem != 0 {
+		quo += 1
+	}
+	return quo
+}
+
 // Check whether a portion of storage power is a strong quorum of the total
 func IsStrongQuorum(part uint16, whole uint16) bool {
-	// XXX ceiling!
-	return part >= (2*whole)/3
+	return part >= divCeil(2*whole, 3)
 }
 
 // Check whether a portion of storage power is a weak quorum of the total
 func hasWeakQuorum(part, whole uint16) bool {
-	// XXX ceiling!
-	return part > whole/3
+	return part > divCeil(whole, 3)
 }
 
 // Tests whether lhs is equal to or greater than rhs.

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -1327,17 +1327,6 @@ func findFirstPrefixOf(preferred ECChain, candidates []ECChain) ECChain {
 	return preferred.BaseChain()
 }
 
-func scalePower(power, total *StoragePower) (uint16, error) {
-	const maxPower = 0xffff
-	if power.Cmp(total) > 0 {
-		return 0, xerrors.Errorf("total power %d is less than the power of a single participant %d", total, power)
-	}
-	scaled := big.NewInt(maxPower)
-	scaled = scaled.Mul(scaled, (*big.Int)(power))
-	scaled = scaled.Div(scaled, (*big.Int)(total))
-	return uint16(scaled.Uint64()), nil
-}
-
 func divCeil(a, b uint32) uint32 {
 	quo := a / b
 	rem := a % b

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -1089,16 +1089,16 @@ func (q *quorumState) HasStrongQuorumFor(key ChainKey) bool {
 // couldReachStrongQuorumFor checks whether the given chain can possibly reach
 // strong quorum.
 func (q *quorumState) couldReachStrongQuorumFor(key ChainKey) bool {
-	supportingPower := new(big.Int)
+	var supportingPower uint16
 	if supportForChain, found := q.chainSupport[key]; found {
-		supportingPower.Set(supportForChain.power)
+		supportingPower = supportForChain.power
 	}
 	// A strong quorum is only feasible when the total support for the given chain,
 	// combined with the aggregate power of not yet voted participants, exceeds ⅔ of
 	// total power.
-	unvotedPower := NewStoragePower(0).Sub(q.powerTable.Total, q.sendersTotalPower)
-	possibleSupport := NewStoragePower(0).Add(supportingPower, unvotedPower)
-	return IsStrongQuorum(possibleSupport, q.powerTable.Total)
+	unvotedPower := q.powerTable.ScaledTotal - q.sendersTotalPower
+	possibleSupport := supportingPower + unvotedPower
+	return IsStrongQuorum(possibleSupport, q.powerTable.ScaledTotal)
 }
 
 type QuorumResult struct {

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -1338,7 +1338,7 @@ func scalePower(power, total *StoragePower) (uint16, error) {
 	return uint16(scaled.Uint64()), nil
 }
 
-func divCeil(a, b uint16) uint16 {
+func divCeil(a, b uint32) uint32 {
 	quo := a / b
 	rem := a % b
 	if rem != 0 {
@@ -1349,12 +1349,14 @@ func divCeil(a, b uint16) uint16 {
 
 // Check whether a portion of storage power is a strong quorum of the total
 func IsStrongQuorum(part uint16, whole uint16) bool {
-	return part >= divCeil(2*whole, 3)
+	// uint32 because 2 * whole exceeds uint16
+	return uint32(part) >= divCeil(2*uint32(whole), 3)
 }
 
 // Check whether a portion of storage power is a weak quorum of the total
 func hasWeakQuorum(part, whole uint16) bool {
-	return part > divCeil(whole, 3)
+	// Must be strictly greater than 1/3. Otherwise, there could be a strong quorum.
+	return uint32(part) > divCeil(uint32(whole), 3)
 }
 
 // Tests whether lhs is equal to or greater than rhs.

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -563,7 +563,7 @@ func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMes
 			}
 			power := powerTable.ScaledPower[bit]
 			if power == 0 {
-				return xerrors.Errorf("signer %d has no power", powerTable.Entries[bit].ID)
+				return xerrors.Errorf("signer with ID %d has no power", powerTable.Entries[bit].ID)
 			}
 			justificationPower += power
 			signers = append(signers, powerTable.Entries[bit].PubKey)

--- a/gpbft/message_builder.go
+++ b/gpbft/message_builder.go
@@ -49,7 +49,7 @@ func (mb MessageBuilder) Justification() *Justification {
 }
 
 type powerTableAccessor interface {
-	Get(ActorID) (*big.Int, PubKey)
+	Get(ActorID) (uint16, *big.Int, PubKey)
 }
 
 type SignerWithMarshaler interface {
@@ -109,7 +109,7 @@ func (sb *SignatureBuilder) VRFToSign() []byte {
 }
 
 func (mt MessageBuilder) PrepareSigningInputs(msh SigningMarshaler, networkName NetworkName, id ActorID) (SignatureBuilder, error) {
-	_, pubKey := mt.powerTable.Get(id)
+	_, _, pubKey := mt.powerTable.Get(id)
 	if pubKey == nil {
 		return SignatureBuilder{}, xerrors.Errorf("could not find pubkey for actor %d", id)
 	}

--- a/gpbft/powertable.go
+++ b/gpbft/powertable.go
@@ -3,7 +3,8 @@ package gpbft
 import (
 	"errors"
 	"fmt"
-	"math/big"
+	"maps"
+	"slices"
 	"sort"
 )
 
@@ -22,9 +23,11 @@ type PowerEntries []PowerEntry
 // PowerTable maps ActorID to a unique index in the range [0, len(powerTable.Entries)).
 // Entries is the reverse mapping to a PowerEntry.
 type PowerTable struct {
-	Entries PowerEntries    // Slice to maintain the order. Meant to be maintained in order in order by (Power descending, ID ascending)
-	Lookup  map[ActorID]int // Maps ActorID to the index of the associated entry in Entries
-	Total   *StoragePower
+	Entries     PowerEntries // Slice to maintain the order. Meant to be maintained in order in order by (Power descending, ID ascending)
+	ScaledPower []uint16
+	Lookup      map[ActorID]int // Maps ActorID to the index of the associated entry in Entries
+	Total       *StoragePower
+	ScaledTotal uint16
 }
 
 // Len returns the number of entries in this PowerTable.
@@ -52,6 +55,28 @@ func (p PowerEntries) Less(i, j int) bool {
 // This function must not be called directly since it is used as part of sort.Interface.
 func (p PowerEntries) Swap(i, j int) {
 	p[i], p[j] = p[j], p[i]
+}
+
+func (p PowerEntries) Scaled() (scaled []uint16, total uint16, err error) {
+	totalUnscaled := new(StoragePower)
+	for i := range p {
+		pwr := p[i].Power
+		if pwr.Sign() <= 0 {
+			return nil, 0, fmt.Errorf("invalid non-positive power %s for participant %d", pwr, p[i].ID)
+		}
+		totalUnscaled = totalUnscaled.Add(totalUnscaled, pwr)
+	}
+	scaled = make([]uint16, len(p))
+	for i := range p {
+		p, err := scalePower(p[i].Power, totalUnscaled)
+		if err != nil {
+			// We just summed the total power, this operation can't fail.
+			panic(err)
+		}
+		scaled[i] = p
+		total += p
+	}
+	return scaled, total, nil
 }
 
 // NewPowerTable creates a new PowerTable from a slice of PowerEntry .
@@ -82,24 +107,36 @@ func (p *PowerTable) Add(entries ...PowerEntry) error {
 		default:
 			p.Total.Add(p.Total, entry.Power)
 			p.Entries = append(p.Entries, entry)
+			p.ScaledPower = append(p.ScaledPower, 0)
 			p.Lookup[entry.ID] = len(p.Entries) - 1
 		}
 	}
 	sort.Sort(p)
+	return p.rescale()
+}
+
+func (p *PowerTable) rescale() error {
+	p.ScaledTotal = 0
+	for i := range p.Entries {
+		scaled, err := scalePower(p.Entries[i].Power, p.Total)
+		if err != nil {
+			return err
+		}
+		p.ScaledPower[i] = scaled
+		p.ScaledTotal += scaled
+	}
 	return nil
 }
 
-// Get retrieves the StoragePower and PubKey for the given id, if present in the table.
-// Otherwise, returns nil.
-func (p *PowerTable) Get(id ActorID) (*StoragePower, PubKey) {
+// Get retrieves the scaled power, unscaled StoragePower and PubKey for the given id, if present in
+// the table. Otherwise, returns 0/nil.
+func (p *PowerTable) Get(id ActorID) (uint16, *StoragePower, PubKey) {
 	if index, ok := p.Lookup[id]; ok {
 		entry := p.Entries[index]
-
-		powerCopy := new(big.Int)
-		powerCopy.Set(entry.Power)
-		return powerCopy, entry.PubKey
+		scaledPower := p.ScaledPower[index]
+		return scaledPower, entry.Power, entry.PubKey
 	}
-	return nil, nil
+	return 0, nil, nil
 }
 
 // Has check whether this PowerTable contains an entry for the given id.
@@ -111,13 +148,10 @@ func (p *PowerTable) Has(id ActorID) bool {
 // Copy creates a deep copy of this PowerTable.
 func (p *PowerTable) Copy() *PowerTable {
 	replica := NewPowerTable()
-	if p.Len() != 0 {
-		replica.Entries = make([]PowerEntry, p.Len())
-		copy(replica.Entries, p.Entries)
-	}
-	for k, v := range p.Lookup {
-		replica.Lookup[k] = v
-	}
+	replica.Entries = slices.Clone(p.Entries)
+	replica.ScaledPower = slices.Clone(p.ScaledPower)
+	replica.Lookup = maps.Clone(p.Lookup)
+	replica.ScaledTotal = p.ScaledTotal
 	replica.Total.Add(replica.Total, p.Total)
 	return replica
 }
@@ -139,6 +173,7 @@ func (p *PowerTable) Less(i, j int) bool {
 // This function must not be called directly since it is used as part of sort.Interface.
 func (p *PowerTable) Swap(i, j int) {
 	p.Entries.Swap(i, j)
+	p.ScaledPower[i], p.ScaledPower[j] = p.ScaledPower[j], p.ScaledPower[i]
 	p.Lookup[p.Entries[i].ID], p.Lookup[p.Entries[j].ID] = i, j
 }
 
@@ -148,13 +183,19 @@ func (p *PowerTable) Swap(i, j int) {
 // * It must not contain any entries with duplicate ID.
 // * All entries must have power larger than zero
 // * All entries must have non-zero public key.
+// * All entries must match their scaled powers.
 // * PowerTable.Total must correspond to the total aggregated power of entries.
+// * PowerTable.ScaledTotal must correspond to the total aggregated scaled power.
 // * PowerTable.Lookup must contain the expected mapping of entry actor ID to index.
 func (p *PowerTable) Validate() error {
 	if len(p.Entries) != len(p.Lookup) {
 		return errors.New("inconsistent entries and lookup map")
 	}
+	if len(p.Entries) != len(p.ScaledPower) {
+		return errors.New("inconsistent entries and scaled power")
+	}
 	total := NewStoragePower(0)
+	totalScaled := uint16(0)
 	var previous *PowerEntry
 	for index, entry := range p.Entries {
 		if lookupIndex, found := p.Lookup[entry.ID]; !found || index != lookupIndex {
@@ -169,11 +210,24 @@ func (p *PowerTable) Validate() error {
 		if previous != nil && !p.Less(index-1, index) {
 			return fmt.Errorf("entry not in order at index: %d", index)
 		}
+
+		scaledPower, err := scalePower(entry.Power, p.Total)
+		if err != nil {
+			return fmt.Errorf("failed to scale power at index %d: %w", index, err)
+		}
+		if scaledPower != p.ScaledPower[index] {
+			return fmt.Errorf("incorrect scaled power at index: %d", index)
+		}
+
 		total.Add(total, entry.Power)
+		totalScaled += scaledPower
 		previous = &entry
 	}
 	if total.Cmp(p.Total) != 0 {
 		return errors.New("total power does not match entries")
+	}
+	if p.ScaledTotal != totalScaled {
+		return errors.New("scaled total power does not match entries")
 	}
 	return nil
 }

--- a/gpbft/powertable_test.go
+++ b/gpbft/powertable_test.go
@@ -11,11 +11,11 @@ import (
 func TestPowerTable(t *testing.T) {
 
 	var (
-		oneValidEntry        = gpbft.PowerEntry{ID: 1413, Power: gpbft.NewStoragePower(1414), PubKey: []byte("fish")}
-		anotherValidEntry    = gpbft.PowerEntry{ID: 1513, Power: gpbft.NewStoragePower(1514), PubKey: []byte("lobster")}
-		yetAnotherValidEntry = gpbft.PowerEntry{ID: 1490, Power: gpbft.NewStoragePower(1491), PubKey: []byte("lobster")}
+		oneValidEntry        = gpbft.PowerEntry{ID: 1413, Power: gpbft.NewStoragePower(1414000), PubKey: []byte("fish")}
+		anotherValidEntry    = gpbft.PowerEntry{ID: 1513, Power: gpbft.NewStoragePower(1514000), PubKey: []byte("lobster")}
+		yetAnotherValidEntry = gpbft.PowerEntry{ID: 1490, Power: gpbft.NewStoragePower(1491000), PubKey: []byte("lobster")}
 		zeroPowerEntry       = gpbft.PowerEntry{ID: 1613, Power: gpbft.NewStoragePower(0), PubKey: []byte("fish")}
-		noPubKeyEntry        = gpbft.PowerEntry{ID: 1613, Power: gpbft.NewStoragePower(1614)}
+		noPubKeyEntry        = gpbft.PowerEntry{ID: 1613, Power: gpbft.NewStoragePower(1614000)}
 	)
 
 	t.Run("empty table", func(t *testing.T) {
@@ -25,7 +25,7 @@ func TestPowerTable(t *testing.T) {
 		})
 		t.Run("gets nil", func(t *testing.T) {
 			subject := gpbft.NewPowerTable()
-			gotPower, gotKey := subject.Get(1413)
+			_, gotPower, gotKey := subject.Get(1413)
 			require.Nil(t, gotPower)
 			require.Nil(t, gotKey)
 		})
@@ -98,7 +98,7 @@ func TestPowerTable(t *testing.T) {
 				name: "inconsistent lookup map is error",
 				subject: func() *gpbft.PowerTable {
 					subject := gpbft.NewPowerTable()
-					subject.Entries = append(subject.Entries, oneValidEntry)
+					require.NoError(t, subject.Add(oneValidEntry))
 					subject.Lookup[oneValidEntry.ID] = 14
 					return subject
 				},
@@ -108,8 +108,8 @@ func TestPowerTable(t *testing.T) {
 				name: "incorrect total is error",
 				subject: func() *gpbft.PowerTable {
 					subject := gpbft.NewPowerTable()
-					subject.Entries = append(subject.Entries, oneValidEntry)
-					subject.Lookup[oneValidEntry.ID] = 0
+					require.NoError(t, subject.Add(oneValidEntry, anotherValidEntry))
+					subject.Total.Sub(subject.Total, gpbft.NewStoragePower(1))
 					return subject
 				},
 				wantErr: "total power does not match",
@@ -119,6 +119,7 @@ func TestPowerTable(t *testing.T) {
 				subject: func() *gpbft.PowerTable {
 					subject := gpbft.NewPowerTable()
 					subject.Entries = append(subject.Entries, zeroPowerEntry)
+					subject.ScaledPower = append(subject.ScaledPower, 0)
 					subject.Lookup[zeroPowerEntry.ID] = 0
 					return subject
 				},
@@ -129,6 +130,7 @@ func TestPowerTable(t *testing.T) {
 				subject: func() *gpbft.PowerTable {
 					subject := gpbft.NewPowerTable()
 					subject.Entries = append(subject.Entries, noPubKeyEntry)
+					subject.ScaledPower = append(subject.ScaledPower, 0)
 					subject.Lookup[noPubKeyEntry.ID] = 0
 					subject.Total.Add(subject.Total, noPubKeyEntry.Power)
 					return subject
@@ -194,7 +196,7 @@ func TestPowerTable(t *testing.T) {
 func requireAddedToPowerTable(t *testing.T, subject *gpbft.PowerTable, entry gpbft.PowerEntry) {
 	t.Helper()
 	require.True(t, subject.Has(entry.ID))
-	gotPower, gotKey := subject.Get(entry.ID)
+	_, gotPower, gotKey := subject.Get(entry.ID)
 	require.Equal(t, entry.Power, gotPower)
 	require.Equal(t, entry.PubKey, gotKey)
 }

--- a/gpbft/powertable_test.go
+++ b/gpbft/powertable_test.go
@@ -1,6 +1,7 @@
 package gpbft_test
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -157,6 +158,8 @@ func TestPowerTable(t *testing.T) {
 					require.ErrorContains(t, gotErr, test.wantErr)
 				} else {
 					require.NoError(t, gotErr)
+					// Scaling power shouldn't change relative power.
+					require.True(t, slices.IsSorted(subject.ScaledPower))
 				}
 			})
 		}

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -51,7 +51,7 @@ func (i *ImmediateDecide) Start() error {
 		Value:    i.value,
 	}
 	sigPayload := i.host.MarshalPayloadForSigning(i.host.NetworkName(), &justificationPayload)
-	_, pubkey := powertable.Get(i.id)
+	_, _, pubkey := powertable.Get(i.id)
 	sig, err := i.host.Sign(pubkey, sigPayload)
 	if err != nil {
 		panic(err)
@@ -96,7 +96,7 @@ func (*ImmediateDecide) AllowMessage(_ gpbft.ActorID, _ gpbft.ActorID, _ gpbft.G
 func (i *ImmediateDecide) broadcast(payload gpbft.Payload, justification *gpbft.Justification, powertable *gpbft.PowerTable) {
 
 	pS := i.host.MarshalPayloadForSigning(i.host.NetworkName(), &payload)
-	_, pubkey := powertable.Get(i.id)
+	_, _, pubkey := powertable.Get(i.id)
 	sig, err := i.host.Sign(pubkey, pS)
 	if err != nil {
 		panic(err)

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -96,7 +96,7 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 	}
 	for i := 0; i < echoCount; i++ {
 		if msg.Sender != r.ID() {
-			_ = r.host.RequestBroadcast(&mt)
+			_ = r.host.RequestBroadcast(mt)
 
 		}
 	}

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -73,7 +73,7 @@ func (s *Spam) spamAtInstance(instance uint64) {
 		mt := gpbft.NewMessageBuilderWithPowerTable(power)
 		mt.SetPayload(p)
 
-		_ = s.host.RequestBroadcast(&mt)
+		_ = s.host.RequestBroadcast(mt)
 	}
 }
 

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -170,7 +170,7 @@ func (w *WithholdCommit) sign(pubkey gpbft.PubKey, msg []byte) []byte {
 func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID, powertable *gpbft.PowerTable) func(gpbft.Payload, *gpbft.Justification) {
 	return func(payload gpbft.Payload, justification *gpbft.Justification) {
 		pS := w.host.MarshalPayloadForSigning(w.host.NetworkName(), &payload)
-		_, pubkey := powertable.Get(sender)
+		_, _, pubkey := powertable.Get(sender)
 		sig, err := w.host.Sign(pubkey, pS)
 		if err != nil {
 			panic(err)

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -10,18 +10,20 @@ import (
 
 // Expects the decision in the first instance to be one of the given tipsets.
 func requireConsensusAtFirstInstance(t *testing.T, sm *sim.Simulation, expectAnyOf ...gpbft.TipSet) {
+	t.Helper()
 	requireConsensusAtInstance(t, sm, 0, expectAnyOf...)
 }
 
 // Expects the decision in an instance to be one of the given tipsets.
 func requireConsensusAtInstance(t *testing.T, sm *sim.Simulation, instance uint64, expectAnyOf ...gpbft.TipSet) {
+	t.Helper()
 	inst := sm.GetInstance(instance)
 	for _, pid := range sm.ListParticipantIDs() {
 		require.NotNil(t, inst, "no such instance")
 		decision := inst.GetDecision(pid)
 		require.NotNil(t, decision, "no decision for participant %d in instance %d", pid, instance)
 		require.Contains(t, expectAnyOf, *decision.Head(), "consensus not reached: participant %d decided %s in instance %d, expected any of %s",
-			pid, decision.Head(), instance, expectAnyOf)
+			pid, decision.Head(), instance, gpbft.ECChain(expectAnyOf))
 	}
 }
 


### PR DESCRIPTION
When we construct a power table, we now:

1. Scale individual power into the range 0-0xffff.
2. Treat the sum of these _scaled_ powers as the maximum power from the perspective of "quorum". We can't use 0xffff as the "total power" due to compounded rounding errors.

Then, we use this scaled power when determining if we have quorum. However, we _don't_ use it for either:

1. Tickets weight.
2. Determining if an SP is eligible to be included in the power table itself.

fixes #33 