### PR TITLE
Signal whether an EC chain was accepted by an instance

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -2,10 +2,15 @@ package gpbft
 
 import "time"
 
-// Receives EC chain values.
+// ChainReceiver defines the interface for receiving updates to an Expected Consensus (EC) chain.
+// Implementers of this interface can act upon received EC chain data, potentially considering the
+// given chain as the expected consensus chain in the current GPBFT instance.
 type ChainReceiver interface {
-	// Receives a new EC chain, and notifies the current instance if it extends its current acceptable chain.
-	// This modifies the set of valid values for the current instance.
+	// ReceiveECChain processes an incoming EC chain update. It assesses whether the new chain
+	// extends or is compatible with the currently accepted chain maintained by the instance.
+	//
+	//Returns ErrECChainNotAcceptable error if the chain was not accepted. Otherwise, an error
+	// is returned if the chain is invalid.
 	ReceiveECChain(chain ECChain) error
 }
 

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -224,12 +224,14 @@ func (i *instance) Start() error {
 	return i.drainInbox()
 }
 
-// Receives a new chain, and updates its current chain if the received one is acceptable
-// (i.e. if it extends the current acceptable).
-func (i *instance) ReceiveAcceptable(chain ECChain) {
-	if chain.HasPrefix(i.acceptable) {
+// ReceiveAcceptable receives a new chain, and updates the current chain of this instance if acceptable.
+// See instance.isAcceptable.
+func (i *instance) ReceiveAcceptable(chain ECChain) bool {
+	acceptable := i.isAcceptable(chain)
+	if acceptable {
 		i.acceptable = chain
 	}
+	return acceptable
 }
 
 // Checks whether a message is valid.

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 )
 
+// ErrECChainNotAcceptable signals that ECChain is not acceptable by gpbft instance, due to mismatching prefix.
+var ErrECChainNotAcceptable = errors.New("ec chain is not acceptable")
+
 // An F3 participant runs repeated instances of Granite to finalise longer chains.
 type Participant struct {
 	id     ActorID
@@ -75,7 +78,9 @@ func (p *Participant) ReceiveECChain(chain ECChain) (err error) {
 	if chain.IsZero() {
 		err = errors.New("cannot receive zero chain")
 	} else if err = chain.Validate(); err == nil && p.granite != nil {
-		p.granite.ReceiveAcceptable(chain)
+		if p.granite.ReceiveAcceptable(chain) {
+			err = ErrECChainNotAcceptable
+		}
 	}
 	return
 }

--- a/sim/adversary/absent.go
+++ b/sim/adversary/absent.go
@@ -27,7 +27,7 @@ func (a *Absent) Start() error {
 	return nil
 }
 
-func (a *Absent) ReceiveECChain(_ gpbft.ECChain) error {
+func (a *Absent) ReceiveECChain(gpbft.ECChain) error {
 	return nil
 }
 

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -30,7 +30,7 @@ func (i *ImmediateDecide) Start() error {
 	return nil
 }
 
-func (i *ImmediateDecide) ReceiveECChain(_ gpbft.ECChain) error {
+func (i *ImmediateDecide) ReceiveECChain(gpbft.ECChain) error {
 	return nil
 }
 

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -41,7 +41,7 @@ func (w *WithholdCommit) Start() error {
 	return nil
 }
 
-func (w *WithholdCommit) ReceiveECChain(_ gpbft.ECChain) error {
+func (w *WithholdCommit) ReceiveECChain(gpbft.ECChain) error {
 	return nil
 }
 


### PR DESCRIPTION
Update `ChainReceiver` interface to signal whether an EC chain was accepted by an instance or not. This allows tests to assert the current state of a participant and its current GPBFT instance specifically during equivocations testing.

Update `ChainReceiver` godoc to document the pre-existing and new behavior.