### PR TITLE
Add local queue for messages for future instances

### DIFF
--- a/adversary/absent.go
+++ b/adversary/absent.go
@@ -33,7 +33,7 @@ func (a *Absent) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
 	return true, nil
 }
 
-func (a *Absent) ReceiveMessage(_ *gpbft.GMessage) (bool, error) {
+func (a *Absent) ReceiveMessage(_ *gpbft.GMessage, _ bool) (bool, error) {
 	return true, nil
 }
 

--- a/adversary/decide.go
+++ b/adversary/decide.go
@@ -39,7 +39,7 @@ func (i *ImmediateDecide) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
 	return true, nil
 }
 
-func (i *ImmediateDecide) ReceiveMessage(_ *gpbft.GMessage) (bool, error) {
+func (i *ImmediateDecide) ReceiveMessage(_ *gpbft.GMessage, _ bool) (bool, error) {
 	return true, nil
 }
 

--- a/adversary/withhold.go
+++ b/adversary/withhold.go
@@ -50,7 +50,7 @@ func (a *WithholdCommit) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
 	return true, nil
 }
 
-func (a *WithholdCommit) ReceiveMessage(_ *gpbft.GMessage) (bool, error) {
+func (a *WithholdCommit) ReceiveMessage(_ *gpbft.GMessage, _ bool) (bool, error) {
 	return true, nil
 }
 

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -15,8 +15,8 @@ type MessageReceiver interface {
 	// Returns whether the message could be validated, and an error if it was invalid.
 	ValidateMessage(msg *GMessage) (bool, error)
 	// Receives a message from another participant.
-	// The message must already have been validated.
-	ReceiveMessage(msg *GMessage) (bool, error)
+	// The `validated` parameter indicates whether the message has already passed validation.
+	ReceiveMessage(msg *GMessage, validated bool) (bool, error)
 	ReceiveAlarm() error
 }
 

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -352,6 +352,11 @@ func (i *instance) tryCompletePhase() error {
 
 // Checks message validity, includng justification and signatures.
 func (i *instance) validateMessage(msg *GMessage) error {
+	// Check the message is for this instance.
+	// The caller should ensure this is always the case.
+	if msg.Vote.Instance != i.instanceID {
+		return xerrors.Errorf("message for wrong instance %d, expected %d", msg.Vote.Instance, i.instanceID)
+	}
 	// Check sender is eligible.
 	senderPower, senderPubKey := i.powerTable.Get(msg.Sender)
 	if senderPower == nil || senderPower.Sign() == 0 {

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -1,10 +1,8 @@
 package test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/sim"
 	"github.com/stretchr/testify/require"
 )
@@ -205,15 +203,4 @@ func newAsyncConfig(honestCount int, latencySeed int) sim.Config {
 		LatencySeed: int64(latencySeed),
 		LatencyMean: LATENCY_ASYNC,
 	}
-}
-
-func expectDecision(t *testing.T, sm *sim.Simulation, expected ...gpbft.TipSet) {
-	decision, ok := sm.GetDecision(0, 0)
-	require.True(t, ok, "no decision")
-	for _, e := range expected {
-		if decision.Head() == e {
-			return
-		}
-	}
-	require.Fail(t, fmt.Sprintf("decided %s, expected one of %s", decision, expected))
 }

--- a/test/util.go
+++ b/test/util.go
@@ -1,0 +1,29 @@
+package test
+
+import (
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/sim"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// Expects the decision in the first instance to be one of the given tipsets.
+func expectDecision(t *testing.T, sm *sim.Simulation, expected ...gpbft.TipSet) {
+	expectInstanceDecision(t, sm, 0, expected...)
+}
+
+// Expects the decision in an instance to be one of the given tipsets.
+func expectInstanceDecision(t *testing.T, sm *sim.Simulation, instance uint64, expected ...gpbft.TipSet) {
+nextParticipant:
+	for _, participant := range sm.Participants {
+		decision, ok := sm.GetDecision(instance, participant.ID())
+		require.True(t, ok, "no decision for participant %d in instance %d", participant.ID(), instance)
+		for _, e := range expected {
+			if decision.Head() == e {
+				continue nextParticipant
+			}
+		}
+		require.Fail(t, "participant %d decided %s in instance %d, expected one of %s",
+			participant.ID(), decision, instance, expected)
+	}
+}


### PR DESCRIPTION
This restores a queue of messages for future instances in the participant. Ensuring the delivery of these messages fixed the divergence in multi-instance tests which can now run for significantly longer (no divergence detected yet).

I'm not sure what the network layer should do with messages that can't be validated yet: see #122. Maybe we can close that with this PR, but I'm leaving it open for discussion about the integration problem.

These queues also introduce denial of service risk. See #12.