### PR TITLE
Add more parallelism to tests in t.Run()

### DIFF
--- a/test/ec_divergence_test.go
+++ b/test/ec_divergence_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestEcDivergence_AbsoluteDivergenceConvergesOnBase(t *testing.T) {
+	t.Parallel()
 	const (
 		instanceCount     = 14
 		divergeAtInstance = 9
@@ -30,6 +31,7 @@ func TestEcDivergence_AbsoluteDivergenceConvergesOnBase(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			seedFuzzer := uint64(985623)
 
 			// uniformECChainGenerator generates different EC chain per instance but the same
@@ -98,6 +100,7 @@ func TestEcDivergence_AbsoluteDivergenceConvergesOnBase(t *testing.T) {
 }
 
 func TestEcDivergence_PartitionedNetworkConvergesOnChainWithMostPower(t *testing.T) {
+	t.Parallel()
 	const (
 		instanceCount       = 23
 		partitionAtInstance = 13
@@ -118,6 +121,7 @@ func TestEcDivergence_PartitionedNetworkConvergesOnChainWithMostPower(t *testing
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			seedFuzzer := uint64(784523)
 
 			chainGeneratorBeforePartition := sim.NewUniformECChainGenerator(17*seedFuzzer, 5, 10)

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -101,7 +101,8 @@ func FuzzHonestMultiInstance_AsyncAgreement(f *testing.F) {
 }
 
 func multiAgreementTest(t *testing.T, seed int, honestCount int, instanceCount uint64, maxRounds uint64, opts ...sim.Option) {
-	t.Parallel()
+	// TODO: t.Parallel() here after https://github.com/filecoin-project/builtin-actors/issues/1541
+	//t.Parallel()
 	rng := rand.New(rand.NewSource(int64(seed)))
 	sm, err := sim.NewSimulation(append(opts,
 		sim.AddHonestParticipants(

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -11,7 +11,8 @@ import (
 
 // TestHonestMultiInstance_Agreement tests for multiple chained instances of the protocol with no adversaries.
 func TestHonestMultiInstance_Agreement(t *testing.T) {
-	t.Parallel()
+	// TODO: t.Parallel() here after https://github.com/filecoin-project/builtin-actors/issues/1541
+	//t.Parallel()
 	const (
 		instanceCount  = 4000
 		testRNGSeed    = 8965130
@@ -62,6 +63,7 @@ func FuzzHonestMultiInstance_AsyncDisagreement(f *testing.F) {
 	)
 	f.Add(981)
 	f.Fuzz(func(t *testing.T, seed int) {
+		t.Parallel()
 		tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
 		baseChain := generateECChain(t, tsg)
 		sm, err := sim.NewSimulation(asyncOptions(seed,
@@ -99,6 +101,7 @@ func FuzzHonestMultiInstance_AsyncAgreement(f *testing.F) {
 }
 
 func multiAgreementTest(t *testing.T, seed int, honestCount int, instanceCount uint64, maxRounds uint64, opts ...sim.Option) {
+	t.Parallel()
 	rng := rand.New(rand.NewSource(int64(seed)))
 	sm, err := sim.NewSimulation(append(opts,
 		sim.AddHonestParticipants(

--- a/test/power_evolution_test.go
+++ b/test/power_evolution_test.go
@@ -32,6 +32,7 @@ func FuzzStoragePower_AsyncIncreaseMidSimulation(f *testing.F) {
 }
 
 func storagePowerIncreaseMidSimulationTest(t *testing.T, seed int, instanceCount uint64, maxRounds uint64, o ...sim.Option) {
+	t.Parallel()
 	const (
 		groupOneStoragePower               = 5
 		groupTwoStoragePowerBeforeIncrease = 2
@@ -119,6 +120,7 @@ func FuzzStoragePower_AsyncDecreaseRevertsToBase(f *testing.F) {
 }
 
 func storagePowerDecreaseRevertsToBaseTest(t *testing.T, seed int, instanceCount uint64, maxRounds uint64, o ...sim.Option) {
+	t.Parallel()
 	rng := rand.New(rand.NewSource(int64(seed)))
 	tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
 	baseChain := generateECChain(t, tsg)


### PR DESCRIPTION
UPDATE: until #262 is fixed and we can enable parallelism in `TestHonestMultiInstance_Agreement`, this only saves 3s.

ORIGINAL:
On my modern MBP with `-parallel=8` this gives an improvement of 54s -> 21s.

A little more is possible, but see #262.