### PR TITLE
Remove redundant `ReceiveECChain` receiver from adversaries

### DIFF
--- a/sim/adversary/absent.go
+++ b/sim/adversary/absent.go
@@ -36,10 +36,6 @@ func (a *Absent) Start() error {
 	return nil
 }
 
-func (a *Absent) ReceiveECChain(gpbft.ECChain) error {
-	return nil
-}
-
 func (a *Absent) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
 	return true, nil
 }

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -74,10 +74,6 @@ func (i *ImmediateDecide) Start() error {
 	return nil
 }
 
-func (i *ImmediateDecide) ReceiveECChain(gpbft.ECChain) error {
-	return nil
-}
-
 func (i *ImmediateDecide) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
 	return true, nil
 }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -107,7 +107,6 @@ func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
 
 func (r *Repeat) ID() gpbft.ActorID                                              { return r.id }
 func (r *Repeat) Start() error                                                   { return nil }
-func (r *Repeat) ReceiveECChain(gpbft.ECChain) error                             { return nil }
 func (r *Repeat) ValidateMessage(*gpbft.GMessage) (bool, error)                  { return true, nil }
 func (r *Repeat) ReceiveAlarm() error                                            { return nil }
 func (r *Repeat) AllowMessage(gpbft.ActorID, gpbft.ActorID, gpbft.GMessage) bool { return true }

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -114,10 +114,6 @@ func (w *WithholdCommit) Start() error {
 	return nil
 }
 
-func (w *WithholdCommit) ReceiveECChain(gpbft.ECChain) error {
-	return nil
-}
-
 func (a *WithholdCommit) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
 	return true, nil
 }


### PR DESCRIPTION
Since externally-provided acceptable chains are replaced with candidate list the gpbft API no longer requires implementation of `ReceiveECChain` receiver function. Remove it.