### PR TITLE
Set default simulation latency to `None`

### DIFF
--- a/sim/options.go
+++ b/sim/options.go
@@ -16,9 +16,8 @@ const (
 )
 
 var (
-	defaultBaseChain    gpbft.ECChain
-	defaultBeacon       = []byte("beacon")
-	defaultLatencyModel latency.Model
+	defaultBaseChain gpbft.ECChain
+	defaultBeacon    = []byte("beacon")
 )
 
 func init() {
@@ -26,10 +25,6 @@ func init() {
 	defaultBaseChain, err = gpbft.NewChain([]byte(("genesis")))
 	if err != nil {
 		panic("failed to instantiate default simulation base chain")
-	}
-	defaultLatencyModel, err = latency.NewLogNormal(time.Now().UnixMilli(), time.Second*5)
-	if err != nil {
-		panic("failed to instantiate default simulation latency model")
 	}
 }
 
@@ -69,7 +64,7 @@ func newOptions(o ...Option) (*options, error) {
 		opts.honestCount = defaultHonestCount
 	}
 	if opts.latencyModel == nil {
-		opts.latencyModel = defaultLatencyModel
+		opts.latencyModel = latency.None
 	}
 	if opts.signingBacked == nil {
 		opts.signingBacked = signing.NewFakeBackend()

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -122,7 +122,7 @@ func (s *Simulation) Run(instanceCount uint64, maxRounds uint64) error {
 		if s.decisions.err != nil {
 			return fmt.Errorf("error in decision: %w", s.decisions.err)
 		}
-		if s.participants[0].CurrentRound() >= maxRounds {
+		if s.getMaxRound() > maxRounds {
 			return fmt.Errorf("reached maximum number of %d rounds", maxRounds)
 		}
 		// Verify the current instance as soon as it completes.
@@ -180,4 +180,15 @@ func (s *Simulation) GetInstance(i int) *ECInstance {
 		return nil
 	}
 	return s.ec.Instances[i]
+}
+
+func (s *Simulation) getMaxRound() uint64 {
+	var maxRound uint64
+	for _, participant := range s.participants {
+		currentRound := participant.CurrentRound()
+		if currentRound > maxRound {
+			maxRound = currentRound
+		}
+	}
+	return maxRound
 }


### PR DESCRIPTION
Set the default simulation latency to `None` when unset to avoid surprising the user. The default was arbitrarily chosen from the simulation CLI and has no significance.

Change the way max round is calculated, where all participants are checked. Fail if simulation go beyond max.

Relates to #196