### PR TITLE
Validate EC chain invariants on instantiation

### DIFF
--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -84,9 +84,26 @@ func TestECChain(t *testing.T) {
 		require.Panics(t, func() { subject.Base() })
 		require.Panics(t, func() { subject.Head() })
 		require.Equal(t, zeroTipSet, subject.HeadOrZero())
+		require.NoError(t, subject.Validate())
+		requireMonotonicallyIncreasingEpochs(t, subject)
 	})
-	// TODO: test chain invariant properties as per:
-	//        - https://github.com/filecoin-project/go-f3/issues/128
+	t.Run("NewChain with zero-value base is error", func(t *testing.T) {
+		subject, err := gpbft.NewChain(zeroTipSet)
+		require.Error(t, err)
+		require.Nil(t, subject)
+	})
+	t.Run("NewChain with repeated epochs is error", func(t *testing.T) {
+		tipSet := gpbft.NewTipSet(1413, gpbft.ZeroTipSetID())
+		subject, err := gpbft.NewChain(tipSet, tipSet)
+		require.Error(t, err)
+		require.Nil(t, subject)
+	})
+	t.Run("NewChain with epoch gaps is not error", func(t *testing.T) {
+		subject, err := gpbft.NewChain(gpbft.NewTipSet(1413, gpbft.ZeroTipSetID()), gpbft.NewTipSet(1414, gpbft.ZeroTipSetID()))
+		require.NoError(t, err)
+		require.NoError(t, subject.Validate())
+		requireMonotonicallyIncreasingEpochs(t, subject)
+	})
 	t.Run("NewChain with unordered tipSets is error", func(t *testing.T) {
 		subject, err := gpbft.NewChain(gpbft.NewTipSet(2, gpbft.ZeroTipSetID()), zeroTipSet)
 		require.Error(t, err)
@@ -99,6 +116,8 @@ func TestECChain(t *testing.T) {
 			gpbft.NewTipSet(2, gpbft.NewTipSetID([]byte("lobster"))))
 		require.Error(t, err)
 		require.Nil(t, subject)
+		require.NoError(t, subject.Validate())
+		requireMonotonicallyIncreasingEpochs(t, subject)
 	})
 	t.Run("extended chain is as expected", func(t *testing.T) {
 		wantBase := gpbft.NewTipSet(1413, gpbft.NewTipSetID([]byte("fish")))
@@ -108,11 +127,15 @@ func TestECChain(t *testing.T) {
 		require.Equal(t, wantBase, subject.Base())
 		require.Equal(t, wantBase, subject.Head())
 		require.Equal(t, wantBase, subject.HeadOrZero())
+		require.NoError(t, subject.Validate())
+		requireMonotonicallyIncreasingEpochs(t, subject)
 
 		wantNextID := gpbft.NewTipSetID([]byte("lobster"))
 		wantNextTipSet := gpbft.NewTipSet(wantBase.Epoch+1, wantNextID)
 		subjectExtended := subject.Extend(wantNextID)
 		require.Len(t, subjectExtended, 2)
+		require.NoError(t, subjectExtended.Validate())
+		requireMonotonicallyIncreasingEpochs(t, subjectExtended)
 		require.Equal(t, wantBase, subjectExtended.Base())
 		require.Equal(t, []gpbft.TipSet{wantNextTipSet}, subjectExtended.Suffix())
 		require.Equal(t, wantNextTipSet, subjectExtended.Head())
@@ -124,5 +147,41 @@ func TestECChain(t *testing.T) {
 
 		require.False(t, subject.Extend(wantBase.CID).HasPrefix(subjectExtended.Extend(wantNextID)))
 	})
+	t.Run("SameBase is false when either chain is zero", func(t *testing.T) {
+		var zeroChain gpbft.ECChain
+		nonZeroChain, err := gpbft.NewChain(gpbft.NewTipSet(2, gpbft.ZeroTipSetID()))
+		require.NoError(t, err)
+		require.False(t, nonZeroChain.SameBase(zeroChain))
+		require.False(t, zeroChain.SameBase(nonZeroChain))
+		require.False(t, zeroChain.SameBase(zeroChain))
+	})
+	t.Run("HasPrefix is false when either chain is zero", func(t *testing.T) {
+		var zeroChain gpbft.ECChain
+		nonZeroChain, err := gpbft.NewChain(gpbft.NewTipSet(2, gpbft.ZeroTipSetID()))
+		require.NoError(t, err)
+		require.False(t, nonZeroChain.HasPrefix(zeroChain))
+		require.False(t, zeroChain.HasPrefix(nonZeroChain))
+		require.False(t, zeroChain.HasPrefix(zeroChain))
+	})
+	t.Run("zero-valued chain is valid", func(t *testing.T) {
+		var zeroChain gpbft.ECChain
+		require.NoError(t, zeroChain.Validate())
+	})
+	t.Run("ordered chain with zero-valued base is invalid", func(t *testing.T) {
+		subject := gpbft.ECChain{zeroTipSet, gpbft.NewTipSet(1, gpbft.ZeroTipSetID())}
+		require.Error(t, subject.Validate())
+	})
+	t.Run("unordered chain is invalid", func(t *testing.T) {
+		subject := gpbft.ECChain{gpbft.NewTipSet(2, gpbft.ZeroTipSetID()), gpbft.NewTipSet(1, gpbft.ZeroTipSetID())}
+		require.Error(t, subject.Validate())
+	})
+}
 
+func requireMonotonicallyIncreasingEpochs(t *testing.T, subject gpbft.ECChain) {
+	t.Helper()
+	var latestEpoch int64
+	for index, tipSet := range subject {
+		require.Less(t, latestEpoch, tipSet.Epoch, "not monotonically increasing at index %d", index)
+		latestEpoch = tipSet.Epoch
+	}
 }


### PR DESCRIPTION
EC chain cannot contain a zero-valued tip set. Enforce this in the exported API and return an error when such tip set is specified in the chain.

Add tests to assert the EC chain invariants are met:
* Epochs in chain are weakly and monotonically increasing, where repeated epochs are not allowed but gaps may exist in the epochs.
* Base cannot be a zero-valued tip set, as defined by `TipSet.IsZero`.

Implement `ECChain.Validate` to encapsulate the chain validation logic, and validate all received chains by a `Participant`. Further, strictly refuse to receive zero-valued chains, since a zero-valued chain is valid but not acceptable by by a `Participant`. The `ECChain` constructor is also refactored to reuse the newly encapsulated validation logic.

Additionally, optimise check for base, prefix, and equality based on the invariants listed above. Specifically, avoid reflection when checking for equality for better performance.

Fixes #128