### PR TITLE
Change host API to separate fetching chain from fetching power tables

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -23,15 +23,17 @@ type Receiver interface {
 }
 
 type Chain interface {
-	// Returns inputs to the next GPBFT instance.
-	// These are:
-	// - the EC chain to propose,
-	// - the power table specifying the participants,
-	// - the beacon value for generating tickets.
-	// These will be used as input to a subsequent instance of the protocol.
-	// The chain should be a suffix of the last chain notified to the host via
-	// ReceiveDecision (or known to be final via some other channel).
-	GetCanonicalChain() (chain ECChain, power PowerTable, beacon []byte)
+	// Returns the chain to propose for a new GPBFT instance.
+	// This should be a suffix of the chain finalised by the immediately prior instance.
+	// Returns an error if the chain for the instance is not available.
+	GetChainForInstance(instance uint64) (chain ECChain, err error)
+
+	// Returns the power table and beacon value to be used for a GPBFT instance.
+	// These values should be derived from a chain previously received as final by the host,
+	// or known to be final via some other channel (e.g. when bootstrapping the protocol).
+	// The offset (how many instances to look back) is determined by the host.
+	// Returns an error if the committee for the instance is not available.
+	GetCommitteeForInstance(instance uint64) (power *PowerTable, beacon []byte, err error)
 }
 
 // Endpoint to which participants can send messages.

--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -113,68 +113,127 @@ func (_c *MockHost_Broadcast_Call) RunAndReturn(run func(*GMessage)) *MockHost_B
 	return _c
 }
 
-// GetCanonicalChain provides a mock function with given fields:
-func (_m *MockHost) GetCanonicalChain() (ECChain, PowerTable, []byte) {
-	ret := _m.Called()
+// GetChainForInstance provides a mock function with given fields: instance
+func (_m *MockHost) GetChainForInstance(instance uint64) (ECChain, error) {
+	ret := _m.Called(instance)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetCanonicalChain")
+		panic("no return value specified for GetChainForInstance")
 	}
 
 	var r0 ECChain
-	var r1 PowerTable
-	var r2 []byte
-	if rf, ok := ret.Get(0).(func() (ECChain, PowerTable, []byte)); ok {
-		return rf()
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint64) (ECChain, error)); ok {
+		return rf(instance)
 	}
-	if rf, ok := ret.Get(0).(func() ECChain); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(uint64) ECChain); ok {
+		r0 = rf(instance)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ECChain)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() PowerTable); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(uint64) error); ok {
+		r1 = rf(instance)
 	} else {
-		r1 = ret.Get(1).(PowerTable)
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func() []byte); ok {
-		r2 = rf()
+	return r0, r1
+}
+
+// MockHost_GetChainForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetChainForInstance'
+type MockHost_GetChainForInstance_Call struct {
+	*mock.Call
+}
+
+// GetChainForInstance is a helper method to define mock.On call
+//   - instance uint64
+func (_e *MockHost_Expecter) GetChainForInstance(instance interface{}) *MockHost_GetChainForInstance_Call {
+	return &MockHost_GetChainForInstance_Call{Call: _e.mock.On("GetChainForInstance", instance)}
+}
+
+func (_c *MockHost_GetChainForInstance_Call) Run(run func(instance uint64)) *MockHost_GetChainForInstance_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint64))
+	})
+	return _c
+}
+
+func (_c *MockHost_GetChainForInstance_Call) Return(chain ECChain, err error) *MockHost_GetChainForInstance_Call {
+	_c.Call.Return(chain, err)
+	return _c
+}
+
+func (_c *MockHost_GetChainForInstance_Call) RunAndReturn(run func(uint64) (ECChain, error)) *MockHost_GetChainForInstance_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetCommitteeForInstance provides a mock function with given fields: instance
+func (_m *MockHost) GetCommitteeForInstance(instance uint64) (*PowerTable, []byte, error) {
+	ret := _m.Called(instance)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCommitteeForInstance")
+	}
+
+	var r0 *PowerTable
+	var r1 []byte
+	var r2 error
+	if rf, ok := ret.Get(0).(func(uint64) (*PowerTable, []byte, error)); ok {
+		return rf(instance)
+	}
+	if rf, ok := ret.Get(0).(func(uint64) *PowerTable); ok {
+		r0 = rf(instance)
 	} else {
-		if ret.Get(2) != nil {
-			r2 = ret.Get(2).([]byte)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*PowerTable)
 		}
+	}
+
+	if rf, ok := ret.Get(1).(func(uint64) []byte); ok {
+		r1 = rf(instance)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(uint64) error); ok {
+		r2 = rf(instance)
+	} else {
+		r2 = ret.Error(2)
 	}
 
 	return r0, r1, r2
 }
 
-// MockHost_GetCanonicalChain_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCanonicalChain'
-type MockHost_GetCanonicalChain_Call struct {
+// MockHost_GetCommitteeForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCommitteeForInstance'
+type MockHost_GetCommitteeForInstance_Call struct {
 	*mock.Call
 }
 
-// GetCanonicalChain is a helper method to define mock.On call
-func (_e *MockHost_Expecter) GetCanonicalChain() *MockHost_GetCanonicalChain_Call {
-	return &MockHost_GetCanonicalChain_Call{Call: _e.mock.On("GetCanonicalChain")}
+// GetCommitteeForInstance is a helper method to define mock.On call
+//   - instance uint64
+func (_e *MockHost_Expecter) GetCommitteeForInstance(instance interface{}) *MockHost_GetCommitteeForInstance_Call {
+	return &MockHost_GetCommitteeForInstance_Call{Call: _e.mock.On("GetCommitteeForInstance", instance)}
 }
 
-func (_c *MockHost_GetCanonicalChain_Call) Run(run func()) *MockHost_GetCanonicalChain_Call {
+func (_c *MockHost_GetCommitteeForInstance_Call) Run(run func(instance uint64)) *MockHost_GetCommitteeForInstance_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(uint64))
 	})
 	return _c
 }
 
-func (_c *MockHost_GetCanonicalChain_Call) Return(chain ECChain, power PowerTable, beacon []byte) *MockHost_GetCanonicalChain_Call {
-	_c.Call.Return(chain, power, beacon)
+func (_c *MockHost_GetCommitteeForInstance_Call) Return(power *PowerTable, beacon []byte, err error) *MockHost_GetCommitteeForInstance_Call {
+	_c.Call.Return(power, beacon, err)
 	return _c
 }
 
-func (_c *MockHost_GetCanonicalChain_Call) RunAndReturn(run func() (ECChain, PowerTable, []byte)) *MockHost_GetCanonicalChain_Call {
+func (_c *MockHost_GetCommitteeForInstance_Call) RunAndReturn(run func(uint64) (*PowerTable, []byte, error)) *MockHost_GetCommitteeForInstance_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -144,7 +144,10 @@ func (p *Participant) ReceiveAlarm() (err error) {
 }
 
 func (p *Participant) beginInstance() error {
-	chain, power, beacon := p.host.GetCanonicalChain()
+	chain, err := p.host.GetChainForInstance(p.nextInstance)
+	if err != nil {
+		return fmt.Errorf("failed fetching chain for instance %d: %w", p.nextInstance, err)
+	}
 	// Limit length of the chain to be proposed.
 	if chain.IsZero() {
 		return errors.New("canonical chain cannot be zero-valued")
@@ -153,11 +156,15 @@ func (p *Participant) beginInstance() error {
 	if err := chain.Validate(); err != nil {
 		return fmt.Errorf("invalid canonical chain: %w", err)
 	}
+
+	power, beacon, err := p.host.GetCommitteeForInstance(p.nextInstance)
+	if err != nil {
+		return fmt.Errorf("failed fetching power table for instance %d: %w", p.nextInstance, err)
+	}
 	if err := power.Validate(); err != nil {
 		return fmt.Errorf("invalid power table: %w", err)
 	}
-	var err error
-	if p.granite, err = newInstance(p, p.nextInstance, chain, power, beacon); err != nil {
+	if p.granite, err = newInstance(p, p.nextInstance, chain, *power, beacon); err != nil {
 		return fmt.Errorf("failed creating new granite instance: %w", err)
 	}
 	p.nextInstance += 1

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -36,7 +36,7 @@ func (i *ImmediateDecide) ID() gpbft.ActorID {
 }
 
 func (i *ImmediateDecide) Start() error {
-	_, powertable, _ := i.host.GetCanonicalChain()
+	powertable, _, _ := i.host.GetCommitteeForInstance(0)
 	// Immediately send a DECIDE message
 	payload := gpbft.Payload{
 		Instance: 0,
@@ -91,7 +91,7 @@ func (i *ImmediateDecide) AllowMessage(_ gpbft.ActorID, _ gpbft.ActorID, _ gpbft
 	return true
 }
 
-func (i *ImmediateDecide) broadcast(payload gpbft.Payload, justification *gpbft.Justification, powertable gpbft.PowerTable) {
+func (i *ImmediateDecide) broadcast(payload gpbft.Payload, justification *gpbft.Justification, powertable *gpbft.PowerTable) {
 
 	pS := i.host.MarshalPayloadForSigning(&payload)
 	_, pubkey := powertable.Get(i.id)

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -76,7 +76,7 @@ func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
 	}
 
 	sigPayload := r.host.MarshalPayloadForSigning(&msg.Vote)
-	_, power, beacon := r.host.GetCanonicalChain()
+	power, beacon, _ := r.host.GetCommitteeForInstance(0)
 	_, pubkey := power.Get(r.id)
 
 	sig, err := r.host.Sign(pubkey, sigPayload)

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -55,7 +55,7 @@ func (w *WithholdCommit) Start() error {
 		return errors.New("victims must be set")
 	}
 
-	_, powertable, _ := w.host.GetCanonicalChain()
+	powertable, _, _ := w.host.GetCommitteeForInstance(0)
 	broadcast := w.broadcastHelper(w.id, powertable)
 	// All victims need to see QUALITY and PREPARE in order to send their COMMIT,
 	// but only the one victim will see our COMMIT.
@@ -165,7 +165,7 @@ func (w *WithholdCommit) sign(pubkey gpbft.PubKey, msg []byte) []byte {
 	return sig
 }
 
-func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID, powertable gpbft.PowerTable) func(gpbft.Payload, *gpbft.Justification) {
+func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID, powertable *gpbft.PowerTable) func(gpbft.Payload, *gpbft.Justification) {
 	return func(payload gpbft.Payload, justification *gpbft.Justification) {
 		pS := w.host.MarshalPayloadForSigning(&payload)
 		_, pubkey := powertable.Get(sender)

--- a/sim/ec.go
+++ b/sim/ec.go
@@ -28,9 +28,9 @@ type ECInstance struct {
 	Instance uint64
 	// The base of all chains, which participants must agree on.
 	BaseChain gpbft.ECChain
-	// The power table at the base chain head.
+	// The power table to be used for this instance.
 	PowerTable *gpbft.PowerTable
-	// The beacon value of the base chain head.
+	// The beacon value to use for this instance.
 	Beacon []byte
 
 	ec        *simEC
@@ -56,7 +56,10 @@ func newEC(opts *options) *simEC {
 	}
 }
 
-func (ec *simEC) BeginInstance(baseChain gpbft.ECChain, pt *gpbft.PowerTable, beacon []byte) *ECInstance {
+func (ec *simEC) BeginInstance(baseChain gpbft.ECChain, pt *gpbft.PowerTable) *ECInstance {
+	// Take beacon value from the head of the base chain.
+	// Note a real beacon value will come from a finalised chain with some lookback.
+	beacon := baseChain.Head().Key
 	instance := &ECInstance{
 		Instance:   uint64(ec.Len()),
 		BaseChain:  baseChain,

--- a/sim/host.go
+++ b/sim/host.go
@@ -1,11 +1,15 @@
 package sim
 
 import (
+	"errors"
 	"time"
 
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/sim/adversary"
 )
+
+// An error to be returned when a chain or committee is not available for an instance.
+var ErrInstanceUnavailable = errors.New("instance not available")
 
 var _ gpbft.Host = (*simHost)(nil)
 var _ adversary.Host = (*simHost)(nil)
@@ -22,12 +26,9 @@ type simHost struct {
 	sim    *Simulation
 	pubkey gpbft.PubKey
 
-	// The simulation package always starts at instance zero.
-	// TODO: https://github.com/filecoin-project/go-f3/issues/195
-	instance uint64
-	ecChain  gpbft.ECChain
-	ecg      ECChainGenerator
-	spg      StoragePowerGenerator
+	ecChain gpbft.ECChain
+	ecg     ECChainGenerator
+	spg     StoragePowerGenerator
 }
 
 func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg StoragePowerGenerator) *simHost {
@@ -45,11 +46,18 @@ func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg Storag
 	}
 }
 
-func (v *simHost) GetCanonicalChain() (gpbft.ECChain, gpbft.PowerTable, []byte) {
-	i := v.sim.ec.GetInstance(v.instance)
+func (v *simHost) GetChainForInstance(instance uint64) (gpbft.ECChain, error) {
 	// Use the head of latest agreement chain as the base of next.
-	chain := v.ecg.GenerateECChain(v.instance, *v.ecChain.Head(), v.id)
-	return chain, *i.PowerTable, i.Beacon
+	chain := v.ecg.GenerateECChain(instance, *v.ecChain.Head(), v.id)
+	return chain, nil
+}
+
+func (v *simHost) GetCommitteeForInstance(instance uint64) (power *gpbft.PowerTable, beacon []byte, err error) {
+	i := v.sim.ec.GetInstance(instance)
+	if i == nil {
+		return nil, nil, ErrInstanceUnavailable
+	}
+	return i.PowerTable, i.Beacon, nil
 }
 
 func (v *simHost) SetAlarm(at time.Time) {
@@ -62,7 +70,6 @@ func (v *simHost) Time() time.Time {
 
 func (v *simHost) ReceiveDecision(decision *gpbft.Justification) time.Time {
 	v.sim.ec.NotifyDecision(v.id, decision)
-	v.instance = decision.Vote.Instance + 1
 	v.ecChain = decision.Vote.Value
 	return v.Time().Add(v.sim.ecEpochDuration).Add(v.sim.ecStabilisationDelay)
 }
@@ -71,15 +78,15 @@ func (v *simHost) BroadcastSynchronous(sender gpbft.ActorID, msg gpbft.GMessage)
 	v.sim.network.BroadcastSynchronous(sender, msg)
 }
 
-func (v *simHost) StoragePower() *gpbft.StoragePower {
-	return v.spg(v.instance, v.id)
+func (v *simHost) StoragePower(instance uint64) *gpbft.StoragePower {
+	return v.spg(instance, v.id)
 }
 
 func (v *simHost) MarshalPayloadForSigning(p *gpbft.Payload) []byte {
 	return v.sim.signingBacked.MarshalPayloadForSigning(v.NetworkName(), p)
 }
 
-func (v *simHost) PublicKey() gpbft.PubKey {
+func (v *simHost) PublicKey( /*instance */ uint64) gpbft.PubKey {
 	return v.pubkey
 }
 

--- a/sim/options.go
+++ b/sim/options.go
@@ -17,7 +17,6 @@ const (
 
 var (
 	defaultBaseChain gpbft.ECChain
-	defaultBeacon    = []byte("beacon")
 )
 
 func init() {
@@ -48,7 +47,6 @@ type options struct {
 	traceLevel         int
 	networkName        gpbft.NetworkName
 	baseChain          *gpbft.ECChain
-	beacon             []byte
 	adversaryGenerator adversary.Generator
 	adversaryCount     uint64
 }
@@ -80,9 +78,6 @@ func newOptions(o ...Option) (*options, error) {
 	}
 	if opts.baseChain == nil {
 		opts.baseChain = &defaultBaseChain
-	}
-	if opts.beacon == nil {
-		opts.beacon = defaultBeacon
 	}
 	return &opts, nil
 }

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -34,11 +34,11 @@ func (s *Simulation) Run(instanceCount uint64, maxRounds uint64) error {
 	if err := s.initParticipants(); err != nil {
 		return err
 	}
-	pt, err := s.getPowerTable()
+	pt, err := s.getPowerTable(0)
 	if err != nil {
 		return err
 	}
-	currentInstance := s.ec.BeginInstance(*s.baseChain, pt, s.beacon)
+	currentInstance := s.ec.BeginInstance(*s.baseChain, pt)
 	s.startParticipants()
 
 	finalInstance := instanceCount - 1
@@ -65,16 +65,14 @@ func (s *Simulation) Run(instanceCount uint64, maxRounds uint64) error {
 				return fmt.Errorf("concensus was not reached at instance %d", currentInstance.Instance)
 			}
 
-			pt, err := s.getPowerTable()
+			pt, err := s.getPowerTable(currentInstance.Instance + 1)
 			if err != nil {
 				return err
 			}
 
 			// Instantiate the next instance even if it goes beyond finalInstance.
 			// The last incomplete instance is used for testing assertions.
-			currentInstance = s.ec.BeginInstance(*decidedChain, pt,
-				[]byte(fmt.Sprintf("beacon %d", currentInstance.Instance+1)),
-			)
+			currentInstance = s.ec.BeginInstance(*decidedChain, pt)
 
 			// Stop after currentInstance is larger than finalInstance, which means we will
 			// instantiate one extra instance that will not complete.
@@ -106,14 +104,15 @@ func (s *Simulation) startParticipants() {
 	}
 }
 
-func (s *Simulation) getPowerTable() (*gpbft.PowerTable, error) {
+// Gets the power table to be used for an instance.
+func (s *Simulation) getPowerTable(instance uint64) (*gpbft.PowerTable, error) {
 	pEntries := make([]gpbft.PowerEntry, 0, len(s.participants))
 	// Set chains for first instance
 	for _, h := range s.hosts {
 		pEntries = append(pEntries, gpbft.PowerEntry{
 			ID:     h.ID(),
-			Power:  h.StoragePower(),
-			PubKey: h.PublicKey(),
+			Power:  h.StoragePower(instance),
+			PubKey: h.PublicKey(instance),
 		})
 	}
 	pt := gpbft.NewPowerTable()


### PR DESCRIPTION
Step 1 of #151. This is in preparation for fetching power tables for validation of messages for future instances.

See discussion in #151 about the interface design. The powertable offset parameter is encapsulated by the host, which can respond to a request for the power table to use for some (possibly-future) instance. This capability isn't used yet.

This change also removes fixed beacons in the sim, which was previously using the same beacon for every instance. Now it's generated (by setting it equal to the base tipset key bytes).
