### PR TITLE
Reduce GC frequency to run tests faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 all: generate test lint
 
+test: GOGC ?= 1000 # Reduce the GC frequency, default to 1000 if unset.
 test:
-	go test ./...
+	GOGC=$(GOGC) go test ./...
 .PHONY: test
 
 lint:

--- a/test/ballast_test.go
+++ b/test/ballast_test.go
@@ -3,7 +3,7 @@ package test
 var ballast []byte
 
 func init() {
-	// 100MiB memory ballast to reduce the frequency of GC
-	// reduces runtime of tests by 20%
-	ballast = make([]byte, 100<<20)
+	// Allocate 200MiB memory ballast to reduce the frequency of GC, which reduces
+	// runtime of tests by ~20%.
+	ballast = make([]byte, 200<<20)
 }


### PR DESCRIPTION
Increase the default `GOGC` by 10x when tests are run using the `make test` target, and respect commandline `GOGC` overrides if set.

Increase the memory ballast to 200MiB for tests.

These changes improve the test runtime by ~50%:

Before:

```
$ time go test ./... -count=1

?       github.com/filecoin-project/go-f3       [no test files]
?       github.com/filecoin-project/go-f3/blssig        [no test files]
?       github.com/filecoin-project/go-f3/gen   [no test files]
?       github.com/filecoin-project/go-f3/sim   [no test files]
?       github.com/filecoin-project/go-f3/sim/adversary [no test files]
?       github.com/filecoin-project/go-f3/sim/cmd/f3sim [no test files]
?       github.com/filecoin-project/go-f3/sim/latency   [no test files]
?       github.com/filecoin-project/go-f3/sim/signing   [no test files]
ok      github.com/filecoin-project/go-f3/certs 0.093s
ok      github.com/filecoin-project/go-f3/gpbft 0.165s
ok      github.com/filecoin-project/go-f3/test  72.994s

go test ./... -count=1  745.97s user 28.26s system 1054% cpu 1:13.41 total
```

After:
```
$ time GOGC=1000 go test ./... -count=1

?       github.com/filecoin-project/go-f3       [no test files]
?       github.com/filecoin-project/go-f3/blssig        [no test files]
?       github.com/filecoin-project/go-f3/gen   [no test files]
?       github.com/filecoin-project/go-f3/sim   [no test files]
?       github.com/filecoin-project/go-f3/sim/adversary [no test files]
?       github.com/filecoin-project/go-f3/sim/cmd/f3sim [no test files]
?       github.com/filecoin-project/go-f3/sim/latency   [no test files]
?       github.com/filecoin-project/go-f3/sim/signing   [no test files]
ok      github.com/filecoin-project/go-f3/certs 0.478s
ok      github.com/filecoin-project/go-f3/gpbft 0.574s
ok      github.com/filecoin-project/go-f3/test  44.909s

GOGC=1000 go test ./... -count=1  449.32s user 19.86s system 1033% cpu 45.386 total
```