### PR TITLE
Simplify simulation messaging with priority queue and parameterise GST

### DIFF
--- a/sim/message_queue.go
+++ b/sim/message_queue.go
@@ -1,49 +1,111 @@
 package sim
 
 import (
-	"sort"
+	"container/heap"
 	"time"
 
 	"github.com/filecoin-project/go-f3/gpbft"
 )
 
+var _ heap.Interface = (*messageQueue)(nil)
+
+// messageQueue is a priority queue that implements heap.Interface and holds
+// simulation messages in flight prioritised by their delivery time in ascending
+// order.
+type messageQueue struct {
+	mailbox []*messageInFlight
+}
+
 type messageInFlight struct {
 	source    gpbft.ActorID // ID of the sender
 	dest      gpbft.ActorID // ID of the receiver
-	payload   interface{}   // Message body
+	payload   any           // Message body
 	deliverAt time.Time     // Timestamp at which to deliver the message
+
+	index int // Index in the heap used internally by the heap implementation
 }
 
-// A queue of directed messages, maintained as an ordered list.
-type messageQueue []messageInFlight
-
-func (h *messageQueue) Insert(x messageInFlight) {
-	// Insert the new message after any messages with a sooner or equal deliverAt.
-	i := sort.Search(len(*h), func(i int) bool {
-		ith := (*h)[i].deliverAt
-		return ith.After(x.deliverAt)
-	})
-	*h = append(*h, messageInFlight{})
-	copy((*h)[i+1:], (*h)[i:])
-	(*h)[i] = x
+func newMessagePriorityQueue() *messageQueue {
+	var mpq messageQueue
+	heap.Init(&mpq)
+	return &mpq
 }
 
-// Removes an entry from the queue
-func (h *messageQueue) Remove(i int) messageInFlight {
-	v := (*h)[i]
-	copy((*h)[i:], (*h)[i+1:])
-	*h = (*h)[:len(*h)-1]
-	return v
+// Len returns the number of messages that are currently in-flight.
+func (pq *messageQueue) Len() int { return len(pq.mailbox) }
+
+// Less determines whether message in-flight at index i should be prioritised
+// before the message in-flight at index j. The message deliverAt filed is used
+// to determine this, where the earlier the deliverAt the higher priority the
+// message, i.e. messages are sorted in ascending order of their deliverAt.
+//
+// This function is part of heap.Interface and must not be called externally.
+func (pq *messageQueue) Less(i, j int) bool {
+	// We want Pop to give us the earliest delivery time, so we use Less to sort by
+	// deliverAt in ascending order.
+	return pq.mailbox[i].deliverAt.Before(pq.mailbox[j].deliverAt)
 }
 
-// Removes all entries from the queue that satisfy a predicate.
-func (h *messageQueue) RemoveWhere(f func(messageInFlight) bool) {
-	i := 0
-	for _, x := range *h {
-		if !f(x) {
-			(*h)[i] = x
-			i++
+// Swap swaps messages in-flight at index i with the one at index j.
+//
+// This function is part of heap.Interface and must not be called externally.
+func (pq *messageQueue) Swap(i, j int) {
+	pq.mailbox[i], pq.mailbox[j] = pq.mailbox[j], pq.mailbox[i]
+	pq.mailbox[i].index = i
+	pq.mailbox[j].index = j
+}
+
+// Push adds an element to this queue.
+//
+// This function is part of heap.Interface and must not be called externally.
+// See: Insert.
+func (pq *messageQueue) Push(x any) {
+	n := len(pq.mailbox)
+	item := x.(*messageInFlight)
+	item.index = n
+	pq.mailbox = append(pq.mailbox, item)
+}
+
+// Pop removes and returns the highest priority message from the queue.
+//
+// This function is part of heap.Interface and must not be called externally.
+// See: Remove.
+func (pq *messageQueue) Pop() any {
+	old := pq.mailbox
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	pq.mailbox = old[0 : n-1]
+	return item
+}
+
+// Insert adds a messageInFlight to the queue.
+func (pq *messageQueue) Insert(x *messageInFlight) {
+	heap.Push(pq, x)
+}
+
+// Remove removes and returns the earliest messageInFlight from the queue.
+func (pq *messageQueue) Remove() *messageInFlight {
+	if pq.Len() > 0 {
+		return heap.Pop(pq).(*messageInFlight)
+	}
+	return nil
+}
+
+// UpsertFirstWhere finds the first message that matches the given criteria, and
+// if found updates its content to the upsert message. Otherwise, inserts the
+// message to the queue.
+func (pq *messageQueue) UpsertFirstWhere(match func(*messageInFlight) bool, upsert *messageInFlight) {
+	for _, msg := range pq.mailbox {
+		if match(msg) {
+			msg.source = upsert.source
+			msg.dest = upsert.dest
+			msg.deliverAt = upsert.deliverAt
+			msg.payload = upsert.payload
+			heap.Fix(pq, msg.index)
+			return
 		}
 	}
-	*h = (*h)[:i]
+	pq.Insert(upsert)
 }

--- a/sim/options.go
+++ b/sim/options.go
@@ -40,7 +40,8 @@ type options struct {
 	// Duration of simEC epochs.
 	ecEpochDuration time.Duration
 	// Time to wait after EC epoch before starting next instance.
-	ecStabilisationDelay time.Duration
+	ecStabilisationDelay    time.Duration
+	globalStabilizationTime time.Duration
 	// If nil then FakeSigningBackend is used unless overridden by F3_TEST_USE_BLS
 	signingBacked      signing.Backend
 	gpbftOptions       []gpbft.Option
@@ -169,6 +170,13 @@ func WithECStabilisationDelay(d time.Duration) Option {
 func WithTraceLevel(i int) Option {
 	return func(o *options) error {
 		o.traceLevel = i
+		return nil
+	}
+}
+
+func WithGlobalStabilizationTime(d time.Duration) Option {
+	return func(o *options) error {
+		o.globalStabilizationTime = d
 		return nil
 	}
 }

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -13,39 +14,65 @@ import (
 )
 
 func TestWitholdCommit1(t *testing.T) {
-	nearSynchrony, err := latency.NewLogNormal(1413, 10*time.Millisecond)
-	require.NoError(t, err)
-	tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
-	baseChain := generateECChain(t, tsg)
-	a := baseChain.Extend(tsg.Sample())
-	b := baseChain.Extend(tsg.Sample())
-	victims := []gpbft.ActorID{0, 1, 2, 3}
-	sm, err := sim.NewSimulation(
-		sim.WithLatencyModel(nearSynchrony),
-		sim.WithECEpochDuration(EcEpochDuration),
-		sim.WitECStabilisationDelay(EcStabilisationDelay),
-		sim.WithGpbftOptions(testGpbftOptions...),
-		sim.WithBaseChain(&baseChain),
-		// Adversary has 30% of 10 total power.
-		// Of 7 nodes, 4 victims will prefer chain A, 3 others will prefer chain B.
-		// The adversary will target the first to decide, and withhold COMMIT from the rest.
-		// After the victim decides in round 0, the adversary stops participating.
-		// Now there are 3 nodes on each side (and one decided), with total power 6/10, less than quorum.
-		// The B side must be swayed to the A side by observing that some nodes on the A side reached a COMMIT.
-		sim.WithAdversary(adversary.NewWitholdCommitGenerator(gpbft.NewStoragePower(3), victims, a)),
-		sim.AddHonestParticipants(4, sim.NewFixedECChainGenerator(a), uniformOneStoragePower),
-		sim.AddHonestParticipants(3, sim.NewFixedECChainGenerator(b), uniformOneStoragePower),
-	)
-	require.NoError(t, err)
-
-	err = sm.Run(1, maxRounds)
-	if err != nil {
-		fmt.Printf("%s", sm.Describe())
-		sm.GetInstance(0).Print()
+	tests := []struct {
+		name string
+		gst  time.Duration
+	}{
+		{
+			name: "immediately stable",
+		},
+		{
+			name: "global stabilisation after ec stabilisation",
+			gst:  EcStabilisationDelay,
+		},
+		{
+			name: "global stabilisation after 1 epoch",
+			gst:  EcEpochDuration,
+		},
+		{
+			name: "never stable",
+			gst:  math.MaxInt16 * time.Hour,
+		},
 	}
-	// The adversary could convince the victim to decide a, so all must decide a.
-	require.NoError(t, err)
-	decision := sm.GetInstance(0).GetDecision(0)
-	require.NotNil(t, decision)
-	require.Equal(t, &a, decision)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			nearSynchrony, err := latency.NewLogNormal(1413, 10*time.Millisecond)
+			require.NoError(t, err)
+			tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
+			baseChain := generateECChain(t, tsg)
+			a := baseChain.Extend(tsg.Sample())
+			b := baseChain.Extend(tsg.Sample())
+			victims := []gpbft.ActorID{0, 1, 2, 3}
+			sm, err := sim.NewSimulation(
+				sim.WithLatencyModel(nearSynchrony),
+				sim.WithECEpochDuration(EcEpochDuration),
+				sim.WitECStabilisationDelay(EcStabilisationDelay),
+				sim.WithGpbftOptions(testGpbftOptions...),
+				sim.WithBaseChain(&baseChain),
+				sim.AddHonestParticipants(4, sim.NewFixedECChainGenerator(a), uniformOneStoragePower),
+				sim.AddHonestParticipants(3, sim.NewFixedECChainGenerator(b), uniformOneStoragePower),
+				sim.WithGlobalStabilizationTime(test.gst),
+				// Adversary has 30% of 10 total power.
+				// Of 7 nodes, 4 victims will prefer chain A, 3 others will prefer chain B.
+				// The adversary will target the first to decide, and withhold COMMIT from the rest.
+				// After the victim decides in round 0, the adversary stops participating.
+				// Now there are 3 nodes on each side (and one decided), with total power 6/10, less than quorum.
+				// The B side must be swayed to the A side by observing that some nodes on the A side reached a COMMIT.
+				sim.WithAdversary(adversary.NewWitholdCommitGenerator(gpbft.NewStoragePower(3), victims, a)),
+			)
+			require.NoError(t, err)
+
+			err = sm.Run(1, maxRounds)
+			if err != nil {
+				fmt.Printf("%s", sm.Describe())
+				sm.GetInstance(0).Print()
+			}
+			// The adversary could convince the victim to decide a, so all must decide a.
+			require.NoError(t, err)
+			decision := sm.GetInstance(0).GetDecision(0)
+			require.NotNil(t, decision)
+			require.Equal(t, &a, decision)
+		})
+	}
 }


### PR DESCRIPTION
Use `heap.Interface` to simplify the implementation of message passing during simulation by implementing a priority queue. The messages in-flight are priorities in ascending order of their `deliverAt` time, i.e. messages with earlier delivery time have higher priority.

Additionally, explicitly introduce an option to set Global Stabilization Time (GST). GST duration is one of the fundamental assumptions made by gPBFT, beyond which message delivery is assumed to be guaranteed. Enhance Withold adversary tests with varying GST time.

Relates to #196