### PR TITLE
Refactor `Host` interface to optionally trace logic logs

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -82,6 +82,12 @@ type DecisionReceiver interface {
 	ReceiveDecision(decision *Justification) time.Time
 }
 
+// Tracer collects trace logs that capture logical state changes.
+// The primary purpose of Tracer is to aid debugging and simulation.
+type Tracer interface {
+	Log(format string, args ...any)
+}
+
 // Participant interface to the host system resources.
 type Host interface {
 	Chain
@@ -90,6 +96,4 @@ type Host interface {
 	Signer
 	Verifier
 	DecisionReceiver
-	// Logs a message at the "logic" level
-	Log(format string, args ...interface{})
 }

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -2,11 +2,12 @@ package sim
 
 import (
 	"fmt"
-	"golang.org/x/xerrors"
 	"math"
 	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-f3/blssig"
 	"github.com/filecoin-project/go-f3/gpbft"
@@ -96,7 +97,7 @@ func NewSimulation(simConfig Config, graniteConfig gpbft.GraniteConfig, traceLev
 			CIDGen:      cidGen,
 			id:          id,
 		}
-		participants[i] = gpbft.NewParticipant(id, graniteConfig, host)
+		participants[i] = gpbft.NewParticipant(id, graniteConfig, host, host)
 		pubKey := ntwk.GenerateKey()
 		ntwk.AddParticipant(participants[i], pubKey)
 		ec.AddParticipant(id, gpbft.NewStoragePower(1), pubKey)


### PR DESCRIPTION
Tracing logic logs is not a fundamental function with gpbft algorithm. Instead, it is a crosscutting concern that currently aids one to reason about the logical changes of a participant.

Refactor the core `Host` interface to relax the requirement for implementing the logic log tracing functionality. Introduce a separate `Tracer` interface that when specified logs logic change logs.

This change separates the tracing requirements introduced primarily by the `sim` package from the core gpbft algorithm interfaces. Additionally, it makes mocking the `gpbft` behaviour for testing purposes simpler.

Note that the tracing concept in simulation defers from the "system logging", in that: it is a configurable textual output of a simulation. Therefore, the work here keeps them separate instead of replacing it with a typical logging library.