### PR TITLE
Make ECChain opaque [][]byte in GBPFT

### DIFF
--- a/cmd/f3sim/f3sim.go
+++ b/cmd/f3sim/f3sim.go
@@ -40,7 +40,7 @@ func main() {
 		sm := sim.NewSimulation(simConfig, graniteConfig, *traceLevel)
 
 		// Same chain for everyone.
-		candidate := sm.Base(0).Extend(sm.CIDGen.Sample())
+		candidate := sm.Base(0).Extend(sm.TipGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: *participantCount, Chain: candidate})
 
 		err := sm.Run(1, *maxRounds)

--- a/gen/main.go
+++ b/gen/main.go
@@ -15,7 +15,6 @@ func main() {
 		gpbft.GMessage{},
 		gpbft.Payload{},
 		gpbft.Justification{},
-		gpbft.TipSet{},
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -2,6 +2,7 @@ package gpbft
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"strings"
@@ -160,8 +161,15 @@ func (c ECChain) Validate() error {
 // Returns an identifier for the chain suitable for use as a map key.
 // This must completely determine the sequence of tipsets in the chain.
 func (c ECChain) Key() ChainKey {
-	buf := bytes.Buffer{}
+	var ln int
 	for _, t := range c {
+		ln += 4      // for length (over-estimate)
+		ln += len(t) // for data
+	}
+	var buf bytes.Buffer
+	buf.Grow(ln)
+	for _, t := range c {
+		_ = binary.Write(&buf, binary.BigEndian, uint32(len(t)))
 		buf.Write(t)
 	}
 	return ChainKey(buf.String())

--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -163,7 +163,7 @@ func (c ECChain) Validate() error {
 func (c ECChain) Key() ChainKey {
 	var ln int
 	for _, t := range c {
-		ln += 4      // for length (over-estimate)
+		ln += 4      // for length
 		ln += len(t) // for data
 	}
 	var buf bytes.Buffer

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -60,7 +60,7 @@ func requireTipSetMarshaledForSigning(t *testing.T, subject gpbft.TipSet) {
 	var gotSigningMarshal bytes.Buffer
 	subject.MarshalForSigning(&gotSigningMarshal)
 	wantPrefix := binary.BigEndian.AppendUint64(nil, uint64(subject.Epoch))
-	wantSuffix := subject.CID.Bytes()
+	wantSuffix := subject.ID.Bytes()
 	require.Equal(t, len(wantPrefix)+len(wantSuffix), gotSigningMarshal.Len())
 	require.True(t, bytes.HasPrefix(gotSigningMarshal.Bytes(), wantPrefix))
 	require.True(t, bytes.HasSuffix(gotSigningMarshal.Bytes(), wantSuffix))
@@ -145,7 +145,7 @@ func TestECChain(t *testing.T) {
 		require.False(t, subject.HasPrefix(subjectExtended))
 		require.True(t, subjectExtended.HasPrefix(subject))
 
-		require.False(t, subject.Extend(wantBase.CID).HasPrefix(subjectExtended.Extend(wantNextID)))
+		require.False(t, subject.Extend(wantBase.ID).HasPrefix(subjectExtended.Extend(wantNextID)))
 	})
 	t.Run("SameBase is false when either chain is zero", func(t *testing.T) {
 		var zeroChain gpbft.ECChain

--- a/gpbft/gen.go
+++ b/gpbft/gen.go
@@ -228,7 +228,15 @@ func (t *Payload) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 	for _, v := range t.Value {
-		if err := v.MarshalCBOR(cw); err != nil {
+		if len(v) > 2097152 {
+			return xerrors.Errorf("Byte array in field v was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(v))); err != nil {
+			return err
+		}
+
+		if _, err := cw.Write(v); err != nil {
 			return err
 		}
 
@@ -316,7 +324,7 @@ func (t *Payload) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > 0 {
-		t.Value = make([]TipSet, extra)
+		t.Value = make([][]uint8, extra)
 	}
 
 	for i := 0; i < int(extra); i++ {
@@ -328,12 +336,24 @@ func (t *Payload) UnmarshalCBOR(r io.Reader) (err error) {
 			_ = extra
 			_ = err
 
-			{
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
 
-				if err := t.Value[i].UnmarshalCBOR(cr); err != nil {
-					return xerrors.Errorf("unmarshaling t.Value[i]: %w", err)
-				}
+			if extra > 2097152 {
+				return fmt.Errorf("t.Value[i]: byte array too large (%d)", extra)
+			}
+			if maj != cbg.MajByteString {
+				return fmt.Errorf("expected byte array")
+			}
 
+			if extra > 0 {
+				t.Value[i] = make([]uint8, extra)
+			}
+
+			if _, err := io.ReadFull(cr, t.Value[i]); err != nil {
+				return err
 			}
 
 		}
@@ -444,156 +464,5 @@ func (t *Justification) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	return nil
-}
-
-var lengthBufTipSet = []byte{130}
-
-func (t *TipSet) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-
-	cw := cbg.NewCborWriter(w)
-
-	if _, err := cw.Write(lengthBufTipSet); err != nil {
-		return err
-	}
-
-	// t.Epoch (int64) (int64)
-	if t.Epoch >= 0 {
-		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Epoch)); err != nil {
-			return err
-		}
-	} else {
-		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Epoch-1)); err != nil {
-			return err
-		}
-	}
-
-	// t.CID (gpbft.TipSetID) (slice)
-	if len(t.ID) > 8192 {
-		return xerrors.Errorf("Slice value in field t.CID was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.ID))); err != nil {
-		return err
-	}
-	for _, v := range t.ID {
-		if len(v) > 2097152 {
-			return xerrors.Errorf("Byte array in field v was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(v))); err != nil {
-			return err
-		}
-
-		if _, err := cw.Write(v); err != nil {
-			return err
-		}
-
-	}
-	return nil
-}
-
-func (t *TipSet) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = TipSet{}
-
-	cr := cbg.NewCborReader(r)
-
-	maj, extra, err := cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-	}()
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.Epoch (int64) (int64)
-	{
-		maj, extra, err := cr.ReadHeader()
-		if err != nil {
-			return err
-		}
-		var extraI int64
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative overflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
-
-		t.Epoch = int64(extraI)
-	}
-	// t.CID (gpbft.TipSetID) (slice)
-
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if extra > 8192 {
-		return fmt.Errorf("t.CID: array too large (%d)", extra)
-	}
-
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
-
-	if extra > 0 {
-		t.ID = make([][]uint8, extra)
-	}
-
-	for i := 0; i < int(extra); i++ {
-		{
-			var maj byte
-			var extra uint64
-			var err error
-			_ = maj
-			_ = extra
-			_ = err
-
-			maj, extra, err = cr.ReadHeader()
-			if err != nil {
-				return err
-			}
-
-			if extra > 2097152 {
-				return fmt.Errorf("t.CID[i]: byte array too large (%d)", extra)
-			}
-			if maj != cbg.MajByteString {
-				return fmt.Errorf("expected byte array")
-			}
-
-			if extra > 0 {
-				t.ID[i] = make([]uint8, extra)
-			}
-
-			if _, err := io.ReadFull(cr, t.ID[i]); err != nil {
-				return err
-			}
-
-		}
-	}
 	return nil
 }

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -114,6 +114,7 @@ func (p Payload) MarshalForSigning(nn NetworkName) []byte {
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
 	_ = binary.Write(&buf, binary.BigEndian, p.Step)
 	for _, t := range p.Value {
+		_ = binary.Write(&buf, binary.BigEndian, uint32(len(t)))
 		buf.Write(t)
 	}
 	return buf.Bytes()

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -114,7 +114,7 @@ func (p Payload) MarshalForSigning(nn NetworkName) []byte {
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
 	_ = binary.Write(&buf, binary.BigEndian, p.Step)
 	for _, t := range p.Value {
-		t.MarshalForSigning(&buf)
+		buf.Write(t)
 	}
 	return buf.Bytes()
 }

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -518,7 +518,7 @@ func (i *instance) tryQuality() error {
 	}
 	// Wait either for a strong quorum that agree on our proposal,
 	// or for the timeout to expire.
-	foundQuorum := i.quality.HasStrongQuorumFor(i.proposal.Head())
+	foundQuorum := i.quality.HasStrongQuorumFor(i.proposal.Key())
 	timeoutExpired := atOrAfter(i.host.Time(), i.phaseTimeout)
 
 	if foundQuorum {
@@ -547,12 +547,12 @@ func (i *instance) beginConverge() {
 	// this node received a COMMIT message (bearing justification), if there were any.
 	// If there were none, there must have been a strong quorum for bottom instead.
 	var justification *Justification
-	if quorum, ok := prevRoundState.committed.FindStrongQuorumFor(ZeroTipSet()); ok {
+	if quorum, ok := prevRoundState.committed.FindStrongQuorumFor(""); ok {
 		// Build justification for strong quorum of COMMITs for bottom in the previous round.
 		justification = i.buildJustification(quorum, i.round-1, COMMIT_PHASE, ECChain{})
 	} else {
 		// Extract the justification received from some participant (possibly this node itself).
-		justification, ok = prevRoundState.committed.receivedJustification[i.proposal.Head()]
+		justification, ok = prevRoundState.committed.receivedJustification[i.proposal.Key()]
 		if !ok {
 			panic("beginConverge called but no justification for proposal")
 		}
@@ -612,7 +612,7 @@ func (i *instance) tryPrepare() error {
 
 	prepared := i.roundState(i.round).prepared
 	// Optimisation: we could advance phase once a strong quorum on our proposal is not possible.
-	foundQuorum := prepared.HasStrongQuorumFor(i.proposal.Head())
+	foundQuorum := prepared.HasStrongQuorumFor(i.proposal.Key())
 	timeoutExpired := atOrAfter(i.host.Time(), i.phaseTimeout)
 
 	if foundQuorum {
@@ -637,7 +637,7 @@ func (i *instance) beginCommit() {
 	// No justification is required for committing bottom.
 	var justification *Justification
 	if !i.value.IsZero() {
-		if quorum, ok := i.roundState(i.round).prepared.FindStrongQuorumFor(i.value.Head()); ok {
+		if quorum, ok := i.roundState(i.round).prepared.FindStrongQuorumFor(i.value.Key()); ok {
 			// Found a strong quorum of PREPARE, build the justification for it.
 			justification = i.buildJustification(quorum, i.round, PREPARE_PHASE, i.value)
 		} else {
@@ -689,7 +689,7 @@ func (i *instance) beginDecide(round uint64) {
 
 	var justification *Justification
 	// Value cannot be empty here.
-	if quorum, ok := roundState.committed.FindStrongQuorumFor(i.value.Head()); ok {
+	if quorum, ok := roundState.committed.FindStrongQuorumFor(i.value.Key()); ok {
 		// Build justification for strong quorum of COMMITs for the value.
 		justification = i.buildJustification(quorum, round, COMMIT_PHASE, i.value)
 	} else {
@@ -707,7 +707,7 @@ func (i *instance) beginDecide(round uint64) {
 func (i *instance) tryDecide() error {
 	quorumValue, ok := i.decision.FindStrongQuorumValue()
 	if ok {
-		if quorum, ok := i.decision.FindStrongQuorumFor(quorumValue.Head()); ok {
+		if quorum, ok := i.decision.FindStrongQuorumFor(quorumValue.Key()); ok {
 			decision := i.buildJustification(quorum, 0, DECIDE_PHASE, quorumValue)
 			i.terminate(decision)
 		} else {
@@ -824,16 +824,16 @@ func (i *instance) sign(msg []byte) ([]byte, error) {
 // which values have reached a strong quorum of support.
 // Supports receiving multiple values from each sender, and hence multiple strong quorum values.
 type quorumState struct {
-	// CID of each chain, used to track the first time a message from a sender is received.
+	// Set of senders from which a message has been received.
 	senders map[ActorID]struct{}
-	// The power supporting each chain so far.
-	chainSupport map[TipSet]chainSupport
-	// Total power of all distinct senders from which some chain has been senders so far.
+	// Total power of all distinct senders from which some chain has been received so far.
 	sendersTotalPower *StoragePower
+	// The power supporting each chain so far.
+	chainSupport map[ChainKey]chainSupport
 	// Table of senders' power.
 	powerTable PowerTable
 	// Stores justifications received for some value.
-	receivedJustification map[TipSet]*Justification
+	receivedJustification map[ChainKey]*Justification
 }
 
 // A chain value and the total power supporting it
@@ -849,10 +849,10 @@ type chainSupport struct {
 func newQuorumState(powerTable PowerTable) *quorumState {
 	return &quorumState{
 		senders:               map[ActorID]struct{}{},
-		chainSupport:          map[TipSet]chainSupport{},
 		sendersTotalPower:     NewStoragePower(0),
+		chainSupport:          map[ChainKey]chainSupport{},
 		powerTable:            powerTable,
-		receivedJustification: map[TipSet]*Justification{},
+		receivedJustification: map[ChainKey]*Justification{},
 	}
 }
 
@@ -866,10 +866,10 @@ func (q *quorumState) Receive(sender ActorID, value ECChain, signature []byte) {
 		q.sendersTotalPower.Add(q.sendersTotalPower, senderPower)
 	}
 
-	head := value.HeadOrZero()
-	candidate, ok := q.chainSupport[head]
+	key := value.Key()
+	candidate, ok := q.chainSupport[key]
 	if ok {
-		// Don't double-count the same chain head for a single participant.
+		// Don't double-count the same chain for a single participant.
 		if _, ok := candidate.signatures[sender]; ok {
 			return
 		}
@@ -881,7 +881,7 @@ func (q *quorumState) Receive(sender ActorID, value ECChain, signature []byte) {
 			hasStrongQuorum: false,
 			hasWeakQuorum:   false,
 		}
-		q.chainSupport[value.HeadOrZero()] = candidate
+		q.chainSupport[key] = candidate
 	}
 
 	candidate.signatures[sender] = signature
@@ -891,7 +891,7 @@ func (q *quorumState) Receive(sender ActorID, value ECChain, signature []byte) {
 
 	candidate.hasStrongQuorum = hasStrongQuorum(candidate.power, q.powerTable.Total)
 	candidate.hasWeakQuorum = hasWeakQuorum(candidate.power, q.powerTable.Total)
-	q.chainSupport[head] = candidate
+	q.chainSupport[key] = candidate
 }
 
 // Receives and stores justification for a value from another participant.
@@ -899,7 +899,7 @@ func (q *quorumState) ReceiveJustification(value ECChain, justification *Justifi
 	if justification == nil {
 		panic("nil justification")
 	}
-	q.receivedJustification[value.HeadOrZero()] = justification
+	q.receivedJustification[value.Key()] = justification
 }
 
 // Lists all values that have been senders from any sender.
@@ -917,9 +917,9 @@ func (q *quorumState) ReceivedFromStrongQuorum() bool {
 	return hasStrongQuorum(q.sendersTotalPower, q.powerTable.Total)
 }
 
-// Checks whether a chain (head) has reached a strong quorum.
-func (q *quorumState) HasStrongQuorumFor(cid TipSet) bool {
-	cp, ok := q.chainSupport[cid]
+// Checks whether a chain has reached a strong quorum.
+func (q *quorumState) HasStrongQuorumFor(key ChainKey) bool {
+	cp, ok := q.chainSupport[key]
 	return ok && cp.hasStrongQuorum
 }
 
@@ -943,10 +943,10 @@ func (q QuorumResult) SignersBitfield() bitfield.BitField {
 	return bf
 }
 
-// Checks whether a chain (head) has reached a strong quorum.
+// Checks whether a chain has reached a strong quorum.
 // If so returns a set of signers and signatures for the value that form a strong quorum.
-func (q *quorumState) FindStrongQuorumFor(value TipSet) (QuorumResult, bool) {
-	chainSupport, ok := q.chainSupport[value]
+func (q *quorumState) FindStrongQuorumFor(key ChainKey) (QuorumResult, bool) {
+	chainSupport, ok := q.chainSupport[key]
 	if !ok || !chainSupport.hasStrongQuorum {
 		return QuorumResult{}, false
 	}
@@ -985,9 +985,9 @@ func (q *quorumState) FindStrongQuorumFor(value TipSet) (QuorumResult, bool) {
 	return QuorumResult{}, false
 }
 
-// Checks whether a chain (head) has reached weak quorum.
-func (q *quorumState) HasWeakQuorumFor(cid TipSet) bool {
-	cp, ok := q.chainSupport[cid]
+// Checks whether a chain has reached weak quorum.
+func (q *quorumState) HasWeakQuorumFor(key ChainKey) bool {
+	cp, ok := q.chainSupport[key]
 	return ok && cp.hasWeakQuorum
 }
 
@@ -999,9 +999,9 @@ func (q *quorumState) HasWeakQuorumFor(cid TipSet) bool {
 // (signalling a violation of assumptions about the adversary).
 func (q *quorumState) ListStrongQuorumValues() []ECChain {
 	var withQuorum []ECChain
-	for cid, cp := range q.chainSupport {
+	for key, cp := range q.chainSupport {
 		if cp.hasStrongQuorum {
-			withQuorum = append(withQuorum, q.chainSupport[cid].chain)
+			withQuorum = append(withQuorum, q.chainSupport[key].chain)
 		}
 	}
 	sort.Slice(withQuorum, func(i, j int) bool {
@@ -1023,13 +1023,13 @@ func (q *quorumState) ListStrongQuorumValues() []ECChain {
 // Panics if there are multiple chains with strong quorum
 // (signalling a violation of assumptions about the adversary).
 func (q *quorumState) FindStrongQuorumValue() (quorumValue ECChain, foundQuorum bool) {
-	for cid, cp := range q.chainSupport {
+	for key, cp := range q.chainSupport {
 		if cp.hasStrongQuorum {
 			if foundQuorum {
 				panic("multiple chains with strong quorum")
 			}
 			foundQuorum = true
-			quorumValue = q.chainSupport[cid].chain
+			quorumValue = q.chainSupport[key].chain
 		}
 	}
 	return
@@ -1038,16 +1038,16 @@ func (q *quorumState) FindStrongQuorumValue() (quorumValue ECChain, foundQuorum 
 //// CONVERGE phase helper /////
 
 type convergeState struct {
-	// Chains indexed by head CID
-	values map[TipSet]ECChain
+	// Chains indexed by key
+	values map[ChainKey]ECChain
 	// Tickets provided by proposers of each chain.
-	tickets map[TipSet][]Ticket
+	tickets map[ChainKey][]Ticket
 }
 
 func newConvergeState() *convergeState {
 	return &convergeState{
-		values:  map[TipSet]ECChain{},
-		tickets: map[TipSet][]Ticket{},
+		values:  map[ChainKey]ECChain{},
+		tickets: map[ChainKey][]Ticket{},
 	}
 }
 
@@ -1056,7 +1056,7 @@ func (c *convergeState) Receive(value ECChain, ticket Ticket) error {
 	if value.IsZero() {
 		return fmt.Errorf("bottom cannot be justified for CONVERGE")
 	}
-	key := value.Head()
+	key := value.Key()
 	c.values[key] = value
 	c.tickets[key] = append(c.tickets[key], ticket)
 
@@ -1066,8 +1066,8 @@ func (c *convergeState) Receive(value ECChain, ticket Ticket) error {
 func (c *convergeState) findMinTicketProposal() ECChain {
 	var minTicket Ticket
 	var minValue ECChain
-	for cid, value := range c.values {
-		for _, ticket := range c.tickets[cid] {
+	for key, value := range c.values {
+		for _, ticket := range c.tickets[key] {
 			if minTicket == nil || ticket.Compare(minTicket) < 0 {
 				minTicket = ticket
 				minValue = value

--- a/gpbft/types.go
+++ b/gpbft/types.go
@@ -1,7 +1,6 @@
 package gpbft
 
 import (
-	"bytes"
 	"github.com/ipfs/go-datastore"
 	"math/big"
 )
@@ -26,47 +25,4 @@ func (nn NetworkName) PubSubTopic() string {
 // Creates a new StoragePower struct with a specific value and returns the result
 func NewStoragePower(value int64) *StoragePower {
 	return new(big.Int).SetInt64(value)
-}
-
-// Opaque type identifying a tipset.
-// This is expected to be a canonical sequence of CIDs of block headers identifying a tipset.
-// GossipPBFT doesn't need to know anything about CID format or behaviour, so adapts to this simple type
-// rather than import all the dependencies of the CID package.
-// This type is intentionally unsuitable for use as a map key.
-type TipSetID [][]byte
-
-// Creates a new TipSetID from a slice of block CIDs.
-func NewTipSetID(blocks [][]byte) TipSetID {
-	return blocks
-}
-
-// Creates a new singleton TipSetID from a string, treated as a CID.
-func NewTipSetIDFromString(s string) TipSetID {
-	return TipSetID{[]byte(s)}
-}
-
-// Checks whether a tipset ID is zero.
-func (t TipSetID) IsZero() bool {
-	return len(t) == 0
-}
-
-func (t TipSetID) Eq(other TipSetID) bool {
-	if len(t) != len(other) {
-		return false
-	}
-	for i, b := range t {
-		if !bytes.Equal(b, other[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-// FIXME this is not unique without a delimiter
-func (t TipSetID) Bytes() []byte {
-	buf := bytes.Buffer{}
-	for _, b := range t {
-		buf.Write(b)
-	}
-	return buf.Bytes()
 }

--- a/gpbft/types_test.go
+++ b/gpbft/types_test.go
@@ -1,67 +1,12 @@
 package gpbft_test
 
 import (
-	"sort"
 	"strings"
 	"testing"
 
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/stretchr/testify/require"
 )
-
-func TestNewTipSetID(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		subject  gpbft.TipSetID
-		wantZero bool
-	}{
-		{
-			name:     "zero-value struct is zero",
-			wantZero: true,
-		},
-		{
-			name:     "ZeroTipSetID is zero",
-			subject:  gpbft.ZeroTipSetID(),
-			wantZero: true,
-		},
-		{
-			name:     "NewTipSet with zero values is zero",
-			subject:  gpbft.NewTipSetID(nil),
-			wantZero: true,
-		},
-		{
-			name:    "Non-zero is not zero",
-			subject: gpbft.NewTipSetID([]byte("fish")),
-		},
-	}
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.wantZero, test.subject.IsZero())
-			gotBytes := test.subject.Bytes()
-			if test.wantZero {
-				require.Empty(t, gotBytes)
-			} else {
-				require.NotEmpty(t, gotBytes)
-			}
-			require.Zero(t, test.subject.Compare(test.subject))
-		})
-	}
-	t.Run("compare", func(t *testing.T) {
-		wantFirst := gpbft.NewTipSetID([]byte("1 fish"))
-		wantSecond := gpbft.NewTipSetID([]byte("2 lobster"))
-		wantThird := gpbft.NewTipSetID([]byte("3 barreleye"))
-		subject := []gpbft.TipSetID{wantSecond, wantFirst, wantThird}
-
-		sort.Slice(subject, func(one, other int) bool {
-			return subject[one].Compare(subject[other]) < 0
-		})
-		require.Equal(t, wantFirst, subject[0])
-		require.Equal(t, wantSecond, subject[1])
-		require.Equal(t, wantThird, subject[2])
-	})
-}
 
 func TestNetworkName(t *testing.T) {
 	t.Parallel()

--- a/sim/ec.go
+++ b/sim/ec.go
@@ -8,9 +8,7 @@ import (
 
 // Simulated EC state for each protocol instance.
 type EC struct {
-	// The first instance's base chain's first epoch.
-	BaseEpoch int64
-	// Timestamp of the base epoch.
+	// Timestamp of the base chain.
 	BaseTimestamp time.Time
 	Instances     []*ECInstance
 }
@@ -28,7 +26,6 @@ type ECInstance struct {
 
 func NewEC(base gpbft.ECChain, beacon []byte) *EC {
 	return &EC{
-		BaseEpoch:     base.Base().Epoch,
 		BaseTimestamp: time.Time{},
 		Instances: []*ECInstance{
 			{

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -60,7 +60,7 @@ type Simulation struct {
 	Participants []*gpbft.Participant
 	Adversary    AdversaryReceiver
 	Decisions    *DecisionLog
-	CIDGen       *TipIDGen
+	TipGen       *TipGen
 }
 
 type AdversaryFactory func(id string, ntwk gpbft.Network) gpbft.Receiver
@@ -79,10 +79,10 @@ func NewSimulation(simConfig Config, graniteConfig gpbft.GraniteConfig, traceLev
 	}
 
 	ntwk := NewNetwork(lat, traceLevel, *sb, "sim")
-	baseChain, _ := gpbft.NewChain(gpbft.NewTipSet(100, gpbft.NewTipSetIDFromString("genesis")))
+	baseChain, _ := gpbft.NewChain([]byte(("genesis")))
 	beacon := []byte("beacon")
 	ec := NewEC(baseChain, beacon)
-	cidGen := NewCIDGen(0x264803e715714f95) // Seed from Drand
+	tipGen := NewTipGen(0x264803e715714f95) // Seed from Drand
 	decisions := NewDecisionLog(ntwk, sb.Verifier)
 
 	// Create participants.
@@ -94,7 +94,7 @@ func NewSimulation(simConfig Config, graniteConfig gpbft.GraniteConfig, traceLev
 			Network:     ntwk,
 			EC:          ec,
 			DecisionLog: decisions,
-			TipIDGen:    cidGen,
+			TipGen:      tipGen,
 			id:          id,
 		}
 		participants[i] = gpbft.NewParticipant(id, graniteConfig, host, host)
@@ -111,7 +111,7 @@ func NewSimulation(simConfig Config, graniteConfig gpbft.GraniteConfig, traceLev
 		Participants: participants,
 		Adversary:    nil,
 		Decisions:    decisions,
-		CIDGen:       cidGen,
+		TipGen:       tipGen,
 	}
 }
 
@@ -136,7 +136,7 @@ func (s *Simulation) HostFor(id gpbft.ActorID) *SimHost {
 		Network:     s.Network,
 		EC:          s.EC,
 		DecisionLog: s.Decisions,
-		TipIDGen:    s.CIDGen,
+		TipGen:      s.TipGen,
 		id:          id,
 	}
 }
@@ -235,7 +235,7 @@ type SimHost struct {
 	*Network
 	*EC
 	*DecisionLog
-	*TipIDGen
+	*TipGen
 	id gpbft.ActorID
 }
 
@@ -277,13 +277,13 @@ func (v *SimHost) ReceiveDecision(decision *gpbft.Justification) time.Time {
 		// Create a new chain for all participants.
 		// There's no facility yet for them to observe different chains after the first instance.
 		// See https://github.com/filecoin-project/go-f3/issues/115.
-		newTip := gpbft.NewTipSet(nextBase.Epoch+1, v.TipIDGen.Sample())
+		newTip := v.TipGen.Sample()
 		nextChain, _ := gpbft.NewChain(nextBase, newTip)
 
 		v.EC.AddInstance(nextChain, nextPowerTable, nextBeacon)
 		v.DecisionLog.BeginInstance(decision.Vote.Instance+1, nextBase, nextPowerTable)
 	}
-	elapsedEpochs := decision.Vote.Value.Head().Epoch - v.EC.BaseEpoch
+	elapsedEpochs := 1 //decision.Vote.Value.Head().Epoch - v.EC.BaseEpoch
 	finalTimestamp := v.EC.BaseTimestamp.Add(time.Duration(elapsedEpochs) * v.Config.ECEpochDuration)
 	// Next instance starts some fixed time after the next EC epoch is due.
 	nextInstanceStart := finalTimestamp.Add(v.Config.ECEpochDuration).Add(v.Config.ECStabilisationDelay)
@@ -448,26 +448,26 @@ func (dl *DecisionLog) verifyDecision(decision *gpbft.Justification) error {
 	return nil
 }
 
-// A tipset ID generator.
+// A tipset generator.
 // This uses a fast xorshift PRNG to generate random tipset IDs.
 // The statistical properties of these are not important to correctness.
-type TipIDGen struct {
+type TipGen struct {
 	xorshiftState uint64
 }
 
-func NewCIDGen(seed uint64) *TipIDGen {
-	return &TipIDGen{seed}
+func NewTipGen(seed uint64) *TipGen {
+	return &TipGen{seed}
 }
 
-func (c *TipIDGen) Sample() gpbft.TipSetID {
+func (c *TipGen) Sample() gpbft.TipSet {
 	b := make([]byte, 8)
 	for i := range b {
 		b[i] = alphanum[c.nextN(len(alphanum))]
 	}
-	return gpbft.NewTipSetID([][]byte{b})
+	return b
 }
 
-func (c *TipIDGen) nextN(n int) uint64 {
+func (c *TipGen) nextN(n int) uint64 {
 	bucketSize := uint64(1<<63) / uint64(n)
 	limit := bucketSize * uint64(n)
 	for {
@@ -478,7 +478,7 @@ func (c *TipIDGen) nextN(n int) uint64 {
 	}
 }
 
-func (c *TipIDGen) next() uint64 {
+func (c *TipGen) next() uint64 {
 	x := c.xorshiftState
 	x ^= x << 13
 	x ^= x >> 7

--- a/test/absent_test.go
+++ b/test/absent_test.go
@@ -15,7 +15,7 @@ func TestAbsent(t *testing.T) {
 		// Adversary has 1/4 of power.
 		sm.SetAdversary(adversary.NewAbsent(99, sm.HostFor(99)), 1)
 
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())

--- a/test/decide_test.go
+++ b/test/decide_test.go
@@ -12,14 +12,14 @@ func TestImmediateDecide(t *testing.T) {
 	sm := sim.NewSimulation(AsyncConfig(1, 0), GraniteConfig(), sim.TraceNone)
 
 	// Create adversarial node
-	value := sm.Base(0).Extend(sm.CIDGen.Sample())
+	value := sm.Base(0).Extend(sm.TipGen.Sample())
 	adv := adversary.NewImmediateDecide(99, sm.HostFor(99), sm.PowerTable(0), value)
 
 	// Add the adversary to the simulation with 3/4 of total power.
 	sm.SetAdversary(adv, 3)
 
 	// The honest node starts with a different chain (on the same base).
-	sm.SetChains(sim.ChainCount{Count: 1, Chain: sm.Base(0).Extend(sm.CIDGen.Sample())})
+	sm.SetChains(sim.ChainCount{Count: 1, Chain: sm.Base(0).Extend(sm.TipGen.Sample())})
 	adv.Begin()
 	err := sm.Run(1, MAX_ROUNDS)
 	if err != nil {

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSingleton(t *testing.T) {
 	sm := sim.NewSimulation(SyncConfig(1), GraniteConfig(), sim.TraceNone)
-	a := sm.Base(0).Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.TipGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a})
 
 	require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -38,7 +38,7 @@ func TestSyncPair(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			sm := sim.NewSimulation(test.config, GraniteConfig(), sim.TraceNone)
-			a := sm.Base(0).Extend(sm.CIDGen.Sample())
+			a := sm.Base(0).Extend(sm.TipGen.Sample())
 			sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
 			require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -51,7 +51,7 @@ func TestASyncPair(t *testing.T) {
 	t.Parallel()
 	repeatInParallel(t, ASYNC_ITERS, func(t *testing.T, repetition int) {
 		sm := sim.NewSimulation(AsyncConfig(2, repetition), GraniteConfig(), sim.TraceNone)
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -78,8 +78,8 @@ func TestSyncPairDisagree(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			sm := sim.NewSimulation(test.config, GraniteConfig(), sim.TraceNone)
-			a := sm.Base(0).Extend(sm.CIDGen.Sample())
-			b := sm.Base(0).Extend(sm.CIDGen.Sample())
+			a := sm.Base(0).Extend(sm.TipGen.Sample())
+			b := sm.Base(0).Extend(sm.TipGen.Sample())
 			sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
 
 			require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -92,8 +92,8 @@ func TestSyncPairDisagree(t *testing.T) {
 func TestAsyncPairDisagree(t *testing.T) {
 	repeatInParallel(t, ASYNC_ITERS, func(t *testing.T, repetition int) {
 		sm := sim.NewSimulation(AsyncConfig(2, repetition), GraniteConfig(), sim.TraceNone)
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
-		b := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
+		b := sm.Base(0).Extend(sm.TipGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: 1, Chain: a}, sim.ChainCount{Count: 1, Chain: b})
 
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -106,7 +106,7 @@ func TestSyncAgreement(t *testing.T) {
 	repeatInParallel(t, 50, func(t *testing.T, repetition int) {
 		honestCount := 3 + repetition
 		sm := sim.NewSimulation(SyncConfig(honestCount), GraniteConfig(), sim.TraceNone)
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
 		// Synchronous, agreeing groups always decide the candidate.
@@ -122,7 +122,7 @@ func TestAsyncAgreement(t *testing.T) {
 		t.Run(fmt.Sprintf("honest count %d", honestCount), func(t *testing.T) {
 			repeatInParallel(t, ASYNC_ITERS, func(t *testing.T, repetition int) {
 				sm := sim.NewSimulation(AsyncConfig(honestCount, repetition), GraniteConfig(), sim.TraceNone)
-				a := sm.Base(0).Extend(sm.CIDGen.Sample())
+				a := sm.Base(0).Extend(sm.TipGen.Sample())
 				sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
 				require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -137,8 +137,8 @@ func TestSyncHalves(t *testing.T) {
 	repeatInParallel(t, 15, func(t *testing.T, repetition int) {
 		honestCount := repetition*2 + 2
 		sm := sim.NewSimulation(SyncConfig(honestCount), GraniteConfig(), sim.TraceNone)
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
-		b := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
+		b := sm.Base(0).Extend(sm.TipGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: honestCount / 2, Chain: a}, sim.ChainCount{Count: honestCount / 2, Chain: b})
 
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -152,8 +152,8 @@ func TestSyncHalvesBLS(t *testing.T) {
 	repeatInParallel(t, 3, func(t *testing.T, repetition int) {
 		honestCount := repetition*2 + 2
 		sm := sim.NewSimulation(SyncConfig(honestCount).UseBLS(), GraniteConfig(), sim.TraceNone)
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
-		b := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
+		b := sm.Base(0).Extend(sm.TipGen.Sample())
 		sm.SetChains(sim.ChainCount{Count: honestCount / 2, Chain: a}, sim.ChainCount{Count: honestCount / 2, Chain: b})
 
 		require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -169,8 +169,8 @@ func TestAsyncHalves(t *testing.T) {
 		t.Run(fmt.Sprintf("honest count %d", honestCount), func(t *testing.T) {
 			repeatInParallel(t, ASYNC_ITERS, func(t *testing.T, repetition int) {
 				sm := sim.NewSimulation(AsyncConfig(honestCount, repetition), GraniteConfig(), sim.TraceNone)
-				a := sm.Base(0).Extend(sm.CIDGen.Sample())
-				b := sm.Base(0).Extend(sm.CIDGen.Sample())
+				a := sm.Base(0).Extend(sm.TipGen.Sample())
+				b := sm.Base(0).Extend(sm.TipGen.Sample())
 				sm.SetChains(sim.ChainCount{Count: honestCount / 2, Chain: a}, sim.ChainCount{Count: honestCount / 2, Chain: b})
 
 				require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
@@ -185,8 +185,8 @@ func TestRequireStrongQuorumToProgress(t *testing.T) {
 	t.Parallel()
 	repeatInParallel(t, ASYNC_ITERS, func(t *testing.T, repetition int) {
 		sm := sim.NewSimulation(AsyncConfig(30, repetition), GraniteConfig(), sim.TraceNone)
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
-		b := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
+		b := sm.Base(0).Extend(sm.TipGen.Sample())
 		// No strict > quorum.
 		sm.SetChains(sim.ChainCount{Count: 20, Chain: a}, sim.ChainCount{Count: 10, Chain: b})
 
@@ -200,11 +200,11 @@ func TestLongestCommonPrefix(t *testing.T) {
 	// This test uses a synchronous configuration to ensure timely message delivery.
 	// If async, it is possible to decide the base chain if QUALITY messages are delayed.
 	sm := sim.NewSimulation(SyncConfig(4), GraniteConfig(), sim.TraceNone)
-	ab := sm.Base(0).Extend(sm.CIDGen.Sample())
-	abc := ab.Extend(sm.CIDGen.Sample())
-	abd := ab.Extend(sm.CIDGen.Sample())
-	abe := ab.Extend(sm.CIDGen.Sample())
-	abf := ab.Extend(sm.CIDGen.Sample())
+	ab := sm.Base(0).Extend(sm.TipGen.Sample())
+	abc := ab.Extend(sm.TipGen.Sample())
+	abd := ab.Extend(sm.TipGen.Sample())
+	abe := ab.Extend(sm.TipGen.Sample())
+	abf := ab.Extend(sm.TipGen.Sample())
 	sm.SetChains(
 		sim.ChainCount{Count: 1, Chain: abc},
 		sim.ChainCount{Count: 1, Chain: abd},

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -13,7 +13,7 @@ const INSTANCE_COUNT = 4000
 
 func TestMultiSingleton(t *testing.T) {
 	sm := sim.NewSimulation(SyncConfig(1), GraniteConfig(), sim.TraceNone)
-	a := sm.Base(0).Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.TipGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: 1, Chain: a})
 
 	require.NoErrorf(t, sm.Run(INSTANCE_COUNT, MAX_ROUNDS), "%s", sm.Describe())
@@ -23,7 +23,7 @@ func TestMultiSingleton(t *testing.T) {
 
 func TestMultiSyncPair(t *testing.T) {
 	sm := sim.NewSimulation(SyncConfig(2), GraniteConfig(), sim.TraceNone)
-	a := sm.Base(0).Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.TipGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
 	require.NoErrorf(t, sm.Run(INSTANCE_COUNT, MAX_ROUNDS), "%s", sm.Describe())
@@ -33,7 +33,7 @@ func TestMultiSyncPair(t *testing.T) {
 
 func TestMultiASyncPair(t *testing.T) {
 	sm := sim.NewSimulation(AsyncConfig(2, 0), GraniteConfig(), sim.TraceNone)
-	a := sm.Base(0).Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.TipGen.Sample())
 	sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
 
 	require.NoErrorf(t, sm.Run(INSTANCE_COUNT, MAX_ROUNDS), "%s", sm.Describe())
@@ -49,7 +49,7 @@ func TestMultiSyncAgreement(t *testing.T) {
 	repeatInParallel(t, 9, func(t *testing.T, repetition int) {
 		honestCount := repetition + 3
 		sm := sim.NewSimulation(SyncConfig(honestCount), GraniteConfig(), sim.TraceNone)
-		a := sm.Base(0).Extend(sm.CIDGen.Sample())
+		a := sm.Base(0).Extend(sm.TipGen.Sample())
 		// All nodes start with the same chain and will observe the same extensions of that chain
 		// in subsequent instances.
 		sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
@@ -65,7 +65,7 @@ func TestMultiAsyncAgreement(t *testing.T) {
 	repeatInParallel(t, 9, func(t *testing.T, repetition int) {
 		honestCount := repetition + 3
 		sm := sim.NewSimulation(AsyncConfig(honestCount, 0), GraniteConfig(), sim.TraceNone)
-		sm.SetChains(sim.ChainCount{Count: honestCount, Chain: sm.Base(0).Extend(sm.CIDGen.Sample())})
+		sm.SetChains(sim.ChainCount{Count: honestCount, Chain: sm.Base(0).Extend(sm.TipGen.Sample())})
 
 		require.NoErrorf(t, sm.Run(INSTANCE_COUNT, MAX_ROUNDS), "%s", sm.Describe())
 		// Note: The expected decision only needs to be something recent.

--- a/test/util.go
+++ b/test/util.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"os"
 	"runtime"
 	"strconv"
@@ -39,7 +40,7 @@ nextParticipant:
 		decision, ok := sm.GetDecision(instance, participant.ID())
 		require.True(t, ok, "no decision for participant %d in instance %d", participant.ID(), instance)
 		for _, e := range expected {
-			if decision.Head().Eq(e) {
+			if bytes.Equal(decision.Head(), e) {
 				continue nextParticipant
 			}
 		}

--- a/test/util.go
+++ b/test/util.go
@@ -39,7 +39,7 @@ nextParticipant:
 		decision, ok := sm.GetDecision(instance, participant.ID())
 		require.True(t, ok, "no decision for participant %d in instance %d", participant.ID(), instance)
 		for _, e := range expected {
-			if decision.Head() == e {
+			if decision.Head().Eq(e) {
 				continue nextParticipant
 			}
 		}

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -19,8 +19,8 @@ func TestWitholdCommit1(t *testing.T) {
 	adv := adversary.NewWitholdCommit(99, sm.HostFor(99), sm.PowerTable(0))
 	sm.SetAdversary(adv, 3) // Adversary has 30% of 10 total power.
 
-	a := sm.Base(0).Extend(sm.CIDGen.Sample())
-	b := sm.Base(0).Extend(sm.CIDGen.Sample())
+	a := sm.Base(0).Extend(sm.TipGen.Sample())
+	b := sm.Base(0).Extend(sm.TipGen.Sample())
 	// Of 7 nodes, 4 victims will prefer chain A, 3 others will prefer chain B.
 	// The adversary will target the first to decide, and withhold COMMIT from the rest.
 	// After the victim decides in round 0, the adversary stops participating.


### PR DESCRIPTION
Removes all internal structure from ECTipset and ECChain, making them entirely opaque. Adds a key type which just stringifies the bytes, ensuring that the entire value is used as a map key. Note that this doesn't yet exactly match the draft FIP (#148).

The internal structure of chain values now needs to be specified elsewhere, but GPBFT will never introspect it.

This also deleted some useful tests for the consistency of chains. When a new type is introduces at the integration layer, those tests should be restored there instead.

Previous PR description below (just introduces the key type) :
<details>
This is a prototype of using the full ECChain payload as a map key, rather than just head tipset ID. It avoids hashing, but just concatenates the bytes and wraps as a string.

This also changes the TipsetID type to be `[][]byte`, removing an additional serialization step and, by design, making it unusable as a map key. Note that this doesn't yet exactly match the draft FIP (#148).

Review: please critique this design and suggest alternatives. There is an outstanding problem of generating a unique key for `[][]byte` (for both keying and signing) that will incorporate the slice boundaries. Ideas welcome.
</details>

Closes #147.