### PR TITLE
Speed up tests by running repetitions in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         with:
           go-version: '1.20'
       - name: Test
+        env:
+          # Override test repetition parallelism, since the default runner seem to have a single core.
+          # This shaves ~30 seconds off the CI test duration. 
+          F3_TEST_REPETITION_PARALLELISM: 2
         run: make test
 
   generate:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/whyrusleeping/cbor-gen v0.1.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.21.0
+	golang.org/x/sync v0.3.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 )
 

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/test/absent_test.go
+++ b/test/absent_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestAbsent(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		// fmt.Println("Iteration", i)
-		sm := sim.NewSimulation(AsyncConfig(3, i), GraniteConfig(), sim.TraceNone)
+	t.Parallel()
+	repeatInParallel(t, ASYNC_ITERS, func(t *testing.T, repetition int) {
+		sm := sim.NewSimulation(AsyncConfig(3, repetition), GraniteConfig(), sim.TraceNone)
 		// Adversary has 1/4 of power.
 		sm.SetAdversary(adversary.NewAbsent(99, sm.HostFor(99)), 1)
 
@@ -19,5 +19,5 @@ func TestAbsent(t *testing.T) {
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
-	}
+	})
 }

--- a/test/util.go
+++ b/test/util.go
@@ -1,11 +1,31 @@
 package test
 
 import (
+	"os"
+	"runtime"
+	"strconv"
+	"testing"
+
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/sim"
 	"github.com/stretchr/testify/require"
-	"testing"
+	"golang.org/x/sync/errgroup"
 )
+
+// repetitionParallelism sets the limit to the maximum degree of parallelism by which repetitions are executed.
+// By default this value is set to runtime.NumCPU, and is overridable via F3_TEST_REPETITION_PARALLELISM environment variable.
+// A negative value indicates no limit.
+var repetitionParallelism int
+
+func init() {
+	repetitionParallelism = runtime.NumCPU()
+	ps, found := os.LookupEnv("F3_TEST_REPETITION_PARALLELISM")
+	if found {
+		if v, err := strconv.ParseInt(ps, 10, 32); err == nil {
+			repetitionParallelism = int(v)
+		}
+	}
+}
 
 // Expects the decision in the first instance to be one of the given tipsets.
 func expectDecision(t *testing.T, sm *sim.Simulation, expected ...gpbft.TipSet) {
@@ -26,4 +46,19 @@ nextParticipant:
 		require.Fail(t, "participant %d decided %s in instance %d, expected one of %s",
 			participant.ID(), decision, instance, expected)
 	}
+}
+
+// repeatInParallel repeats target for the given number of repetitions.
+// See repetitionParallelism.
+func repeatInParallel(t *testing.T, repetitions int, target func(t *testing.T, repetition int)) {
+	var eg errgroup.Group
+	eg.SetLimit(repetitionParallelism)
+	for i := 1; i <= repetitions; i++ {
+		repetition := i
+		eg.Go(func() error {
+			target(t, repetition)
+			return nil
+		})
+	}
+	require.NoError(t, eg.Wait())
 }


### PR DESCRIPTION
Speed up tests by ~2X through running simulator test-case repetitions in parallel. The repetition parallelism is by default limited to the number of CPUs. Optionally, it is overridable by setting `F3_TEST_REPETITION_PARALLELISM` environment variable.

Refactor tests to reduce duplicate code and run tests in parallel wherever possible.

Note, the repetition parallelism limit is overridden to 2 for the CI runners. This reduces the test workflow execution time by ~10% compared to default, since the default runners run in a single core.

For comparison, the following lists the test time differences across three configurations:

1) This branch, with default parallelism limit:
```
$ time go test -count=1 ./...

?       github.com/filecoin-project/go-f3       [no test files]
?       github.com/filecoin-project/go-f3/adversary     [no test files]
?       github.com/filecoin-project/go-f3/cmd/f3sim     [no test files]
?       github.com/filecoin-project/go-f3/gen   [no test files]
ok      github.com/filecoin-project/go-f3/blssig        1.927s
ok      github.com/filecoin-project/go-f3/certs 2.331s
ok      github.com/filecoin-project/go-f3/gpbft 1.451s
ok      github.com/filecoin-project/go-f3/sim   2.738s
ok      github.com/filecoin-project/go-f3/test  94.702s

949.92s user 36.05s system 1036% cpu 1:35.15 total
```

2) This branch, with parallelism limit of 1:
```
$ time F3_TEST_REPETITION_PARALLELISM=1 go test -count=1 ./...

?       github.com/filecoin-project/go-f3       [no test files]
?       github.com/filecoin-project/go-f3/adversary     [no test files]
?       github.com/filecoin-project/go-f3/cmd/f3sim     [no test files]
?       github.com/filecoin-project/go-f3/gen   [no test files]
ok      github.com/filecoin-project/go-f3/blssig        1.192s
ok      github.com/filecoin-project/go-f3/certs 0.393s
ok      github.com/filecoin-project/go-f3/gpbft 0.819s
ok      github.com/filecoin-project/go-f3/sim   1.510s
ok      github.com/filecoin-project/go-f3/test  157.910s

548.50s user 4.93s system 349% cpu 2:38.33 total
```

3) The current head of `main` at `e5c4b15` :
```
$ time go test -count=1 ./...
?       github.com/filecoin-project/go-f3       [no test files]
?       github.com/filecoin-project/go-f3/adversary     [no test files]
?       github.com/filecoin-project/go-f3/cmd/f3sim     [no test files]
?       github.com/filecoin-project/go-f3/gen   [no test files]
ok      github.com/filecoin-project/go-f3/blssig        2.593s
ok      github.com/filecoin-project/go-f3/certs 3.048s
ok      github.com/filecoin-project/go-f3/gpbft 4.438s
ok      github.com/filecoin-project/go-f3/sim   3.536s
ok      github.com/filecoin-project/go-f3/test  164.805s

549.18s user 4.29s system 334% cpu 2:45.24 total
```