### PR TITLE
Use `go generate` to generate sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
@@ -31,4 +31,18 @@ jobs:
           go-version: '1.20'
       - name: Test
         run: make test
+
+  generate:
+    name: Generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Generate
+        run: make generate
+      - name: Check for changes
+        run: |
+          git diff --exit-code || { echo "##[error] Generated code differs from repository content, run 'make generate' and commit the changes."; exit 1; }
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: test lint
+all: generate test lint
 
 test:
 	go test ./...
@@ -7,3 +7,7 @@ test:
 lint:
 	golangci-lint run ./...
 .PHONY: lint
+
+generate:
+	go generate ./...
+.PHONY: generate

--- a/gen/main.go
+++ b/gen/main.go
@@ -8,8 +8,10 @@ import (
 	gen "github.com/whyrusleeping/cbor-gen"
 )
 
+//go:generate go run .
+
 func main() {
-	err := gen.WriteTupleEncodersToFile("./gpbft/gen.go", "gpbft",
+	err := gen.WriteTupleEncodersToFile("../gpbft/gen.go", "gpbft",
 		gpbft.GMessage{},
 		gpbft.Payload{},
 		gpbft.Justification{},


### PR DESCRIPTION
Use `go:generate` directive to generate sources such that executing `go generate ./...` in root of the project would work.

Set up CI to assert that checked in code is consistent with what `go generate` generates.

Fix typo in CI to trigger builds on the `main` branch.