### PR TITLE
Adjust latency model to always return zero for local messages

### DIFF
--- a/sim/latency/log_normal.go
+++ b/sim/latency/log_normal.go
@@ -32,7 +32,12 @@ func NewLogNormal(seed int64, mean time.Duration) (*LogNormal, error) {
 // with the configured mean. The samples returned disregard time and
 // participants, i.e. all the samples returned correspond to a fixed log normal
 // distribution.
-func (l *LogNormal) Sample(time.Time, gpbft.ActorID, gpbft.ActorID) time.Duration {
+//
+// Note, here from and to are the same the latency sample will always be zero.
+func (l *LogNormal) Sample(_ time.Time, from gpbft.ActorID, to gpbft.ActorID) time.Duration {
+	if from == to {
+		return 0
+	}
 	norm := l.rng.NormFloat64()
 	lognorm := math.Exp(norm)
 	return time.Duration(lognorm * float64(l.mean))

--- a/sim/latency/zipf.go
+++ b/sim/latency/zipf.go
@@ -34,6 +34,11 @@ func NewZipf(seed int64, s, v float64, max time.Duration) (*Zipf, error) {
 // Sample returns latency samples that correspond to this ZipF numerical
 // distribution. The samples returned disregard time and participants, i.e. the
 // distribution does not vary over time nor for specific participants.
-func (l *Zipf) Sample(time.Time, gpbft.ActorID, gpbft.ActorID) time.Duration {
+//
+// Note, here from and to are the same the latency sample will always be zero.
+func (l *Zipf) Sample(_ time.Time, from gpbft.ActorID, to gpbft.ActorID) time.Duration {
+	if from == to {
+		return 0
+	}
 	return time.Duration(l.dist.Uint64())
 }


### PR DESCRIPTION
When the sender and receiver of a message is the same, always return zero as the latency sample.

Relates to #196