### PR TITLE
Add the ability to download corpus of fuzz tests failed on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,30 @@ jobs:
         env:
           FUZZTIME: 30s
         run: make fuzz
+      - name: Upload fuzz failure seed corpus as run artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        id: testdata-upload
+        with:
+          name: testdata
+          path: '**/testdata/fuzz'
+      - name: Output message
+        if: failure()
+        shell: bash
+        run: |
+          echo -e 'Fuzz test failed on commit https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}. To troubleshoot locally, use the GitHub CLI to download the seed corpus by running:\n $ gh run download ${ github.run_id } -n testdata\nAlternatively, download from:\n ${{ steps.testdata-upload.outputs.artifact-url }}'
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        if: failure() && github.event_name == 'pull_request'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Fuzz test failed on commit ${{ github.event.pull_request.head.sha }}. To troubleshoot locally, download the seed corpus using [GitHub CLI](https://cli.github.com) by running:\n```shell\ngh run download ${{ github.run_id }} -n testdata\n```\nAleternatively, download directly from [here](${{ steps.testdata-upload.outputs.artifact-url }}).'
+            })
 
   generate:
     name: Generate

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ test/cover: GOTEST_ARGS=-coverprofile=coverage.txt -covermode=atomic -coverpkg=.
 
 fuzz: FUZZTIME ?= 10s # The duration to run fuzz testing, default to 10s if unset.
 fuzz: # List all fuzz tests across the repo, and run them one at a time with the configured fuzztime.
-	@go list ./... | while read -r package; do \
+	@set -e; \
+	go list ./... | while read -r package; do \
 		go test -list '^Fuzz' "$$package" | grep '^Fuzz' | while read -r func; do \
 			echo "Running $$package $$func for $(FUZZTIME)..."; \
 			GOGC=$(GOGC) go test "$$package" -run '^$$' -fuzz="$$func" -fuzztime=$(FUZZTIME) || exit 1; \


### PR DESCRIPTION
Enhance the CI fuzz job to upload failed fuzz test corpus as run artefact.

Change the `fuzz` make target to exit immediately when a fuzz test fails.