### PR TITLE
Truncate ECChain capacity when extending/truncating

### DIFF
--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -72,14 +72,14 @@ func (c ECChain) BaseChain() ECChain {
 }
 
 func (c ECChain) Extend(tip ...TipSet) ECChain {
-	return append(c, tip...)
+	return append(c[:len(c):len(c)], tip...)
 }
 
 // Returns a chain with suffix (after the base) truncated to a maximum length.
 // Prefix(0) returns the base chain.
 // Invalid for a zero value.
 func (c ECChain) Prefix(to int) ECChain {
-	return c[:to+1]
+	return c[: to+1 : to+1]
 }
 
 // Compares two ECChains for equality.

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -118,4 +118,22 @@ func TestECChain(t *testing.T) {
 		subject := gpbft.ECChain{zeroTipSet, []byte{1}}
 		require.Error(t, subject.Validate())
 	})
+
+	t.Run("prefix and extend don't mutate", func(t *testing.T) {
+		subject := gpbft.ECChain{[]byte{0}, []byte{1}}
+		dup := append(gpbft.ECChain{}, subject...)
+		after := subject.Prefix(0).Extend([]byte{2})
+		require.True(t, subject.Eq(dup))
+		require.True(t, after.Eq(gpbft.ECChain{[]byte{0}, []byte{2}}))
+	})
+
+	t.Run("extending multiple times doesn't clobber", func(t *testing.T) {
+		// simulate over-allocation
+		initial := gpbft.ECChain{[]byte{0}, []byte{0}}[:1]
+
+		first := initial.Extend([]byte{1})
+		second := initial.Extend([]byte{2})
+		require.Equal(t, first[1], []byte{1})
+		require.Equal(t, second[1], []byte{2})
+	})
 }


### PR DESCRIPTION
Truncate the capacity when truncating and extending the chain. That way:

1. Prefixing then extending won't mutate the original chain.
2. Extending the same base chain with one tipset then another won't clobber the first by re-using the capacity from the original slice.

This isn't great for performance, but:

1. `Extend` is only used for testing.
2. Truncating the capacity in `Prefix` has no performance cost unless we decide to append to the chain later.