### PR TITLE
Drop spammable messages beyond max allowed lookahead rounds

### DIFF
--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -288,6 +288,28 @@ func (i *instance) receiveOne(msg *GMessage) error {
 		return nil
 	}
 
+	// Drop message that:
+	//  * belong to future rounds, beyond the configured max lookahead threshold, and
+	//  * carry no justification, i.e. are spammable.
+	//
+	// The only messages that are spammable are COMMIT for bottom. QUALITY and
+	// PREPARE messages may also not carry justification, but they are not
+	// spammable. Because:
+	//  * QUALITY is only valid for round zero.
+	//  * PREPARE must carry justification for non-zero rounds.
+	//
+	// Therefore, we are only left with COMMIT for bottom messages as potentially
+	// spammable for rounds beyond zero.
+	//
+	// To drop such messages, the implementation below defensively uses a stronger
+	// condition of "nil justification with round larger than zero" to determine
+	// whether a message is "spammable".
+	beyondMaxLookaheadRounds := msg.Vote.Round > i.round+i.participant.maxLookaheadRounds
+	spammable := msg.Justification == nil && msg.Vote.Round > 0
+	if beyondMaxLookaheadRounds && spammable {
+		return nil
+	}
+
 	round := i.roundState(msg.Vote.Round)
 	switch msg.Vote.Step {
 	case QUALITY_PHASE:

--- a/gpbft/options.go
+++ b/gpbft/options.go
@@ -16,9 +16,12 @@ type Option func(*options) error
 type options struct {
 	delta                time.Duration
 	deltaBackOffExponent float64
+
+	initialInstance    uint64
+	maxLookaheadRounds uint64
+
 	// tracer traces logic logs for debugging and simulation purposes.
-	tracer          Tracer
-	initialInstance uint64
+	tracer Tracer
 }
 
 func newOptions(o ...Option) (*options, error) {
@@ -79,6 +82,18 @@ func WithInitialInstance(i uint64) Option {
 func WithTracer(t Tracer) Option {
 	return func(o *options) error {
 		o.tracer = t
+		return nil
+	}
+}
+
+// WithMaxLookaheadRounds sets the maximum number of rounds ahead of the current
+// round for which messages without justification are buffered. Setting a max
+// value of larger than zero would aid gPBFT to potentially reach consensus in
+// fewer rounds during periods of asynchronous broadcast as well as re-broadcast.
+// Defaults to zero if unset.
+func WithMaxLookaheadRounds(r uint64) Option {
+	return func(o *options) error {
+		o.maxLookaheadRounds = r
 		return nil
 	}
 }

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -1,0 +1,85 @@
+package adversary
+
+import (
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+var _ Receiver = (*Spam)(nil)
+
+// Spam is an adversary that propagates COMMIT messages for bottom for a
+// configured number of future rounds.
+type Spam struct {
+	id                     gpbft.ActorID
+	host                   Host
+	roundsAhead            uint64
+	latestObservedInstance uint64
+}
+
+// NewSpam instantiates a new Spam adversary that spams the network with
+// spammable messages (i.e. COMMIT for bottom) for the configured number of
+// roundsAhead via either synchronous or regular broadcast. This adversary
+// resigns the spammable messages as its own to mimic messages with valid
+// signature but for future rounds.
+func NewSpam(id gpbft.ActorID, host Host, roundsAhead uint64) *Spam {
+	return &Spam{
+		id:          id,
+		host:        host,
+		roundsAhead: roundsAhead,
+	}
+}
+
+func NewSpamGenerator(power *gpbft.StoragePower, roundsAhead uint64) Generator {
+	return func(id gpbft.ActorID, host Host) *Adversary {
+		return &Adversary{
+			Receiver: NewSpam(id, host, roundsAhead),
+			Power:    power,
+		}
+	}
+}
+
+func (s *Spam) Start() error {
+	// Immediately start spamming the network.
+	s.spamAtInstance(s.latestObservedInstance)
+	return nil
+}
+
+func (s *Spam) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
+	// Watch for increase in instance, and when increased spam again.
+	if msg.Vote.Instance > s.latestObservedInstance {
+		s.spamAtInstance(msg.Vote.Instance)
+		s.latestObservedInstance = msg.Vote.Instance
+	}
+	return true, nil
+}
+
+func (s *Spam) spamAtInstance(instance uint64) {
+	// Spam the network with COMMIT messages by incrementing rounds up to
+	// roundsAhead.
+	for spamRound := uint64(0); spamRound < s.roundsAhead; spamRound++ {
+		spamVote := gpbft.Payload{
+			Instance: instance,
+			Round:    spamRound,
+			Step:     gpbft.COMMIT_PHASE,
+		}
+		sigPayload := s.host.MarshalPayloadForSigning(&spamVote)
+		power, _, err := s.host.GetCommitteeForInstance(instance)
+		if err != nil {
+			panic(err)
+		}
+		_, pubkey := power.Get(s.id)
+		sig, err := s.host.Sign(pubkey, sigPayload)
+		if err != nil {
+			panic(err)
+		}
+		s.host.Broadcast(&gpbft.GMessage{
+			Sender:    s.ID(),
+			Vote:      spamVote,
+			Signature: sig,
+		})
+	}
+}
+
+func (s *Spam) ID() gpbft.ActorID                                              { return s.id }
+func (s *Spam) ValidateMessage(*gpbft.GMessage) (bool, error)                  { return true, nil }
+func (s *Spam) ReceiveAlarm() error                                            { return nil }
+func (s *Spam) AllowMessage(gpbft.ActorID, gpbft.ActorID, gpbft.GMessage) bool { return true }

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -163,8 +163,14 @@ func (s *Simulation) Describe() string {
 	return b.String()
 }
 
+// ListParticipantIDs lists the ID of honest participants in simulation. Note
+// that the adversary ID is not included in the list.
 func (s *Simulation) ListParticipantIDs() []gpbft.ActorID {
-	return s.network.participantIDs
+	pids := make([]gpbft.ActorID, len(s.participants))
+	for i, participant := range s.participants {
+		pids[i] = participant.ID()
+	}
+	return pids
 }
 
 func (s *Simulation) GetInstance(i uint64) *ECInstance {

--- a/test/spam_test.go
+++ b/test/spam_test.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/sim"
+	"github.com/filecoin-project/go-f3/sim/adversary"
+	"github.com/filecoin-project/go-f3/sim/latency"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpamAdversary(t *testing.T) {
+	t.Parallel()
+	const (
+		instanceCount = 2000
+		maxRounds     = 30
+	)
+	honestCounts := []int{3, 4, 5, 6, 7, 8, 9}
+	tests := []struct {
+		name               string
+		maxLookaheadRounds uint64
+		spamAheadRounds    uint64
+	}{
+		{
+			name:            "zero lookahead 10x spam",
+			spamAheadRounds: 10,
+		},
+		{
+			name:               "10 lookahead 3x spam",
+			maxLookaheadRounds: 10,
+			spamAheadRounds:    30,
+		},
+	}
+	for _, test := range tests {
+		for _, hc := range honestCounts {
+			test := test
+			hc := hc
+			lessThanOneThirdAdversaryStoragePower := gpbft.NewStoragePower(int64(max(hc/3-1, 1)))
+			name := fmt.Sprintf("%s honest count %d", test.name, hc)
+			t.Run(name, func(t *testing.T) {
+				ecChainGenerator := sim.NewUniformECChainGenerator(651651, 1, 10)
+				sm, err := sim.NewSimulation(
+					sim.WithLatencyModel(latency.NewLogNormal(455454, time.Second)),
+					sim.WithECEpochDuration(EcEpochDuration),
+					sim.WitECStabilisationDelay(EcStabilisationDelay),
+					sim.WithGpbftOptions(testGpbftOptions...),
+					sim.AddHonestParticipants(hc, ecChainGenerator, uniformOneStoragePower),
+					sim.WithGpbftOptions(gpbft.WithMaxLookaheadRounds(test.maxLookaheadRounds)),
+					sim.WithAdversary(adversary.NewSpamGenerator(lessThanOneThirdAdversaryStoragePower, test.spamAheadRounds)),
+				)
+				require.NoError(t, err)
+				require.NoErrorf(t, sm.Run(instanceCount, maxRounds), "%s", sm.Describe())
+
+				instance := sm.GetInstance(0)
+				require.NotNil(t, instance, "instance 0")
+				latestBaseECChain := instance.BaseChain
+				for i := uint64(0); i < instanceCount; i++ {
+					instance = sm.GetInstance(i + 1)
+					require.NotNil(t, instance, "instance %d", i)
+					wantDecision := ecChainGenerator.GenerateECChain(i, *latestBaseECChain.Head(), math.MaxUint64)
+
+					// Sanity check that the expected decision is progressed from the base chain
+					require.Equal(t, wantDecision.Base(), latestBaseECChain.Head())
+					require.NotEqual(t, wantDecision.Suffix(), latestBaseECChain.Suffix())
+
+					// Assert the consensus is reached at the head of expected chain despite the spam.
+					requireConsensusAtInstance(t, sm, i, wantDecision...)
+					latestBaseECChain = instance.BaseChain
+				}
+
+				// TODO: We have no good way of asserting that the spam is mitigated as DoS
+				//       vector via maxLookaheadRounds. Expand assertions of this test via
+				//       metrics once observability/telemetry is implemented.
+			})
+		}
+	}
+}


### PR DESCRIPTION
The gPBFT rebroadcast design revision introduced an improvement whereby "spammable" messages, i.e. `COMMIT` for bottom, for future rounds should be dropped by the participants. The specification leaves room for implementers to optionally retain some number of such messages to reduce reliance on the need for rebroadcast and ultimately help reach consensus in fewer rounds.

The work here:
1. introduces `WithMaxLookaheadRounds` configuration option to `gpbft` package, defaulting to zero if unset.
2. drops all spammable messages belonging to rounds that are beyond the configured max lookahead rounds.

A `Spam` adversary is introduced to replicate the conditions at which max lookahead rounds would start dropping messages. A set of tests then use the `Spam` adversary to assert that honest participants reach expected consensus despite the presence of spam messages.

Note that there are no APIs to assert that the upper lookahead bound is respected by the implementation. A TODO is left to revisit this once telemetry is introduced whereby tests can observe future message queue size metrics to assert a configured lookahead is indeed respected.

Resolves #240