### PR TITLE
Investigate sensitivity to latency in multi instance tests

### DIFF
--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -15,7 +15,7 @@ const (
 	tipSetGeneratorSeed = 0x264803e715714f95
 
 	latencyAsync         = 100 * time.Millisecond
-	maxRounds            = 18
+	maxRounds            = 30
 	asyncInterations     = 5000
 	EcEpochDuration      = 30 * time.Second
 	EcStabilisationDelay = 3 * time.Second

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -100,7 +100,7 @@ func TestMultiAsyncAgreement(t *testing.T) {
 		honestCount := repetition + 3
 		tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
 		baseChain := generateECChain(t, tsg)
-		sm, err := sim.NewSimulation(asyncOptions(t, 1413,
+		sm, err := sim.NewSimulation(asyncOptions(t, 1414,
 			sim.WithHonestParticipantCount(honestCount),
 			sim.WithTipSetGenerator(tsg),
 			sim.WithBaseChain(&baseChain))...)


### PR DESCRIPTION
Assert that when latency seed is changed the tests passes eventually. In this case, it looks like the change in latency results in few additional rounds for the test to pass; 21 to be precise.

Increase the max rounds to 30 in order to avoid intermittent errors during dev work that might change latency seeds.

Closes #189