### PR TITLE
Delay next instance until EC chain progresses

### DIFF
--- a/cmd/f3sim/f3sim.go
+++ b/cmd/f3sim/f3sim.go
@@ -27,9 +27,11 @@ func main() {
 		fmt.Printf("Iteration %d: seed=%d, mean=%f\n", i, seed, *latencyMean)
 
 		simConfig := sim.Config{
-			HonestCount: *participantCount,
-			LatencySeed: *latencySeed,
-			LatencyMean: time.Duration(*latencyMean * float64(time.Second)),
+			HonestCount:          *participantCount,
+			LatencySeed:          *latencySeed,
+			LatencyMean:          time.Duration(*latencyMean * float64(time.Second)),
+			ECEpochDuration:      30 * time.Second,
+			ECStabilisationDelay: 0,
 		}
 		graniteConfig := gpbft.GraniteConfig{
 			Delta:                time.Duration(*graniteDelta * float64(time.Second)),

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -48,9 +48,11 @@ type Network interface {
 type Clock interface {
 	// Returns the current network time.
 	Time() time.Time
-	// Sets an alarm to fire at the given timestamp.
+	// Sets an alarm to fire after the given timestamp.
 	// At most one alarm can be set at a time.
 	// Setting an alarm replaces any previous alarm that has not yet fired.
+	// The timestamp may be in the past, in which case the alarm will fire as soon as possible
+	// (but not synchronously).
 	SetAlarm(at time.Time)
 }
 
@@ -74,7 +76,10 @@ type DecisionReceiver interface {
 	// Receives a finality decision from the instance, with signatures from a strong quorum
 	// of participants justifying it.
 	// The decision payload always has round = 0 and step = DECIDE.
-	ReceiveDecision(decision *Justification)
+	// The notification must return the timestamp at which the next instance should begin,
+	// based on the decision received (which may be in the past).
+	// E.g. this might be: finalised tipset timestamp + epoch duration + stabilisation delay.
+	ReceiveDecision(decision *Justification) time.Time
 }
 
 // Participant interface to the host system resources.

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -176,13 +176,10 @@ func (p *Participant) handleDecision() error {
 		p.finalised = p.granite.terminationValue
 		p.terminatedDuringRound = p.granite.round
 		p.granite = nil
-		p.host.ReceiveDecision(p.finalised)
+		nextStart := p.host.ReceiveDecision(p.finalised)
 
 		// Set an alarm at which to fetch the next chain and begin a new instance.
-		// At the moment, this is set to "immediately".
-		// TODO: set delay based on tipset timestamp when they are provided by the host.
-		// https://github.com/filecoin-project/go-f3/issues/113
-		p.host.SetAlarm(p.host.Time())
+		p.host.SetAlarm(nextStart)
 		return nil
 	}
 	return nil

--- a/sim/ec.go
+++ b/sim/ec.go
@@ -2,11 +2,16 @@ package sim
 
 import (
 	"github.com/filecoin-project/go-f3/gpbft"
+	"time"
 )
 
 // Simulated EC state for each protocol instance.
 type EC struct {
-	Instances []*ECInstance
+	// The first instance's base chain's first epoch.
+	BaseEpoch int64
+	// Timestamp of the base epoch.
+	BaseTimestamp time.Time
+	Instances     []*ECInstance
 }
 
 type ECInstance struct {
@@ -22,6 +27,8 @@ type ECInstance struct {
 
 func NewEC(base gpbft.ECChain, beacon []byte) *EC {
 	return &EC{
+		BaseEpoch:     base.Base().Epoch,
+		BaseTimestamp: time.Time{},
 		Instances: []*ECInstance{
 			{
 				Base:       base,

--- a/test/absent_test.go
+++ b/test/absent_test.go
@@ -11,11 +11,7 @@ import (
 func TestAbsent(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		// fmt.Println("Iteration", i)
-		sm := sim.NewSimulation(sim.Config{
-			HonestCount: 3,
-			LatencySeed: int64(i),
-			LatencyMean: LATENCY_ASYNC,
-		}, GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(AsyncConfig(3, i), GraniteConfig(), sim.TraceNone)
 		// Adversary has 1/4 of power.
 		sm.SetAdversary(adversary.NewAbsent(99, sm.HostFor(99)), 1)
 

--- a/test/constants.go
+++ b/test/constants.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/sim"
 	"time"
 )
 
@@ -9,18 +10,42 @@ import (
 // These values are not intended to reflect real-world conditions.
 // The latency and delta values are similar in order to stress "slow" message paths and interleaving.
 // The values are not appropriate for benchmarks.
+// Granite configuration.
 const DELTA = 200 * time.Millisecond
 const DELTA_BACK_OFF_EXPONENT = 1.300
-
-const LATENCY_SYNC = 0
-const LATENCY_ASYNC = 100 * time.Millisecond
-const MAX_ROUNDS = 10
-const ASYNC_ITERS = 5000
 
 // Returns a default Granite configuration.
 func GraniteConfig() gpbft.GraniteConfig {
 	return gpbft.GraniteConfig{
 		Delta:                DELTA,
 		DeltaBackOffExponent: DELTA_BACK_OFF_EXPONENT,
+	}
+}
+
+// Simulator configuration.
+const LATENCY_SYNC = 0
+const LATENCY_ASYNC = 100 * time.Millisecond
+const MAX_ROUNDS = 10
+const ASYNC_ITERS = 5000
+const EC_EPOCH_DURATION = 30 * time.Second
+const EC_STABILISATION_DELAY = 3 * time.Second
+
+func SyncConfig(honestCount int) sim.Config {
+	return sim.Config{
+		HonestCount:          honestCount,
+		LatencySeed:          0,
+		LatencyMean:          LATENCY_SYNC,
+		ECEpochDuration:      EC_EPOCH_DURATION,
+		ECStabilisationDelay: EC_STABILISATION_DELAY,
+	}
+}
+
+func AsyncConfig(honestCount, latencySeed int) sim.Config {
+	return sim.Config{
+		HonestCount:          honestCount,
+		LatencySeed:          int64(latencySeed),
+		LatencyMean:          LATENCY_ASYNC,
+		ECEpochDuration:      EC_EPOCH_DURATION,
+		ECStabilisationDelay: EC_STABILISATION_DELAY,
 	}
 }

--- a/test/decide_test.go
+++ b/test/decide_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func TestImmediateDecide(t *testing.T) {
-	sm := sim.NewSimulation(sim.Config{
-		HonestCount: 1,
-		LatencyMean: LATENCY_ASYNC,
-	}, GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(AsyncConfig(1, 0), GraniteConfig(), sim.TraceNone)
 
 	// Create adversarial node
 	value := sm.Base(0).Extend(sm.CIDGen.Sample())

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-///// Tests with no adversaries.
+///// Tests for a single instance with no adversaries.
 
 func TestSingleton(t *testing.T) {
-	sm := sim.NewSimulation(newSyncConfig(1), GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(SyncConfig(1), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a})
 
@@ -19,7 +19,7 @@ func TestSingleton(t *testing.T) {
 }
 
 func TestSyncPair(t *testing.T) {
-	sm := sim.NewSimulation(newSyncConfig(2), GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(SyncConfig(2), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
@@ -28,7 +28,7 @@ func TestSyncPair(t *testing.T) {
 }
 
 func TestSyncPairBLS(t *testing.T) {
-	sm := sim.NewSimulation(newSyncConfig(2).UseBLS(), GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(SyncConfig(2).UseBLS(), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
@@ -39,7 +39,7 @@ func TestSyncPairBLS(t *testing.T) {
 func TestASyncPair(t *testing.T) {
 	for i := 0; i < ASYNC_ITERS; i++ {
 		//fmt.Println("i =", i)
-		sm := sim.NewSimulation(newAsyncConfig(2, i), GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(AsyncConfig(2, i), GraniteConfig(), sim.TraceNone)
 		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
@@ -49,7 +49,7 @@ func TestASyncPair(t *testing.T) {
 }
 
 func TestSyncPairDisagree(t *testing.T) {
-	sm := sim.NewSimulation(newSyncConfig(2), GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(SyncConfig(2), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	b := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
@@ -60,7 +60,7 @@ func TestSyncPairDisagree(t *testing.T) {
 }
 
 func TestSyncPairDisagreeBLS(t *testing.T) {
-	sm := sim.NewSimulation(newSyncConfig(2).UseBLS(), GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(SyncConfig(2).UseBLS(), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	b := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
@@ -73,7 +73,7 @@ func TestSyncPairDisagreeBLS(t *testing.T) {
 func TestAsyncPairDisagree(t *testing.T) {
 	for i := 0; i < ASYNC_ITERS; i++ {
 		//fmt.Println("i =", i)
-		sm := sim.NewSimulation(newAsyncConfig(2, i), GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(AsyncConfig(2, i), GraniteConfig(), sim.TraceNone)
 		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
@@ -86,7 +86,7 @@ func TestAsyncPairDisagree(t *testing.T) {
 
 func TestSyncAgreement(t *testing.T) {
 	for n := 3; n <= 50; n++ {
-		sm := sim.NewSimulation(newSyncConfig(n), GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(SyncConfig(n), GraniteConfig(), sim.TraceNone)
 		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -101,7 +101,7 @@ func TestAsyncAgreement(t *testing.T) {
 	for n := 3; n <= 16; n++ {
 		for i := 0; i < ASYNC_ITERS; i++ {
 			//fmt.Println("n =", n, "i =", i)
-			sm := sim.NewSimulation(newAsyncConfig(n, i), GraniteConfig(), sim.TraceNone)
+			sm := sim.NewSimulation(AsyncConfig(n, i), GraniteConfig(), sim.TraceNone)
 			a := sm.Base(0).Extend(sm.CIDGen.Sample())
 			sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
@@ -113,7 +113,7 @@ func TestAsyncAgreement(t *testing.T) {
 
 func TestSyncHalves(t *testing.T) {
 	for n := 4; n <= 50; n += 2 {
-		sm := sim.NewSimulation(newSyncConfig(n), GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(SyncConfig(n), GraniteConfig(), sim.TraceNone)
 		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: n / 2, Chain: a}, sim.ChainCount{Count: n / 2, Chain: b})
@@ -126,7 +126,7 @@ func TestSyncHalves(t *testing.T) {
 
 func TestSyncHalvesBLS(t *testing.T) {
 	for n := 4; n <= 10; n += 2 {
-		sm := sim.NewSimulation(newSyncConfig(n).UseBLS(), GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(SyncConfig(n).UseBLS(), GraniteConfig(), sim.TraceNone)
 		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: n / 2, Chain: a}, sim.ChainCount{Count: n / 2, Chain: b})
@@ -141,7 +141,7 @@ func TestAsyncHalves(t *testing.T) {
 	t.Parallel()
 	for n := 4; n <= 20; n += 2 {
 		for i := 0; i < ASYNC_ITERS; i++ {
-			sm := sim.NewSimulation(newAsyncConfig(n, i), GraniteConfig(), sim.TraceNone)
+			sm := sim.NewSimulation(AsyncConfig(n, i), GraniteConfig(), sim.TraceNone)
 			a := sm.Base(0).Extend(sm.CIDGen.Sample())
 			b := sm.Base(0).Extend(sm.CIDGen.Sample())
 			sm.SetChains(sim.ChainCount{Count: n / 2, Chain: a}, sim.ChainCount{Count: n / 2, Chain: b})
@@ -156,7 +156,7 @@ func TestAsyncHalves(t *testing.T) {
 func TestRequireStrongQuorumToProgress(t *testing.T) {
 	t.Parallel()
 	for i := 0; i < ASYNC_ITERS; i++ {
-		sm := sim.NewSimulation(newAsyncConfig(30, i), GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(AsyncConfig(30, i), GraniteConfig(), sim.TraceNone)
 		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		b := sm.Base(0).Extend(sm.CIDGen.Sample())
 		// No strict > quorum.
@@ -171,7 +171,7 @@ func TestRequireStrongQuorumToProgress(t *testing.T) {
 func TestLongestCommonPrefix(t *testing.T) {
 	// This test uses a synchronous configuration to ensure timely message delivery.
 	// If async, it is possible to decide the base chain if QUALITY messages are delayed.
-	sm := sim.NewSimulation(newSyncConfig(4), GraniteConfig(), sim.TraceAll)
+	sm := sim.NewSimulation(SyncConfig(4), GraniteConfig(), sim.TraceNone)
 	ab := sm.Base(0).Extend(sm.CIDGen.Sample())
 	abc := ab.Extend(sm.CIDGen.Sample())
 	abd := ab.Extend(sm.CIDGen.Sample())
@@ -187,20 +187,4 @@ func TestLongestCommonPrefix(t *testing.T) {
 	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 	// Must decide ab, the longest common prefix.
 	expectDecision(t, sm, ab.Head())
-}
-
-func newSyncConfig(honestCount int) sim.Config {
-	return sim.Config{
-		HonestCount: honestCount,
-		LatencySeed: 0,
-		LatencyMean: LATENCY_SYNC,
-	}
-}
-
-func newAsyncConfig(honestCount int, latencySeed int) sim.Config {
-	return sim.Config{
-		HonestCount: honestCount,
-		LatencySeed: int64(latencySeed),
-		LatencyMean: LATENCY_ASYNC,
-	}
 }

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -11,10 +11,7 @@ import (
 const INSTANCE_COUNT = 4000
 
 func TestMultiSingleton(t *testing.T) {
-	sm := sim.NewSimulation(sim.Config{
-		HonestCount: 1,
-		LatencyMean: LATENCY_SYNC,
-	}, GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(SyncConfig(1), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a})
 
@@ -24,10 +21,7 @@ func TestMultiSingleton(t *testing.T) {
 }
 
 func TestMultiSyncPair(t *testing.T) {
-	sm := sim.NewSimulation(sim.Config{
-		HonestCount: 2,
-		LatencyMean: LATENCY_SYNC,
-	}, GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(SyncConfig(2), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
@@ -37,10 +31,7 @@ func TestMultiSyncPair(t *testing.T) {
 }
 
 func TestMultiASyncPair(t *testing.T) {
-	sm := sim.NewSimulation(sim.Config{
-		HonestCount: 2,
-		LatencyMean: LATENCY_ASYNC,
-	}, GraniteConfig(), sim.TraceNone)
+	sm := sim.NewSimulation(AsyncConfig(2, 0), GraniteConfig(), sim.TraceNone)
 	a := sm.Base(0).Extend(sm.CIDGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
@@ -55,10 +46,7 @@ func TestMultiASyncPair(t *testing.T) {
 func TestMultiSyncAgreement(t *testing.T) {
 	t.Parallel()
 	for n := 3; n <= 12; n++ {
-		sm := sim.NewSimulation(sim.Config{
-			HonestCount: n,
-			LatencyMean: LATENCY_SYNC,
-		}, GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(SyncConfig(n), GraniteConfig(), sim.TraceNone)
 		a := sm.Base(0).Extend(sm.CIDGen.Sample())
 		// All nodes start with the same chain and will observe the same extensions of that chain
 		// in subsequent instances.
@@ -73,10 +61,7 @@ func TestMultiSyncAgreement(t *testing.T) {
 func TestMultiAsyncAgreement(t *testing.T) {
 	t.Parallel()
 	for n := 3; n <= 12; n++ {
-		sm := sim.NewSimulation(sim.Config{
-			HonestCount: n,
-			LatencyMean: LATENCY_ASYNC,
-		}, GraniteConfig(), sim.TraceNone)
+		sm := sim.NewSimulation(AsyncConfig(n, 0), GraniteConfig(), sim.TraceNone)
 		sm.SetChains(sim.ChainCount{Count: n, Chain: sm.Base(0).Extend(sm.CIDGen.Sample())})
 
 		require.NoErrorf(t, sm.Run(INSTANCE_COUNT, MAX_ROUNDS), "%s", sm.Describe())

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -13,11 +13,9 @@ import (
 
 func TestWitholdCommit1(t *testing.T) {
 	i := 0
-	sm := sim.NewSimulation(sim.Config{
-		HonestCount: 7,
-		LatencySeed: int64(i),
-		LatencyMean: 10 * time.Millisecond, // Near-synchrony
-	}, GraniteConfig(), sim.TraceNone)
+	simConfig := AsyncConfig(7, i)
+	simConfig.LatencyMean = 10 * time.Millisecond // Near-synchrony
+	sm := sim.NewSimulation(simConfig, GraniteConfig(), sim.TraceNone)
 	adv := adversary.NewWitholdCommit(99, sm.HostFor(99), sm.PowerTable(0))
 	sm.SetAdversary(adv, 3) // Adversary has 30% of 10 total power.
 


### PR DESCRIPTION
Adds the timestamp for next instance as a return value from host's ReceiveDecision callback. This design delegates all knowledge of EC epoch timing and policy about how long to wait for stabilization to the host. Nodes will need to adopt the same policy here to stay in sync but this knowledge doesn't belong inside GBPFT.

Closes #113.