### PR TITLE
Get PowerTable from Host during adversary testing

### DIFF
--- a/adversary/withhold.go
+++ b/adversary/withhold.go
@@ -12,20 +12,18 @@ import (
 // Against a naive algorithm, when set up with 30% of power, and a victim set with 40%,
 // it can cause one victim to decide, while others revert to the base.
 type WithholdCommit struct {
-	id         gpbft.ActorID
-	host       sim.AdversaryHost
-	powertable *gpbft.PowerTable
+	id   gpbft.ActorID
+	host sim.AdversaryHost
 	// The first victim is the target, others are those who need to confirm.
 	victims     []gpbft.ActorID
 	victimValue gpbft.ECChain
 }
 
 // A participant that never sends anything.
-func NewWitholdCommit(id gpbft.ActorID, host sim.AdversaryHost, powertable *gpbft.PowerTable) *WithholdCommit {
+func NewWitholdCommit(id gpbft.ActorID, host sim.AdversaryHost) *WithholdCommit {
 	return &WithholdCommit{
-		id:         id,
-		host:       host,
-		powertable: powertable,
+		id:   id,
+		host: host,
 	}
 }
 
@@ -59,7 +57,8 @@ func (w *WithholdCommit) ReceiveAlarm() error {
 }
 
 func (w *WithholdCommit) Begin() {
-	broadcast := w.broadcastHelper(w.id)
+	_, powertable, _ := w.host.GetCanonicalChain()
+	broadcast := w.broadcastHelper(w.id, powertable)
 	// All victims need to see QUALITY and PREPARE in order to send their COMMIT,
 	// but only the one victim will see our COMMIT.
 	broadcast(gpbft.Payload{
@@ -93,16 +92,16 @@ func (w *WithholdCommit) Begin() {
 	// properly to accumulate the evidence for its COMMIT message.
 	signers := make([]int, 0)
 	for _, actorID := range w.victims {
-		signers = append(signers, w.powertable.Lookup[actorID])
+		signers = append(signers, powertable.Lookup[actorID])
 	}
-	signers = append(signers, w.powertable.Lookup[w.id])
+	signers = append(signers, powertable.Lookup[w.id])
 	sort.Ints(signers)
 
 	signatures := make([][]byte, 0)
 	pubKeys := make([]gpbft.PubKey, 0)
 	prepareMarshalled := preparePayload.MarshalForSigning(w.host.NetworkName())
 	for _, signerIndex := range signers {
-		entry := w.powertable.Entries[signerIndex]
+		entry := powertable.Entries[signerIndex]
 		signatures = append(signatures, w.sign(entry.PubKey, prepareMarshalled))
 		pubKeys = append(pubKeys, entry.PubKey)
 		justification.Signers.Set(uint64(signerIndex))
@@ -155,10 +154,10 @@ func (w *WithholdCommit) sign(pubkey gpbft.PubKey, msg []byte) []byte {
 	return sig
 }
 
-func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID) func(gpbft.Payload, *gpbft.Justification) {
+func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID, powertable gpbft.PowerTable) func(gpbft.Payload, *gpbft.Justification) {
 	return func(payload gpbft.Payload, justification *gpbft.Justification) {
 		pS := payload.MarshalForSigning(w.host.NetworkName())
-		_, pubkey := w.powertable.Get(sender)
+		_, pubkey := powertable.Get(sender)
 		sig, err := w.host.Sign(pubkey, pS)
 		if err != nil {
 			panic(err)

--- a/test/decide_test.go
+++ b/test/decide_test.go
@@ -2,10 +2,11 @@ package test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/filecoin-project/go-f3/adversary"
 	"github.com/filecoin-project/go-f3/sim"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestImmediateDecide(t *testing.T) {
@@ -13,7 +14,7 @@ func TestImmediateDecide(t *testing.T) {
 
 	// Create adversarial node
 	value := sm.Base(0).Extend(sm.TipGen.Sample())
-	adv := adversary.NewImmediateDecide(99, sm.HostFor(99), sm.PowerTable(0), value)
+	adv := adversary.NewImmediateDecide(99, sm.HostFor(99), value)
 
 	// Add the adversary to the simulation with 3/4 of total power.
 	sm.SetAdversary(adv, 3)

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -16,7 +16,7 @@ func TestWitholdCommit1(t *testing.T) {
 	simConfig := AsyncConfig(7, i)
 	simConfig.LatencyMean = 10 * time.Millisecond // Near-synchrony
 	sm := sim.NewSimulation(simConfig, GraniteConfig(), sim.TraceNone)
-	adv := adversary.NewWitholdCommit(99, sm.HostFor(99), sm.PowerTable(0))
+	adv := adversary.NewWitholdCommit(99, sm.HostFor(99))
 	sm.SetAdversary(adv, 3) // Adversary has 30% of 10 total power.
 
 	a := sm.Base(0).Extend(sm.TipGen.Sample())


### PR DESCRIPTION
`Decide` and `Withhold` adversaries require an instance of `Host` and access to its power table. Simplify the test setup by retrieving the power table directly from `Host` instead of taking it as an explicit parameter.