### PR TITLE
Test repeated messages do not interfere with consensus

### DIFF
--- a/adversary/repeat.go
+++ b/adversary/repeat.go
@@ -1,0 +1,64 @@
+package adversary
+
+import (
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+type (
+	Repeat struct {
+		id            gpbft.ActorID
+		host          gpbft.Host
+		echoCountDist CountSampler
+	}
+	CountSampler interface {
+		// TODO replace with math/rand/v2 rand.Source once upgraded to go 1.22.
+		Uint64() uint64
+	}
+)
+
+func NewRepeat(id gpbft.ActorID, host gpbft.Host, echoCountDist CountSampler) *Repeat {
+	return &Repeat{
+		id:            id,
+		host:          host,
+		echoCountDist: echoCountDist,
+	}
+}
+
+func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
+	sigPayload := msg.Vote.MarshalForSigning(r.host.NetworkName())
+	_, power, beacon := r.host.GetCanonicalChain()
+	_, pubkey := power.Get(r.id)
+
+	sig, err := r.host.Sign(pubkey, sigPayload)
+	if err != nil {
+		panic(err)
+	}
+
+	var ticket gpbft.Ticket
+	if len(msg.Ticket) != 0 {
+		var err error
+		ticket, err = gpbft.MakeTicket(beacon, msg.Vote.Instance, msg.Vote.Round, pubkey, r.host)
+		if err != nil {
+			panic(err)
+		}
+	}
+	echo := &gpbft.GMessage{
+		Sender:        r.ID(),
+		Vote:          msg.Vote,
+		Signature:     sig,
+		Justification: msg.Justification,
+		Ticket:        ticket,
+	}
+	echoCount := int(r.echoCountDist.Uint64())
+	for i := 0; i < echoCount; i++ {
+		r.host.Broadcast(echo)
+	}
+	return true, nil
+}
+
+func (r *Repeat) ID() gpbft.ActorID                                              { return r.id }
+func (r *Repeat) Start() error                                                   { return nil }
+func (r *Repeat) ReceiveECChain(gpbft.ECChain) error                             { return nil }
+func (r *Repeat) ValidateMessage(*gpbft.GMessage) (bool, error)                  { return true, nil }
+func (r *Repeat) ReceiveAlarm() error                                            { return nil }
+func (r *Repeat) AllowMessage(gpbft.ActorID, gpbft.ActorID, gpbft.GMessage) bool { return true }

--- a/test/repeat_test.go
+++ b/test/repeat_test.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/filecoin-project/go-f3/adversary"
+	"github.com/filecoin-project/go-f3/sim"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepeat(t *testing.T) {
+	t.Parallel()
+
+	// Repeated messages should not interfere with consensus. Hence, test with larger than 1/3 adversary power.
+	honestCounts := []int{
+		1, // 1/2 adversary power
+		2, // 1/3 adversary power
+		3, // 1/4 adversary power
+	}
+	tests := []struct {
+		name          string
+		honestCount   []int
+		echoCountDist func(int) adversary.CountSampler // Distribution from which the number of echos is drawn.
+	}{
+		{
+			name: "uniform random",
+			echoCountDist: func(repetition int) adversary.CountSampler {
+				return uniformRandomRange{
+					rng: rand.New(rand.NewSource(int64(repetition))),
+					min: 10,
+					max: 50,
+				}
+			},
+		},
+		{
+			name: "zipf",
+			echoCountDist: func(repetition int) adversary.CountSampler {
+				rng := rand.New(rand.NewSource(int64(repetition)))
+				return rand.NewZipf(rng, 1.2, 1.0, 100)
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			for _, hc := range honestCounts {
+				repeatInParallel(t, ASYNC_ITERS, func(t *testing.T, repetition int) {
+					sm := sim.NewSimulation(AsyncConfig(hc, repetition), GraniteConfig(), sim.TraceNone)
+					dist := test.echoCountDist(repetition)
+					repeat := adversary.NewRepeat(99, sm.HostFor(99), dist)
+					sm.SetAdversary(repeat, 1)
+
+					a := sm.Base(0).Extend(sm.TipGen.Sample())
+					sm.SetChains(sim.ChainCount{Count: len(sm.Participants), Chain: a})
+
+					require.NoErrorf(t, sm.Run(1, MAX_ROUNDS), "%s", sm.Describe())
+				})
+			}
+
+		})
+	}
+}
+
+var _ adversary.CountSampler = (*uniformRandomRange)(nil)
+
+type uniformRandomRange struct {
+	rng      *rand.Rand
+	min, max uint64
+}
+
+func (r uniformRandomRange) Uint64() uint64 {
+	return r.rng.Uint64()%(r.max-r.min+1) + r.min
+}


### PR DESCRIPTION
Implement an adversary that echos all messages it receives with a configurable echo count distribution.

Test that  echoed messages do not interfere with consensus even at adversary power of larger than 1/3 of network size.