### PR TITLE
Refactor `sim` package in prep for expanding the implementation

### DIFF
--- a/sim/config.go
+++ b/sim/config.go
@@ -1,0 +1,27 @@
+package sim
+
+import (
+	"time"
+
+	"github.com/filecoin-project/go-f3/sim/signing"
+)
+
+type Config struct {
+	// Honest participant count.
+	// Honest participants have one unit of power each.
+	HonestCount int
+	LatencySeed int64
+	// Mean delivery latency for messages.
+	LatencyMean time.Duration
+	// Duration of EC epochs.
+	ECEpochDuration time.Duration
+	// Time to wait after EC epoch before starting next instance.
+	ECStabilisationDelay time.Duration
+	// If nil then FakeSigningBackend is used unless overridden by F3_TEST_USE_BLS
+	SigningBacked signing.Backend
+}
+
+func (c Config) UseBLS() Config {
+	c.SigningBacked = signing.NewBLSBackend()
+	return c
+}

--- a/sim/decision_log.go
+++ b/sim/decision_log.go
@@ -1,0 +1,163 @@
+package sim
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+	"golang.org/x/xerrors"
+)
+
+// Receives and validates finality decisions
+type DecisionLog struct {
+	Network  gpbft.Network
+	Verifier gpbft.Verifier
+	// Base tipset for each instance.
+	Bases []gpbft.TipSet
+	// Powertable for each instance.
+	PowerTables []*gpbft.PowerTable
+	// Decisions received for each instance and participant.
+	Decisions []map[gpbft.ActorID]*gpbft.Justification
+	err       error
+}
+
+func NewDecisionLog(ntwk gpbft.Network, verifier gpbft.Verifier) *DecisionLog {
+	return &DecisionLog{
+		Network:  ntwk,
+		Verifier: verifier,
+	}
+}
+
+// Establishes the base tipset and power table for a new instance.
+func (dl *DecisionLog) BeginInstance(instance uint64, base gpbft.TipSet, power *gpbft.PowerTable) {
+	if instance != uint64(len(dl.Bases)) {
+		panic(fmt.Errorf("instance %d is not the next instance", instance))
+	}
+	dl.Bases = append(dl.Bases, base)
+	dl.PowerTables = append(dl.PowerTables, power)
+	dl.Decisions = append(dl.Decisions, make(map[gpbft.ActorID]*gpbft.Justification))
+}
+
+// Checks whether all participants (except any adversary) have decided on a value for an instance.
+func (dl *DecisionLog) HasCompletedInstance(instance uint64, adversary gpbft.ActorID) bool {
+	if instance >= uint64(len(dl.Bases)) {
+		return false
+	}
+	target := len(dl.PowerTables[instance].Entries)
+	if dl.PowerTables[instance].Has(adversary) {
+		target -= 1
+	}
+
+	return len(dl.Decisions[instance]) == target
+}
+
+// Checks that all participants (except any adversary) for an instance decided on the same value.
+func (dl *DecisionLog) VerifyInstance(instance uint64, adversary gpbft.ActorID) error {
+	if dl.err != nil {
+		return dl.err
+	}
+	if instance >= uint64(len(dl.Bases)) {
+		panic(fmt.Errorf("instance %d not yet begun", instance))
+	}
+	// Check each actor in the power table decided, and their decisions matched.
+	var first gpbft.ECChain
+	for _, powerEntry := range dl.PowerTables[instance].Entries {
+		decision, ok := dl.Decisions[instance][powerEntry.ID]
+		if powerEntry.ID == adversary {
+			continue
+		}
+		if !ok {
+			return fmt.Errorf("actor %d did not decide", powerEntry.ID)
+		}
+		if first.IsZero() {
+			first = decision.Vote.Value
+		}
+		if !decision.Vote.Value.Eq(first) {
+			return fmt.Errorf("actor %d decided %v, but first actor decided %v",
+				powerEntry.ID, decision.Vote.Value, first)
+		}
+	}
+	return nil
+}
+
+func (dl *DecisionLog) PrintInstance(instance uint64) {
+	if instance >= uint64(len(dl.Bases)) {
+		panic(fmt.Errorf("instance %d not yet begun", instance))
+	}
+	var first gpbft.ECChain
+	for _, powerEntry := range dl.PowerTables[instance].Entries {
+		decision, ok := dl.Decisions[instance][powerEntry.ID]
+		if !ok {
+			fmt.Printf("‼️ Participant %d did not decide\n", powerEntry.ID)
+		}
+		if first.IsZero() {
+			first = decision.Vote.Value
+		}
+		if !decision.Vote.Value.Eq(first) {
+			fmt.Printf("‼️ Participant %d decided %v, but %d decided %v\n",
+				powerEntry.ID, decision.Vote, dl.PowerTables[instance].Entries[0].ID, first)
+		}
+	}
+}
+
+// Verifies and records a decision from a participant.
+// Returns whether this was the first decision for the instance.
+func (dl *DecisionLog) ReceiveDecision(participant gpbft.ActorID, decision *gpbft.Justification) (first bool) {
+	if err := dl.verifyDecision(decision); err == nil {
+		if len(dl.Decisions[decision.Vote.Instance]) == 0 {
+			first = true
+		}
+		// Record the participant's decision.
+		dl.Decisions[decision.Vote.Instance][participant] = decision
+	} else {
+		fmt.Printf("invalid decision: %v\n", err)
+		dl.err = err
+	}
+	return
+}
+
+func (dl *DecisionLog) verifyDecision(decision *gpbft.Justification) error {
+	if decision.Vote.Instance >= uint64(len(dl.Bases)) {
+		return fmt.Errorf("decision for future instance: %v", decision)
+	}
+	base := dl.Bases[decision.Vote.Instance]
+	powerTable := dl.PowerTables[decision.Vote.Instance]
+	if decision.Vote.Step != gpbft.DECIDE_PHASE {
+		return fmt.Errorf("decision for wrong phase: %v", decision)
+	}
+	if decision.Vote.Round != 0 {
+		return fmt.Errorf("decision for wrong round: %v", decision)
+	}
+	if decision.Vote.Value.IsZero() {
+		return fmt.Errorf("decided empty tipset: %v", decision)
+	}
+	if !decision.Vote.Value.HasBase(base) {
+		return fmt.Errorf("decided tipset with wrong base: %v", decision)
+	}
+
+	// Extract signers.
+	justificationPower := gpbft.NewStoragePower(0)
+	signers := make([]gpbft.PubKey, 0)
+	if err := decision.Signers.ForEach(func(bit uint64) error {
+		if int(bit) >= len(powerTable.Entries) {
+			return fmt.Errorf("invalid signer index: %d", bit)
+		}
+		justificationPower.Add(justificationPower, powerTable.Entries[bit].Power)
+		signers = append(signers, powerTable.Entries[bit].PubKey)
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to iterate over signers: %w", err)
+	}
+	// Check signers have strong quorum
+	strongQuorum := gpbft.NewStoragePower(0)
+	strongQuorum = strongQuorum.Mul(strongQuorum, gpbft.NewStoragePower(2))
+	strongQuorum = strongQuorum.Div(strongQuorum, gpbft.NewStoragePower(3))
+	if justificationPower.Cmp(strongQuorum) < 0 {
+		return fmt.Errorf("decision lacks strong quorum: %v", decision)
+	}
+	// Verify aggregate signature
+	payload := decision.Vote.MarshalForSigning(dl.Network.NetworkName())
+	if err := dl.Verifier.VerifyAggregate(payload, decision.Signature, signers); err != nil {
+		return xerrors.Errorf("invalid aggregate signature: %v: %w", decision, err)
+	}
+	return nil
+}

--- a/sim/host.go
+++ b/sim/host.go
@@ -1,0 +1,70 @@
+package sim
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+// One participant's host
+// This provides methods that know the caller's participant ID and can provide its view of the world.
+type SimHost struct {
+	*Config
+	*Network
+	*EC
+	*DecisionLog
+	*TipGen
+	id gpbft.ActorID
+}
+
+var _ gpbft.Host = (*SimHost)(nil)
+
+///// Chain interface
+
+func (v *SimHost) GetCanonicalChain() (chain gpbft.ECChain, power gpbft.PowerTable, beacon []byte) {
+	// Find the instance after the last instance finalised by the participant.
+	instance := uint64(0)
+	for i := len(v.Decisions) - 1; i >= 0; i-- {
+		if v.Decisions[i][v.id] != nil {
+			instance = uint64(i + 1)
+			break
+		}
+	}
+
+	i := v.Instances[instance]
+	chain = i.Chains[v.id]
+	power = *i.PowerTable
+	beacon = i.Beacon
+	return
+}
+
+func (v *SimHost) SetAlarm(at time.Time) {
+	v.Network.SetAlarm(v.id, at)
+}
+
+func (v *SimHost) ReceiveDecision(decision *gpbft.Justification) time.Time {
+	firstForInstance := v.DecisionLog.ReceiveDecision(v.id, decision)
+	if firstForInstance {
+		// When the first valid decision is received for an instance, prepare for the next one.
+		nextBase := decision.Vote.Value.Head()
+		// Copy the previous instance power table.
+		// The simulator doesn't have any facility to evolve the power table.
+		// See https://github.com/filecoin-project/go-f3/issues/114.
+		nextPowerTable := v.EC.Instances[decision.Vote.Instance].PowerTable.Copy()
+		nextBeacon := []byte(fmt.Sprintf("beacon %d", decision.Vote.Instance+1))
+		// Create a new chain for all participants.
+		// There's no facility yet for them to observe different chains after the first instance.
+		// See https://github.com/filecoin-project/go-f3/issues/115.
+		newTip := v.TipGen.Sample()
+		nextChain, _ := gpbft.NewChain(nextBase, newTip)
+
+		v.EC.AddInstance(nextChain, nextPowerTable, nextBeacon)
+		v.DecisionLog.BeginInstance(decision.Vote.Instance+1, nextBase, nextPowerTable)
+	}
+	elapsedEpochs := 1 //decision.Vote.Value.Head().Epoch - v.EC.BaseEpoch
+	finalTimestamp := v.EC.BaseTimestamp.Add(time.Duration(elapsedEpochs) * v.Config.ECEpochDuration)
+	// Next instance starts some fixed time after the next EC epoch is due.
+	nextInstanceStart := finalTimestamp.Add(v.Config.ECEpochDuration).Add(v.Config.ECStabilisationDelay)
+	return nextInstanceStart
+}

--- a/sim/latency/latency.go
+++ b/sim/latency/latency.go
@@ -1,4 +1,4 @@
-package sim
+package latency
 
 import (
 	"math"
@@ -7,21 +7,21 @@ import (
 )
 
 // A model for network latency.
-type LatencyModel interface {
+type Model interface {
 	Sample() time.Duration
 }
 
-type LogNormalLatency struct {
+type LogNormal struct {
 	rng  *rand.Rand
 	mean time.Duration
 }
 
-func NewLogNormal(seed int64, mean time.Duration) *LogNormalLatency {
+func NewLogNormal(seed int64, mean time.Duration) *LogNormal {
 	rng := rand.New(rand.NewSource(seed))
-	return &LogNormalLatency{rng: rng, mean: mean}
+	return &LogNormal{rng: rng, mean: mean}
 }
 
-func (l *LogNormalLatency) Sample() time.Duration {
+func (l *LogNormal) Sample() time.Duration {
 	norm := l.rng.NormFloat64()
 	lognorm := math.Exp(norm)
 	return time.Duration(lognorm * float64(l.mean))

--- a/sim/message_queue.go
+++ b/sim/message_queue.go
@@ -1,0 +1,49 @@
+package sim
+
+import (
+	"sort"
+	"time"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+type messageInFlight struct {
+	source    gpbft.ActorID // ID of the sender
+	dest      gpbft.ActorID // ID of the receiver
+	payload   interface{}   // Message body
+	deliverAt time.Time     // Timestamp at which to deliver the message
+}
+
+// A queue of directed messages, maintained as an ordered list.
+type messageQueue []messageInFlight
+
+func (h *messageQueue) Insert(x messageInFlight) {
+	// Insert the new message after any messages with a sooner or equal deliverAt.
+	i := sort.Search(len(*h), func(i int) bool {
+		ith := (*h)[i].deliverAt
+		return ith.After(x.deliverAt)
+	})
+	*h = append(*h, messageInFlight{})
+	copy((*h)[i+1:], (*h)[i:])
+	(*h)[i] = x
+}
+
+// Removes an entry from the queue
+func (h *messageQueue) Remove(i int) messageInFlight {
+	v := (*h)[i]
+	copy((*h)[i:], (*h)[i+1:])
+	*h = (*h)[:len(*h)-1]
+	return v
+}
+
+// Removes all entries from the queue that satisfy a predicate.
+func (h *messageQueue) RemoveWhere(f func(messageInFlight) bool) {
+	i := 0
+	for _, x := range *h {
+		if !f(x) {
+			(*h)[i] = x
+			i++
+		}
+	}
+	*h = (*h)[:i]
+}

--- a/sim/signing/bls.go
+++ b/sim/signing/bls.go
@@ -1,4 +1,4 @@
-package sim
+package signing
 
 import (
 	"errors"
@@ -10,16 +10,16 @@ import (
 	"github.com/filecoin-project/go-f3/gpbft"
 )
 
-var _ SigningBacked = (*BLSSigningBackend)(nil)
+var _ Backend = (*BLSBackend)(nil)
 
-type BLSSigningBackend struct {
+type BLSBackend struct {
 	gpbft.Verifier
 	signersByPubKey map[string]*blssig.Signer
 	suite           pairing.Suite
 	scheme          *bdn.Scheme
 }
 
-func (b *BLSSigningBackend) Sign(sender gpbft.PubKey, msg []byte) ([]byte, error) {
+func (b *BLSBackend) Sign(sender gpbft.PubKey, msg []byte) ([]byte, error) {
 	signer, known := b.signersByPubKey[string(sender)]
 	if !known {
 		return nil, errors.New("cannot sign: unknown sender")
@@ -27,9 +27,9 @@ func (b *BLSSigningBackend) Sign(sender gpbft.PubKey, msg []byte) ([]byte, error
 	return signer.Sign(sender, msg)
 }
 
-func NewBLSSigningBackend() *BLSSigningBackend {
+func NewBLSBackend() *BLSBackend {
 	suite := bls12381.NewBLS12381Suite()
-	return &BLSSigningBackend{
+	return &BLSBackend{
 		Verifier:        blssig.VerifierWithKeyOnG1(),
 		signersByPubKey: make(map[string]*blssig.Signer),
 		suite:           suite,
@@ -37,7 +37,7 @@ func NewBLSSigningBackend() *BLSSigningBackend {
 	}
 }
 
-func (b *BLSSigningBackend) GenerateKey() (gpbft.PubKey, any) {
+func (b *BLSBackend) GenerateKey() (gpbft.PubKey, any) {
 	priv, pub := b.scheme.NewKeyPair(b.suite.RandomStream())
 	pubKeyB, err := pub.MarshalBinary()
 	if err != nil {

--- a/sim/signing/signing.go
+++ b/sim/signing/signing.go
@@ -1,0 +1,9 @@
+package signing
+
+import "github.com/filecoin-project/go-f3/gpbft"
+
+type Backend interface {
+	gpbft.Signer
+	gpbft.Verifier
+	GenerateKey() (gpbft.PubKey, any)
+}

--- a/sim/tipgen.go
+++ b/sim/tipgen.go
@@ -1,0 +1,44 @@
+package sim
+
+import "github.com/filecoin-project/go-f3/gpbft"
+
+var alphanum = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+// A tipset generator.
+// This uses a fast xorshift PRNG to generate random tipset IDs.
+// The statistical properties of these are not important to correctness.
+type TipGen struct {
+	xorshiftState uint64
+}
+
+func NewTipGen(seed uint64) *TipGen {
+	return &TipGen{seed}
+}
+
+func (c *TipGen) Sample() gpbft.TipSet {
+	b := make([]byte, 8)
+	for i := range b {
+		b[i] = alphanum[c.nextN(len(alphanum))]
+	}
+	return b
+}
+
+func (c *TipGen) nextN(n int) uint64 {
+	bucketSize := uint64(1<<63) / uint64(n)
+	limit := bucketSize * uint64(n)
+	for {
+		x := c.next()
+		if x < limit {
+			return x / bucketSize
+		}
+	}
+}
+
+func (c *TipGen) next() uint64 {
+	x := c.xorshiftState
+	x ^= x << 13
+	x ^= x >> 7
+	x ^= x << 17
+	c.xorshiftState = x
+	return x
+}

--- a/test/constants.go
+++ b/test/constants.go
@@ -1,9 +1,10 @@
 package test
 
 import (
+	"time"
+
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/sim"
-	"time"
 )
 
 // Configuration constants used across most tests.

--- a/test/signing_suite_test.go
+++ b/test/signing_suite_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/drand/kyber/sign/bdn"
 	"github.com/filecoin-project/go-f3/blssig"
 	"github.com/filecoin-project/go-f3/gpbft"
-	"github.com/filecoin-project/go-f3/sim"
+	"github.com/filecoin-project/go-f3/sim/signing"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -35,7 +35,7 @@ func TestBLSSigning(t *testing.T) {
 }
 
 func TestFakeSigning(t *testing.T) {
-	var fakeSigning = sim.NewFakeSigningBackend()
+	var fakeSigning = signing.NewFakeBackend()
 	suite.Run(t, NewSigningSuite(func(t *testing.T) (gpbft.PubKey, gpbft.Signer) {
 		pubKey, _ := fakeSigning.GenerateKey()
 		return pubKey, fakeSigning


### PR DESCRIPTION
Break up large go files into separate ones that capture minimal functionality. Encapsulate simulated signing related implementations into their own package, called `signing`.

Rename inconsistent struct/constructor names, and resolve minor lint issues.

Note, the changes here do not make any net functional difference. Instead, they aim to reduce the LOC changed in successive PRs where simulation will be expanded to accommodate more complex scenarios, including more control over adversary message propagation, latency and message loss modeling.