### PR TITLE
Trigger merge group checks with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   lint:


### PR DESCRIPTION
Merge queue is now enabled on `main`. Trigger merge group checks with GitHub Actions.

See:
 * https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions