### PR TITLE
Implement `gpbft` option-based configuration with built-in defaults

### DIFF
--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -113,53 +113,6 @@ func (_c *MockHost_Broadcast_Call) RunAndReturn(run func(*GMessage)) *MockHost_B
 	return _c
 }
 
-// GenerateKey provides a mock function with given fields:
-func (_m *MockHost) GenerateKey() PubKey {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GenerateKey")
-	}
-
-	var r0 PubKey
-	if rf, ok := ret.Get(0).(func() PubKey); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(PubKey)
-		}
-	}
-
-	return r0
-}
-
-// MockHost_GenerateKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GenerateKey'
-type MockHost_GenerateKey_Call struct {
-	*mock.Call
-}
-
-// GenerateKey is a helper method to define mock.On call
-func (_e *MockHost_Expecter) GenerateKey() *MockHost_GenerateKey_Call {
-	return &MockHost_GenerateKey_Call{Call: _e.mock.On("GenerateKey")}
-}
-
-func (_c *MockHost_GenerateKey_Call) Run(run func()) *MockHost_GenerateKey_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockHost_GenerateKey_Call) Return(_a0 PubKey) *MockHost_GenerateKey_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockHost_GenerateKey_Call) RunAndReturn(run func() PubKey) *MockHost_GenerateKey_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetCanonicalChain provides a mock function with given fields:
 func (_m *MockHost) GetCanonicalChain() (ECChain, PowerTable, []byte) {
 	ret := _m.Called()

--- a/gpbft/options.go
+++ b/gpbft/options.go
@@ -1,0 +1,81 @@
+package gpbft
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	defaultDelta                = 2 * time.Second
+	defaultDeltaBackOffExponent = 1.3
+)
+
+// Option represents a configurable parameter.
+type Option func(*options) error
+
+type options struct {
+	delta                time.Duration
+	deltaBackOffExponent float64
+	// tracer traces logic logs for debugging and simulation purposes.
+	tracer          Tracer
+	initialInstance uint64
+}
+
+func newOptions(o ...Option) (*options, error) {
+	opts := &options{
+		delta:                defaultDelta,
+		deltaBackOffExponent: defaultDeltaBackOffExponent,
+	}
+	for _, apply := range o {
+		if err := apply(opts); err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}
+
+// WithDelta sets the expected bound on message propagation latency. Defaults to
+// 2 seconds if unspecified. Delta must be larger than zero.
+//
+// See: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md#synchronization-of-participants-in-the-current-instance
+func WithDelta(d time.Duration) Option {
+	return func(o *options) error {
+		if d < 0 {
+			return errors.New("delta duration cannot be less than zero")
+		}
+		o.delta = d
+		return nil
+	}
+}
+
+// WithDeltaBackOffExponent sets the delta back-off exponent for each round.
+// Defaults to 1.3 if unspecified. It must be larger than zero.
+//
+// See: https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0086.md#synchronization-of-participants-in-the-current-instance
+func WithDeltaBackOffExponent(e float64) Option {
+	return func(o *options) error {
+		if e < 0 {
+			return errors.New("delta backoff exponent cannot be less than zero")
+		}
+		o.deltaBackOffExponent = e
+		return nil
+	}
+}
+
+// WithInitialInstance sets the first instance number. Defaults to zero if
+// unspecified.
+func WithInitialInstance(i uint64) Option {
+	return func(o *options) error {
+		o.initialInstance = i
+		return nil
+	}
+}
+
+// WithTracer sets the Tracer for this gPBFT instance, which receives diagnostic
+// logs about the state mutation. Defaults to no tracer if unspecified.
+func WithTracer(t Tracer) Option {
+	return func(o *options) error {
+		o.tracer = t
+		return nil
+	}
+}

--- a/sim/cmd/f3sim/f3sim.go
+++ b/sim/cmd/f3sim/f3sim.go
@@ -21,7 +21,7 @@ func main() {
 	maxRounds := flag.Uint64("max-rounds", 10, "max rounds to allow before failing")
 	traceLevel := flag.Int("trace", sim.TraceNone, "trace verbosity level")
 
-	graniteDelta := flag.Float64("granite-delta", 2.000, "granite delta parameter (bound on message delay)")
+	delta := flag.Duration("delta", 2*time.Second, "bound on message delay")
 	deltaBackOffExponent := flag.Float64("delta-back-off-exponent", 1.300, "exponential factor adjusting the delta value per round")
 	flag.Parse()
 
@@ -41,10 +41,6 @@ func main() {
 			log.Fatalf("failed to generate base chain: %v\n", err)
 		}
 
-		graniteConfig := &gpbft.GraniteConfig{
-			Delta:                time.Duration(*graniteDelta * float64(time.Second)),
-			DeltaBackOffExponent: *deltaBackOffExponent,
-		}
 		options := []sim.Option{
 			sim.WithHonestParticipantCount(*participantCount),
 			sim.WithLatencyModel(latencyModel),
@@ -53,7 +49,10 @@ func main() {
 			sim.WithTipSetGenerator(tsg),
 			sim.WithBaseChain(&baseChain),
 			sim.WithTraceLevel(*traceLevel),
-			sim.WithGraniteConfig(graniteConfig),
+			sim.WithGpbftOptions(
+				gpbft.WithDelta(*delta),
+				gpbft.WithDeltaBackOffExponent(*deltaBackOffExponent),
+			),
 		}
 
 		if os.Getenv("F3_TEST_USE_BLS") == "1" {

--- a/sim/options.go
+++ b/sim/options.go
@@ -16,12 +16,8 @@ const (
 )
 
 var (
-	defaultBaseChain     gpbft.ECChain
-	defaultBeacon        = []byte("beacon")
-	defaultGraniteConfig = gpbft.GraniteConfig{
-		Delta:                2.0,
-		DeltaBackOffExponent: 1.3,
-	}
+	defaultBaseChain    gpbft.ECChain
+	defaultBeacon       = []byte("beacon")
 	defaultLatencyModel latency.Model
 )
 
@@ -52,11 +48,10 @@ type options struct {
 	ecStabilisationDelay time.Duration
 	// If nil then FakeSigningBackend is used unless overridden by F3_TEST_USE_BLS
 	signingBacked      signing.Backend
-	graniteConfig      *gpbft.GraniteConfig
+	gpbftOptions       []gpbft.Option
 	traceLevel         int
 	networkName        gpbft.NetworkName
 	tipSetGenerator    *TipSetGenerator
-	initialInstance    uint64
 	baseChain          *gpbft.ECChain
 	beacon             []byte
 	adversaryGenerator adversary.Generator
@@ -75,9 +70,6 @@ func newOptions(o ...Option) (*options, error) {
 	}
 	if opts.latencyModel == nil {
 		opts.latencyModel = defaultLatencyModel
-	}
-	if opts.graniteConfig == nil {
-		opts.graniteConfig = &defaultGraniteConfig
 	}
 	if opts.signingBacked == nil {
 		opts.signingBacked = signing.NewFakeBackend()
@@ -136,9 +128,9 @@ func WitECStabilisationDelay(d time.Duration) Option {
 	}
 }
 
-func WithGraniteConfig(c *gpbft.GraniteConfig) Option {
+func WithGpbftOptions(gOpts ...gpbft.Option) Option {
 	return func(o *options) error {
-		o.graniteConfig = c
+		o.gpbftOptions = gOpts
 		return nil
 	}
 }

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -35,11 +35,15 @@ func NewSimulation(o ...Option) (*Simulation, error) {
 		decisions: decisions,
 	}
 
+	pOpts := append(opts.gpbftOptions, gpbft.WithTracer(s.network))
 	var nextID gpbft.ActorID
 	s.participants = make([]*gpbft.Participant, s.honestCount)
 	for i := range s.participants {
 		host := newHost(nextID, s)
-		s.participants[i] = gpbft.NewParticipant(nextID, *s.graniteConfig, host, s.network, s.initialInstance)
+		s.participants[i], err = gpbft.NewParticipant(nextID, host, pOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instnatiate participant: %w", err)
+		}
 		pubKey, _ := s.signingBacked.GenerateKey()
 		s.network.AddParticipant(s.participants[i])
 		s.ec.AddParticipant(nextID, gpbft.NewStoragePower(1), pubKey)

--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -24,13 +24,13 @@ const (
 var (
 	oneStoragePower = gpbft.NewStoragePower(1)
 
-	// testGraniteConfig is configuration constants used across most tests.
+	// testGpbftOptions is configuration constants used across most tests.
 	// These values are not intended to reflect real-world conditions.
 	// The latency and delta values are similar in order to stress "slow" message paths and interleaving.
 	// The values are not appropriate for benchmarks.
-	testGraniteConfig = &gpbft.GraniteConfig{
-		Delta:                200 * time.Millisecond,
-		DeltaBackOffExponent: 1.300,
+	testGpbftOptions = []gpbft.Option{
+		gpbft.WithDelta(200 * time.Millisecond),
+		gpbft.WithDeltaBackOffExponent(1.300),
 	}
 )
 
@@ -39,7 +39,7 @@ func syncOptions(o ...sim.Option) []sim.Option {
 		sim.WithLatencyModel(latency.None),
 		sim.WithECEpochDuration(EcEpochDuration),
 		sim.WitECStabilisationDelay(EcStabilisationDelay),
-		sim.WithGraniteConfig(testGraniteConfig),
+		sim.WithGpbftOptions(testGpbftOptions...),
 	)
 }
 
@@ -50,6 +50,6 @@ func asyncOptions(t *testing.T, latencySeed int, o ...sim.Option) []sim.Option {
 		sim.WithLatencyModel(lm),
 		sim.WithECEpochDuration(EcEpochDuration),
 		sim.WitECStabilisationDelay(EcStabilisationDelay),
-		sim.WithGraniteConfig(testGraniteConfig),
+		sim.WithGpbftOptions(testGpbftOptions...),
 	)
 }

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -25,7 +25,7 @@ func TestWitholdCommit1(t *testing.T) {
 		sim.WithLatencyModel(nearSynchrony),
 		sim.WithECEpochDuration(EcEpochDuration),
 		sim.WitECStabilisationDelay(EcStabilisationDelay),
-		sim.WithGraniteConfig(testGraniteConfig),
+		sim.WithGpbftOptions(testGpbftOptions...),
 		sim.WithTipSetGenerator(tsg),
 		sim.WithBaseChain(&baseChain),
 		// Adversary has 30% of 10 total power.


### PR DESCRIPTION
Use `Option` function pattern to implement `gpbft` configuration parameters. Validate the input parameters and use default values if unset. The value of defaults is borrowed from FIP-0086.

Reflect changes in tests and simulation package.

Fixes #184