### PR TITLE
Truncate ECChain capacity when taking a prefix

### DIFF
--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -79,7 +79,7 @@ func (c ECChain) Extend(tip TipSet) ECChain {
 // Prefix(0) returns the base chain.
 // Invalid for a zero value.
 func (c ECChain) Prefix(to int) ECChain {
-	return c[:to+1]
+	return c[: to+1 : to+1]
 }
 
 // Compares two ECChains for equality.

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -118,4 +118,12 @@ func TestECChain(t *testing.T) {
 		subject := gpbft.ECChain{zeroTipSet, []byte{1}}
 		require.Error(t, subject.Validate())
 	})
+
+	t.Run("truncate and extend don't mutate", func(t *testing.T) {
+		subject := gpbft.ECChain{[]byte{0}, []byte{1}}
+		dup := append(gpbft.ECChain{}, subject...)
+		after := subject.Prefix(0).Extend([]byte{2})
+		require.True(t, subject.Eq(dup))
+		require.True(t, after.Eq(gpbft.ECChain{[]byte{0}, []byte{2}}))
+	})
 }


### PR DESCRIPTION
We don't need to be thread-safe, but the `chain.Prefix(n).Extend(tip)` would previously have overwritten `chain`. I don't think this is an issue (we only use `Extend` in tests?) but we might as well fix it.