### PR TITLE
Report code coverage via Continuous Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,15 @@ jobs:
           # Override test repetition parallelism, since the default runner seem to have a single core.
           # This shaves ~30 seconds off the CI test duration. 
           F3_TEST_REPETITION_PARALLELISM: 2
-        run: make test
+        run: make test/cover
+      - name: Upload coverage to Codecov
+        # Commit SHA corresponds to version v4.4.0
+        # See: https://github.com/codecov/codecov-action/releases/tag/v4.4.0
+        uses: codecov/codecov-action@6d798873df2b1b8e5846dba6fb86631229fbcb17
+        with:
+          files: coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   generate:
     name: Generate

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # IDE project files
 .idea/
+
+# Test coverage output; see `test` target in Makefile.
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,13 @@ all: generate test lint
 
 test: GOGC ?= 1000 # Reduce the GC frequency, default to 1000 if unset.
 test:
-	GOGC=$(GOGC) go test ./...
+	GOGC=$(GOGC) go test $(GOTEST_ARGS) ./...
 .PHONY: test
+
+test/cover: test
+test/cover: GOTEST_ARGS=-coverprofile=coverage.txt -covermode=atomic
+.PHONY: test/cover
+
 
 lint:
 	golangci-lint run ./...


### PR DESCRIPTION
Change `make test` target to measure code coverage in atomic mode, and extend CI test workflow to upload the reports to Codecov.