### PR TITLE
Replace externally-provided acceptable chains with candidate list including possibly-decided values

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -2,18 +2,6 @@ package gpbft
 
 import "time"
 
-// ChainReceiver defines the interface for receiving updates to an Expected Consensus (EC) chain.
-// Implementers of this interface can act upon received EC chain data, potentially considering the
-// given chain as the expected consensus chain in the current GPBFT instance.
-type ChainReceiver interface {
-	// ReceiveECChain processes an incoming EC chain update. It assesses whether the new chain
-	// extends or is compatible with the currently accepted chain maintained by the instance.
-	//
-	//Returns ErrECChainNotAcceptable error if the chain was not accepted. Otherwise, an error
-	// is returned if the chain is invalid.
-	ReceiveECChain(chain ECChain) error
-}
-
 // Receives a Granite protocol message.
 type MessageReceiver interface {
 	// Validates a message received from another participant, if possible.
@@ -31,7 +19,6 @@ type Receiver interface {
 	// Begins executing the protocol.
 	// The node will request the canonical chain to propose from the host.
 	Start() error
-	ChainReceiver
 	MessageReceiver
 }
 

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -515,7 +515,7 @@ func (i *instance) tryQuality() error {
 	}
 
 	if foundQuorum || timeoutExpired {
-		// Add quorum prefixes to candidates (skipping base chain, which is already there).
+		// Add prefixes with quorum to candidates (skipping base chain, which is already there).
 		for l := range i.proposal {
 			if l > 0 {
 				i.candidates = append(i.candidates, i.proposal.Prefix(l))
@@ -584,9 +584,10 @@ func (i *instance) tryConverge() error {
 	if i.isCandidate(winner.Chain) {
 		i.proposal = winner.Chain
 		i.log("adopting proposal %s after converge", &winner.Chain)
-	}
-	// Else preserve own proposal
-	// XXX spec says to loop to next lowest ticket, rather than fall back to own proposal.
+	} // Else preserve own proposal
+	// NOTE: FIP-0086 says to loop to next lowest ticket, rather than fall back to own proposal.
+	// But using own proposal is valid (the spec can't assume any others have been received),
+	// considering others is an optimisation.
 
 	i.value = i.proposal
 	i.beginPrepare()

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 )
 
-// ErrECChainNotAcceptable signals that ECChain is not acceptable by gpbft instance, due to mismatching prefix.
-var ErrECChainNotAcceptable = errors.New("ec chain is not acceptable")
-
 // An F3 participant runs repeated instances of Granite to finalise longer chains.
 type Participant struct {
 	*options

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -75,24 +75,6 @@ func (p *Participant) CurrentRound() uint64 {
 	return p.granite.round
 }
 
-// Receives a new EC chain, and notifies the current instance.
-// This may modify the set of valid values for the current instance.
-func (p *Participant) ReceiveECChain(chain ECChain) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = &PanicError{Err: r}
-		}
-	}()
-	if chain.IsZero() {
-		err = errors.New("cannot receive zero chain")
-	} else if err = chain.Validate(); err == nil && p.granite != nil {
-		if p.granite.ReceiveAcceptable(chain) {
-			err = ErrECChainNotAcceptable
-		}
-	}
-	return
-}
-
 // Validates a message received from another participant, if possible.
 // An invalid message can never become valid, so may be dropped.
 // A message can only be validated if it is for the currently-executing protocol instance.

--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -15,7 +15,7 @@ const (
 	tipSetGeneratorSeed = 0x264803e715714f95
 
 	latencyAsync         = 100 * time.Millisecond
-	maxRounds            = 20
+	maxRounds            = 18
 	asyncInterations     = 5000
 	EcEpochDuration      = 30 * time.Second
 	EcStabilisationDelay = 3 * time.Second

--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -15,7 +15,7 @@ const (
 	tipSetGeneratorSeed = 0x264803e715714f95
 
 	latencyAsync         = 100 * time.Millisecond
-	maxRounds            = 10
+	maxRounds            = 20
 	asyncInterations     = 5000
 	EcEpochDuration      = 30 * time.Second
 	EcStabilisationDelay = 3 * time.Second

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -156,35 +156,6 @@ func TestAsyncAgreement(t *testing.T) {
 	}
 }
 
-func TestAsyncAgreementXXX(t *testing.T) {
-	n := 3
-	iters := 100
-	//for n := 3; n <= 16; n++ {
-	honestCount := n
-	t.Run(fmt.Sprintf("honest count %d", honestCount), func(t *testing.T) {
-		for repetition := 1; repetition < iters; repetition++ {
-			t.Log("iteration", repetition)
-			tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
-			baseChain := generateECChain(t, tsg)
-			sm, err := sim.NewSimulation(asyncOptions(t, repetition,
-				sim.WithTraceLevel(sim.TraceAll), // TRACE
-				sim.WithHonestParticipantCount(honestCount),
-				sim.WithTipSetGenerator(tsg),
-				sim.WithBaseChain(&baseChain),
-			)...)
-			require.NoError(t, err)
-			a := baseChain.Extend(tsg.Sample())
-			sm.SetChains(sim.ChainCount{Count: sm.HonestParticipantsCount(), Chain: a})
-
-			require.NoErrorf(t, sm.Run(1, maxRounds), "%s", sm.Describe())
-			requireConsensus(t, sm, baseChain.Head(), a.Head())
-		}
-		//repeatInParallel(t, iters, func(t *testing.T, repetition int) {
-		//})
-	})
-	//}
-}
-
 func TestSyncHalves(t *testing.T) {
 	t.Parallel()
 

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -156,6 +156,35 @@ func TestAsyncAgreement(t *testing.T) {
 	}
 }
 
+func TestAsyncAgreementXXX(t *testing.T) {
+	n := 3
+	iters := 100
+	//for n := 3; n <= 16; n++ {
+	honestCount := n
+	t.Run(fmt.Sprintf("honest count %d", honestCount), func(t *testing.T) {
+		for repetition := 1; repetition < iters; repetition++ {
+			t.Log("iteration", repetition)
+			tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
+			baseChain := generateECChain(t, tsg)
+			sm, err := sim.NewSimulation(asyncOptions(t, repetition,
+				sim.WithTraceLevel(sim.TraceAll), // TRACE
+				sim.WithHonestParticipantCount(honestCount),
+				sim.WithTipSetGenerator(tsg),
+				sim.WithBaseChain(&baseChain),
+			)...)
+			require.NoError(t, err)
+			a := baseChain.Extend(tsg.Sample())
+			sm.SetChains(sim.ChainCount{Count: sm.HonestParticipantsCount(), Chain: a})
+
+			require.NoErrorf(t, sm.Run(1, maxRounds), "%s", sm.Describe())
+			requireConsensus(t, sm, baseChain.Head(), a.Head())
+		}
+		//repeatInParallel(t, iters, func(t *testing.T, repetition int) {
+		//})
+	})
+	//}
+}
+
 func TestSyncHalves(t *testing.T) {
 	t.Parallel()
 

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -58,6 +58,7 @@ func generateECChain(t *testing.T, tsg *sim.TipSetGenerator) gpbft.ECChain {
 }
 
 // repeatInParallel repeats target for the given number of repetitions.
+// Set F3_TEST_REPETITION_PARALLELISM=1 to run repetitions sequentially.
 // See repetitionParallelism.
 func repeatInParallel(t *testing.T, repetitions int, target func(t *testing.T, repetition int)) {
 	var eg errgroup.Group


### PR DESCRIPTION
Replace collection of acceptable chains received from outside with a collection of candidate chains that is updated to include any that might have been decided by another participant in a previous round.

- Prepare phase now waits to hear from >2/3 of power
- Evidence for CONVERGE is retained in order to justify swaying (and later to propagate to PREPARE)

The sequence of tests in COMMIT is slightly different than the spec, checking first for a strong quorum of COMMIT for bottom, and inferring that if that doesn't exist, any non-bottom COMMIT value could have been decided by another participant.

There is currently a shortcut in CONVERGE, where if the max ticket value cannot be accepted, the participant falls back to their own value instead of iterating through sequential tickets. I think this must be ok, since the node might not have received any others. But to be discussed whether this is good enough. Iterating the tickets will involve a larger change (I can follow up with it).

Part of #170.