### PR TITLE
Fix a bug in simulated next instance start time

### DIFF
--- a/sim/ec.go
+++ b/sim/ec.go
@@ -1,16 +1,12 @@
 package sim
 
 import (
-	"time"
-
 	"github.com/filecoin-project/go-f3/gpbft"
 )
 
 // Simulated EC state for each protocol instance.
 type EC struct {
-	// Timestamp of the base chain.
-	BaseTimestamp time.Time
-	Instances     []*ECInstance
+	Instances []*ECInstance
 }
 
 type ECInstance struct {
@@ -26,7 +22,6 @@ type ECInstance struct {
 
 func newEC(opts *options) *EC {
 	return &EC{
-		BaseTimestamp: time.Time{},
 		Instances: []*ECInstance{
 			{
 				Base:       *opts.baseChain,

--- a/sim/host.go
+++ b/sim/host.go
@@ -77,10 +77,8 @@ func (v *simHost) ReceiveDecision(decision *gpbft.Justification) time.Time {
 		v.sim.ec.AddInstance(nextChain, nextPowerTable, nextBeacon)
 		v.sim.decisions.BeginInstance(decision.Vote.Instance+1, nextBase, nextPowerTable)
 	}
-	elapsedEpochs := 1 //decision.Vote.Value.Head().Epoch - v.EC.BaseEpoch
-	finalTimestamp := v.sim.ec.BaseTimestamp.Add(time.Duration(elapsedEpochs) * v.sim.ecEpochDuration)
 	// Next instance starts some fixed time after the next EC epoch is due.
-	nextInstanceStart := finalTimestamp.Add(v.sim.ecEpochDuration).Add(v.sim.ecStabilisationDelay)
+	nextInstanceStart := v.Time().Add(v.sim.ecEpochDuration).Add(v.sim.ecStabilisationDelay)
 	return nextInstanceStart
 }
 


### PR DESCRIPTION
The simulation has configurations to set the length of an epoch as well as a stabilisation delay before it starts the next instance after one finishes.

Since the original implementation the code has undergone a number of iterations one of which removed epoch from tipset. Since that change, the simulation seem to have been using a fixed next start time upon receiving a decision. The start time is an absolute time; therefore using a fixed time meant that the simulation was not waiting for the configured stabilization in between instances.

Additionally, because the returned start time is used as deliver at timestamp by the simulated network transport alerts may have been fired immediately after a participant received a decision, before all participants finished deciding. This is fine as far as constraints of GPBFT algorithm is concerned. Which is why simulation tests have been passing so far. But it diverges from the intended simulation conditions.

The changes here fix the above issue by setting the next start time to the configured length of one epoch plus the configured stabilization delay _relative to the current network time_. This means the next instance start progresses as the time in the network does.

Further, the changes here remove the base timestamp field from simulated EC state as it seems to be unused.
