### PR TITLE
Consistently model P2P latency to reduce max rounds in tests

### DIFF
--- a/sim/latency/log_normal.go
+++ b/sim/latency/log_normal.go
@@ -15,8 +15,9 @@ var _ Model = (*LogNormal)(nil)
 // mean latency. This latency model does not specialise based on host clock time
 // nor participants.
 type LogNormal struct {
-	rng  *rand.Rand
-	mean time.Duration
+	rng           *rand.Rand
+	mean          time.Duration
+	latencyFromTo map[gpbft.ActorID]map[gpbft.ActorID]time.Duration
 }
 
 // NewLogNormal instantiates a new latency model of log normal latency
@@ -25,19 +26,38 @@ func NewLogNormal(seed int64, mean time.Duration) (*LogNormal, error) {
 	if mean < 0 {
 		return nil, errors.New("mean duration cannot be negative")
 	}
-	return &LogNormal{rng: rand.New(rand.NewSource(seed)), mean: mean}, nil
+	return &LogNormal{
+		rng:           rand.New(rand.NewSource(seed)),
+		mean:          mean,
+		latencyFromTo: make(map[gpbft.ActorID]map[gpbft.ActorID]time.Duration),
+	}, nil
 }
 
 // Sample returns latency samples that correspond to the log normal distribution
 // with the configured mean. The samples returned disregard time and
 // participants, i.e. all the samples returned correspond to a fixed log normal
-// distribution.
+// distribution. Latency from one participant to another may be asymmetric and
+// once generated remains constant for the lifetime of a simulation.
 //
 // Note, here from and to are the same the latency sample will always be zero.
 func (l *LogNormal) Sample(_ time.Time, from gpbft.ActorID, to gpbft.ActorID) time.Duration {
 	if from == to {
 		return 0
 	}
+	latencyFrom, latencyFromFound := l.latencyFromTo[from]
+	if !latencyFromFound {
+		latencyFrom = make(map[gpbft.ActorID]time.Duration)
+		l.latencyFromTo[from] = latencyFrom
+	}
+	latencyTo, latencyToFound := latencyFrom[to]
+	if !latencyToFound {
+		latencyTo = l.generate()
+		latencyFrom[to] = latencyTo
+	}
+	return latencyTo
+}
+
+func (l *LogNormal) generate() time.Duration {
 	norm := l.rng.NormFloat64()
 	lognorm := math.Exp(norm)
 	return time.Duration(lognorm * float64(l.mean))

--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -15,7 +15,7 @@ const (
 	tipSetGeneratorSeed = 0x264803e715714f95
 
 	latencyAsync         = 100 * time.Millisecond
-	maxRounds            = 30
+	maxRounds            = 10
 	asyncIterations      = 5000
 	EcEpochDuration      = 30 * time.Second
 	EcStabilisationDelay = 3 * time.Second


### PR DESCRIPTION
The latency model in simulations is generated using a Log Normal distribution with some configured mean. The latency generation occurs every time a message is sent from any one participant to another participant. This effectively simulates an adhoc network with volatile latency which is typically observed in mobile networks.

Compared to Filecoin network, this approach is unrealistic and too volatile. Because, in Filecoin SPs are typically well-connected servers with high bandwidth low latency connection to their peers. As a result, tests regularly exceed the maximum number of rounds where, so far, they require at least 21 rounds to succeed.

A more realistic latency model is one that uses some randomly generated but fixed point-to-point latency that remains constant or varies very slightly over the lifetime of a participant. The changes here introduce consistent P2P modeling of latency for Log Normal latency model, where the latency from one participant to another is generated once and remains constant for the lifetime of a simulation. The latency model uses an asymmetric model, where latency from one node to another is not necessarily the same other way around.

This change reduces the maximum number of rounds required for tests from 30 to 10.

Fixes #196