### PR TITLE
FFF-103: Async delivery of local messages

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -38,9 +38,8 @@ type Chain interface {
 type Network interface {
 	// Returns the network's name (for signature separation)
 	NetworkName() NetworkName
-	// Sends a message to all other participants.
-	// The message's sender must be one that the network interface can sign on behalf of.
-	Broadcast(msg *GMessage)
+	// Requests that the message is signed and broadcasted, it should also be delivered locally
+	RequestBroadcast(msg *GMessage)
 }
 
 type Clock interface {

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -155,8 +155,6 @@ type instance struct {
 	// This field is an alternative to plumbing an optional decision value out through
 	// all the method calls, or holding a callback handle to receive it here.
 	terminationValue *Justification
-	// Queue of messages to be synchronously processed before returning from top-level call.
-	inbox []*GMessage
 	// Quality phase state (only for round 0)
 	quality *quorumState
 	// State for each round of phases.
@@ -212,10 +210,7 @@ func newRoundState(powerTable PowerTable) *roundState {
 }
 
 func (i *instance) Start() error {
-	if err := i.beginQuality(); err != nil {
-		return err
-	}
-	return i.drainInbox()
+	return i.beginQuality()
 }
 
 // Checks whether a message is valid.
@@ -233,45 +228,15 @@ func (i *instance) Receive(msg *GMessage) error {
 	if i.terminated() {
 		return fmt.Errorf("senders message after decision")
 	}
-	if len(i.inbox) > 0 {
-		return fmt.Errorf("senders message while already processing inbox")
-	}
-
-	// Enqueue the message for synchronous processing.
-	i.enqueueInbox(msg)
-	return i.drainInbox()
+	return i.receiveOne(msg)
 }
 
 func (i *instance) ReceiveAlarm() error {
-	if err := i.tryCurrentPhase(); err != nil {
-		return fmt.Errorf("failed completing protocol phase: %w", err)
-	}
-
-	// A phase may have been successfully completed.
-	// Re-process any queued messages for the next phase.
-	return i.drainInbox()
+	return i.tryCurrentPhase()
 }
 
 func (i *instance) Describe() string {
 	return fmt.Sprintf("P%d{%d}, round %d, phase %s", i.participant.id, i.instanceID, i.round, i.phase)
-}
-
-func (i *instance) enqueueInbox(msg *GMessage) {
-	i.inbox = append(i.inbox, msg)
-}
-
-func (i *instance) drainInbox() error {
-	for len(i.inbox) > 0 {
-		// Process one message.
-		// Note the message being processed is left in the inbox until after processing,
-		// as a signal that this loop is currently draining the inbox.
-		if err := i.receiveOne(i.inbox[0]); err != nil {
-			return fmt.Errorf("failed receiving message: %w", err)
-		}
-		i.inbox = i.inbox[1:]
-	}
-
-	return nil
 }
 
 // Processes a single message.

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -816,7 +816,6 @@ func (i *instance) broadcast(round uint64, step Phase, value ECChain, ticket Tic
 		Justification: justification,
 	}
 	i.participant.host.RequestBroadcast(gmsg)
-	i.enqueueInbox(gmsg)
 }
 
 // Sets an alarm to be delivered after a synchrony delay.

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -815,7 +815,7 @@ func (i *instance) broadcast(round uint64, step Phase, value ECChain, ticket Tic
 		Ticket:        ticket,
 		Justification: justification,
 	}
-	i.participant.host.Broadcast(gmsg)
+	i.participant.host.RequestBroadcast(gmsg)
 	i.enqueueInbox(gmsg)
 }
 

--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -80,39 +80,6 @@ func (_c *MockHost_Aggregate_Call) RunAndReturn(run func([]PubKey, [][]byte) ([]
 	return _c
 }
 
-// Broadcast provides a mock function with given fields: msg
-func (_m *MockHost) Broadcast(msg *GMessage) {
-	_m.Called(msg)
-}
-
-// MockHost_Broadcast_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Broadcast'
-type MockHost_Broadcast_Call struct {
-	*mock.Call
-}
-
-// Broadcast is a helper method to define mock.On call
-//   - msg *GMessage
-func (_e *MockHost_Expecter) Broadcast(msg interface{}) *MockHost_Broadcast_Call {
-	return &MockHost_Broadcast_Call{Call: _e.mock.On("Broadcast", msg)}
-}
-
-func (_c *MockHost_Broadcast_Call) Run(run func(msg *GMessage)) *MockHost_Broadcast_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*GMessage))
-	})
-	return _c
-}
-
-func (_c *MockHost_Broadcast_Call) Return() *MockHost_Broadcast_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockHost_Broadcast_Call) RunAndReturn(run func(*GMessage)) *MockHost_Broadcast_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetCanonicalChain provides a mock function with given fields:
 func (_m *MockHost) GetCanonicalChain() (ECChain, PowerTable, []byte) {
 	ret := _m.Called()
@@ -314,6 +281,39 @@ func (_c *MockHost_ReceiveDecision_Call) Return(_a0 time.Time) *MockHost_Receive
 }
 
 func (_c *MockHost_ReceiveDecision_Call) RunAndReturn(run func(*Justification) time.Time) *MockHost_ReceiveDecision_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RequestBroadcast provides a mock function with given fields: msg
+func (_m *MockHost) RequestBroadcast(msg *GMessage) {
+	_m.Called(msg)
+}
+
+// MockHost_RequestBroadcast_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RequestBroadcast'
+type MockHost_RequestBroadcast_Call struct {
+	*mock.Call
+}
+
+// RequestBroadcast is a helper method to define mock.On call
+//   - msg *GMessage
+func (_e *MockHost_Expecter) RequestBroadcast(msg interface{}) *MockHost_RequestBroadcast_Call {
+	return &MockHost_RequestBroadcast_Call{Call: _e.mock.On("RequestBroadcast", msg)}
+}
+
+func (_c *MockHost_RequestBroadcast_Call) Run(run func(msg *GMessage)) *MockHost_RequestBroadcast_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*GMessage))
+	})
+	return _c
+}
+
+func (_c *MockHost_RequestBroadcast_Call) Return() *MockHost_RequestBroadcast_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockHost_RequestBroadcast_Call) RunAndReturn(run func(*GMessage)) *MockHost_RequestBroadcast_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -110,7 +110,7 @@ func (pt *participantTestSubject) expectBeginInstance() {
 		},
 		Signature: wantSignature,
 	}
-	pt.host.EXPECT().Broadcast(wantQualityPhaseBroadcastMessage)
+	pt.host.EXPECT().RequestBroadcast(wantQualityPhaseBroadcastMessage)
 }
 
 func (pt *participantTestSubject) requireNotStarted() {

--- a/sim/adversary/adversary.go
+++ b/sim/adversary/adversary.go
@@ -13,7 +13,8 @@ type Host interface {
 	// Sends a message to all other participants, immediately.
 	// Note that the adversary can subsequently delay delivery to some participants,
 	// before messages are actually received.
-	BroadcastSynchronous(sender gpbft.ActorID, msg gpbft.GMessage)
+	// The sync flag can be used to determine how the message is broadcast.
+	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage, synchronouos bool)
 }
 
 type Generator func(gpbft.ActorID, Host) *Adversary

--- a/sim/adversary/adversary.go
+++ b/sim/adversary/adversary.go
@@ -10,12 +10,10 @@ type Receiver interface {
 // Endpoint with which the adversary can control the network
 type Host interface {
 	gpbft.Host
-	// Sends a message to all other participants
-	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage)
 	// Sends a message to all other participants, immediately.
 	// Note that the adversary can subsequently delay delivery to some participants,
 	// before messages are actually received.
-	BroadcastSynchronous(sender gpbft.ActorID, msg *gpbft.GMessage)
+	BroadcastSynchronous(msg *gpbft.GMessage)
 }
 
 type Generator func(gpbft.ActorID, Host) *Adversary

--- a/sim/adversary/adversary.go
+++ b/sim/adversary/adversary.go
@@ -10,11 +10,12 @@ type Receiver interface {
 // Endpoint with which the adversary can control the network
 type Host interface {
 	gpbft.Host
+	// Sends a message to all other participants
+	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage)
 	// Sends a message to all other participants, immediately.
 	// Note that the adversary can subsequently delay delivery to some participants,
 	// before messages are actually received.
-	// The sync flag can be used to determine how the message is broadcast.
-	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage, synchronouos bool)
+	BroadcastSynchronous(sender gpbft.ActorID, msg *gpbft.GMessage)
 }
 
 type Generator func(gpbft.ActorID, Host) *Adversary

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -100,10 +100,10 @@ func (i *ImmediateDecide) broadcast(payload gpbft.Payload, justification *gpbft.
 		panic(err)
 	}
 
-	i.host.Broadcast(i.id, &gpbft.GMessage{
+	i.host.BroadcastSynchronous(i.id, &gpbft.GMessage{
 		Sender:        i.id,
 		Vote:          payload,
 		Signature:     sig,
 		Justification: justification,
-	}, true)
+	})
 }

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -100,10 +100,10 @@ func (i *ImmediateDecide) broadcast(payload gpbft.Payload, justification *gpbft.
 		panic(err)
 	}
 
-	i.host.BroadcastSynchronous(i.id, gpbft.GMessage{
+	i.host.Broadcast(i.id, &gpbft.GMessage{
 		Sender:        i.id,
 		Vote:          payload,
 		Signature:     sig,
 		Justification: justification,
-	})
+	}, true)
 }

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -100,7 +100,7 @@ func (i *ImmediateDecide) broadcast(payload gpbft.Payload, justification *gpbft.
 		panic(err)
 	}
 
-	i.host.BroadcastSynchronous(i.id, &gpbft.GMessage{
+	i.host.BroadcastSynchronous(&gpbft.GMessage{
 		Sender:        i.id,
 		Vote:          payload,
 		Signature:     sig,

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -100,7 +100,7 @@ func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
 		Ticket:        ticket,
 	}
 	for i := 0; i < echoCount; i++ {
-		r.host.Broadcast(echo.Sender, echo, false)
+		r.host.Broadcast(echo.Sender, echo)
 	}
 	return true, nil
 }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -92,15 +92,17 @@ func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
 			panic(err)
 		}
 	}
-	echo := &gpbft.GMessage{
-		Sender:        r.ID(),
-		Vote:          msg.Vote,
-		Signature:     sig,
-		Justification: msg.Justification,
-		Ticket:        ticket,
-	}
-	for i := 0; i < echoCount; i++ {
-		r.host.RequestBroadcast(echo)
+	if msg.Sender != r.ID() {
+		echo := &gpbft.GMessage{
+			Sender:        r.ID(),
+			Vote:          msg.Vote,
+			Signature:     sig,
+			Justification: msg.Justification,
+			Ticket:        ticket,
+		}
+		for i := 0; i < echoCount; i++ {
+			r.host.RequestBroadcast(echo)
+		}
 	}
 	return true, nil
 }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -24,7 +24,7 @@ var _ Receiver = (*Repeat)(nil)
 // See RepetitionSampler.
 type Repeat struct {
 	id   gpbft.ActorID
-	host gpbft.Host
+	host Host
 
 	// repetitionSampler determines the number of times each message is echoed by this adversary.
 	repetitionSampler RepetitionSampler
@@ -52,7 +52,7 @@ type RepetitionSampler func(*gpbft.GMessage) int
 // signed and optionally includes a new ticket if the original message had one. Note, this adversary does not modify the
 // received messages. Instead, it resigns them as its own and broadcasts them effectively mimicking the behavior of other
 // participants in the network.
-func NewRepeat(id gpbft.ActorID, host gpbft.Host, sampler RepetitionSampler) *Repeat {
+func NewRepeat(id gpbft.ActorID, host Host, sampler RepetitionSampler) *Repeat {
 	return &Repeat{
 		id:                id,
 		host:              host,
@@ -100,7 +100,7 @@ func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
 		Ticket:        ticket,
 	}
 	for i := 0; i < echoCount; i++ {
-		r.host.Broadcast(echo)
+		r.host.Broadcast(echo.Sender, echo, false)
 	}
 	return true, nil
 }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -100,7 +100,7 @@ func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
 		Ticket:        ticket,
 	}
 	for i := 0; i < echoCount; i++ {
-		r.host.Broadcast(echo.Sender, echo)
+		r.host.RequestBroadcast(echo)
 	}
 	return true, nil
 }

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -71,7 +71,7 @@ func (s *Spam) spamAtInstance(instance uint64) {
 		if err != nil {
 			panic(err)
 		}
-		s.host.Broadcast(s.ID(), &gpbft.GMessage{
+		s.host.RequestBroadcast(&gpbft.GMessage{
 			Sender:    s.ID(),
 			Vote:      spamVote,
 			Signature: sig,

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -174,11 +174,11 @@ func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID, powertable gpbft.
 			panic(err)
 		}
 
-		w.host.BroadcastSynchronous(sender, gpbft.GMessage{
+		w.host.Broadcast(sender, &gpbft.GMessage{
 			Sender:        sender,
 			Vote:          payload,
 			Signature:     sig,
 			Justification: justification,
-		})
+		}, true)
 	}
 }

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -174,7 +174,7 @@ func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID, powertable *gpbft
 			panic(err)
 		}
 
-		w.host.BroadcastSynchronous(sender, &gpbft.GMessage{
+		w.host.BroadcastSynchronous(&gpbft.GMessage{
 			Sender:        sender,
 			Vote:          payload,
 			Signature:     sig,

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -174,11 +174,11 @@ func (w *WithholdCommit) broadcastHelper(sender gpbft.ActorID, powertable gpbft.
 			panic(err)
 		}
 
-		w.host.Broadcast(sender, &gpbft.GMessage{
+		w.host.BroadcastSynchronous(sender, &gpbft.GMessage{
 			Sender:        sender,
 			Vote:          payload,
 			Signature:     sig,
 			Justification: justification,
-		}, true)
+		})
 	}
 }

--- a/sim/host.go
+++ b/sim/host.go
@@ -33,7 +33,9 @@ type simHost struct {
 type SimNetwork interface {
 	gpbft.Network
 	// Sends a message to all other participants.
-	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage, synchronouos bool)
+	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage)
+	// sends a message to all other participants immediately.
+	BroadcastSynchronous(sender gpbft.ActorID, msg *gpbft.GMessage)
 }
 
 func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg StoragePowerGenerator) *simHost {

--- a/sim/host.go
+++ b/sim/host.go
@@ -13,7 +13,7 @@ var _ adversary.Host = (*simHost)(nil)
 // One participant's host
 // This provides methods that know the caller's participant ID and can provide its view of the world.
 type simHost struct {
-	gpbft.Network
+	SimNetwork
 	gpbft.Signer
 	gpbft.Verifier
 	gpbft.Clock
@@ -30,18 +30,24 @@ type simHost struct {
 	spg      StoragePowerGenerator
 }
 
+type SimNetwork interface {
+	gpbft.Network
+	// Sends a message to all other participants.
+	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage, synchronouos bool)
+}
+
 func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg StoragePowerGenerator) *simHost {
 	pubKey, _ := sim.signingBacked.GenerateKey()
 	return &simHost{
-		Network:  sim.network,
-		Verifier: sim.signingBacked,
-		Signer:   sim.signingBacked,
-		sim:      sim,
-		id:       id,
-		ecg:      ecg,
-		spg:      spg,
-		pubkey:   pubKey,
-		ecChain:  *sim.baseChain,
+		SimNetwork: sim.network.NetworkFor(sim.signingBacked, id),
+		Verifier:   sim.signingBacked,
+		Signer:     sim.signingBacked,
+		sim:        sim,
+		id:         id,
+		ecg:        ecg,
+		spg:        spg,
+		pubkey:     pubKey,
+		ecChain:    *sim.baseChain,
 	}
 }
 
@@ -65,10 +71,6 @@ func (v *simHost) ReceiveDecision(decision *gpbft.Justification) time.Time {
 	v.instance = decision.Vote.Instance + 1
 	v.ecChain = decision.Vote.Value
 	return v.Time().Add(v.sim.ecEpochDuration).Add(v.sim.ecStabilisationDelay)
-}
-
-func (v *simHost) BroadcastSynchronous(sender gpbft.ActorID, msg gpbft.GMessage) {
-	v.sim.network.BroadcastSynchronous(sender, msg)
 }
 
 func (v *simHost) StoragePower() *gpbft.StoragePower {

--- a/sim/host.go
+++ b/sim/host.go
@@ -33,10 +33,8 @@ type simHost struct {
 
 type SimNetwork interface {
 	gpbft.Network
-	// Sends a message to all other participants.
-	Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage)
 	// sends a message to all other participants immediately.
-	BroadcastSynchronous(sender gpbft.ActorID, msg *gpbft.GMessage)
+	BroadcastSynchronous(msg *gpbft.GMessage)
 }
 
 func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg StoragePowerGenerator) *simHost {

--- a/sim/network.go
+++ b/sim/network.go
@@ -63,26 +63,26 @@ func (n *Network) AddParticipant(p gpbft.Receiver) {
 
 ////// Network interface
 
-func (n *Network) NetworkFor(signer gpbft.Signer, id gpbft.ActorID) *NetworkFor {
-	return &NetworkFor{
+func (n *Network) NetworkFor(signer gpbft.Signer, id gpbft.ActorID) *networkFor {
+	return &networkFor{
 		ParticipantID: id,
 		Signer:        signer,
 		Network:       n,
 	}
 }
 
-type NetworkFor struct {
+type networkFor struct {
 	ParticipantID gpbft.ActorID
 	Signer        gpbft.Signer
 	*Network
 }
 
 // Log implements tagging Tracer interface
-func (nf *NetworkFor) Log(format string, args ...interface{}) {
+func (nf *networkFor) Log(format string, args ...interface{}) {
 	nf.Network.log(TraceLogic, "P%d "+format, append([]any{nf.ParticipantID}, args...)...)
 }
 
-func (nf *NetworkFor) RequestBroadcast(msg *gpbft.GMessage) {
+func (nf *networkFor) RequestBroadcast(msg *gpbft.GMessage) {
 	nf.log(TraceSent, "P%d ↗ %v", msg.Sender, msg)
 	for _, dest := range nf.participantIDs {
 		latencySample := time.Duration(0)

--- a/sim/network.go
+++ b/sim/network.go
@@ -78,7 +78,7 @@ type networkFor struct {
 }
 
 // Log implements tagging Tracer interface
-func (nf *networkFor) Log(format string, args ...interface{}) {
+func (nf *networkFor) Log(format string, args ...any) {
 	nf.Network.log(TraceLogic, "P%d "+format, append([]any{nf.ParticipantID}, args...)...)
 }
 

--- a/sim/network.go
+++ b/sim/network.go
@@ -145,7 +145,7 @@ func (n *Network) SetAlarm(sender gpbft.ActorID, at time.Time) {
 	)
 }
 
-func (n *Network) Log(format string, args ...interface{}) {
+func (n *Network) Log(format string, args ...any) {
 	n.log(TraceLogic, format, args...)
 }
 

--- a/sim/network.go
+++ b/sim/network.go
@@ -104,7 +104,15 @@ func (n *Network) NetworkName() gpbft.NetworkName {
 	return n.networkName
 }
 
-func (n *Network) Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage, synchronous bool) {
+func (n *Network) Broadcast(sender gpbft.ActorID, msg *gpbft.GMessage) {
+	n.broadcast(sender, msg, false)
+}
+
+func (n *Network) BroadcastSynchronous(sender gpbft.ActorID, msg *gpbft.GMessage) {
+	n.broadcast(sender, msg, true)
+}
+
+func (n *Network) broadcast(sender gpbft.ActorID, msg *gpbft.GMessage, synchronous bool) {
 	n.log(TraceSent, "P%d ↗ %v", sender, msg)
 	for _, dest := range n.participantIDs {
 		if dest == sender {


### PR DESCRIPTION
This PR partially addresses #103 and implements and addresses the reviews from #188 related to the broadcast interface and the async delivery of local messages.
- It introduces a `RequestBroadcast` function to the `Network` interface that delivers local messages aynchronously.
- Unifies `Broadcast` and `BroadcastSynchronous`  into a single `Broadcast` function.
- Introduces `SimNetwork` interface as an intermediary step to the removal of IDs from gpbft.Participant (coming next)

### Coming next
Two more PRs extracted from #188 with:
- removal of ID from gpbft.Participant
- addition of the message builder pattern