### PR TITLE
Use offset committees to validate and queue/drop messages for future instances

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -1,15 +1,49 @@
 package gpbft
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+// Sentinel errors for the message validation and reception APIs.
+var (
+	ErrValidationTooOld      = errors.New("message is for prior instance")
+	ErrValidationNoCommittee = errors.New("no committee for message instance")
+	ErrValidationInvalid     = errors.New("message invalid")
+	ErrValidationWrongBase   = errors.New("unexpected base chain")
+
+	ErrReceivedWrongInstance    = errors.New("received message for wrong instance")
+	ErrReceivedAfterTermination = errors.New("received message after terminating")
+	ErrReceivedInternalError    = errors.New("error processing message")
+)
+
+type MessageValidator interface {
+	// Validates a Granite message.
+	// An invalid message can never become valid, so may be dropped.
+	// Returns an error, wrapping (use errors.Is()/Unwrap()):
+	// - ErrValidationTooOld if the message is for a prior instance;
+	// - both ErrValidationNoCommittee and an error describing the reason;
+	//   if there is no committee available with with to validate the message;
+	// - both ErrValidationInvalid and a cause if the message is invalid,
+	// Returns a validated message if the message is valid.
+	ValidateMessage(msg *GMessage) (valid ValidatedMessage, err error)
+}
+
+// Opaque type tagging a validated message.
+type ValidatedMessage interface {
+	// Returns the validated message.
+	Message() *GMessage
+}
 
 // Receives a Granite protocol message.
 type MessageReceiver interface {
-	// Validates a message received from another participant, if possible.
-	// Returns whether the message could be validated, and an error if it was invalid.
-	ValidateMessage(msg *GMessage) (bool, error)
-	// Receives a message from another participant.
-	// The `validated` parameter indicates whether the message has already passed validation.
-	ReceiveMessage(msg *GMessage, validated bool) (bool, error)
+	// Receives a validated Granite message from some other participant.
+	// Returns an error, wrapping (use errors.Is()/Unwrap()):
+	// - ErrValidationTooOld if the message is for a prior instance
+	// - ErrValidationWrongBase if the message has an invalid base chain
+	// - ErrReceivedAfterTermination if the message is received after the instance has terminated (a programming error)
+	// - both ErrReceivedInternalError and a cause if there was an internal error processing the message
+	ReceiveMessage(msg ValidatedMessage) error
 	ReceiveAlarm() error
 }
 
@@ -19,6 +53,7 @@ type Receiver interface {
 	// Begins executing the protocol.
 	// The node will request the canonical chain to propose from the host.
 	Start() error
+	MessageValidator
 	MessageReceiver
 }
 

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -214,20 +214,24 @@ func (i *instance) Start() error {
 	return i.beginQuality()
 }
 
-// Checks whether a message is valid.
-// An invalid message can never become valid, so may be dropped.
-// This method is read-only and inspects only immutable state, so should be safe to invoke
-// concurrently.
-func (i *instance) Validate(msg *GMessage) error {
-	return i.validateMessage(msg)
-}
-
-// Receives a validated message.
-// This method will not attempt to validate the message, the caller must ensure the message
-// is valid before calling this method.
+// Receives and processes a message.
+// Returns an error indicating either message invalidation or a programming error.
 func (i *instance) Receive(msg *GMessage) error {
+	// Check the message is for this instance, to guard against programming error.
+	if msg.Vote.Instance != i.instanceID {
+		// Return true here to cause a loud failure at the caller, which should not have
+		// passed this message here.
+		return fmt.Errorf("message for instance %d, expected %d: %w",
+			msg.Vote.Instance, i.instanceID, ErrReceivedWrongInstance)
+	}
+	// Perform validation that could not be done until the instance started.
+	if !(msg.Vote.Value.IsZero() || msg.Vote.Value.HasBase(i.input.Base())) {
+		return fmt.Errorf("message base %s, expected %s: %w",
+			&msg.Vote.Value, i.input.Base(), ErrValidationWrongBase)
+	}
+
 	if i.terminated() {
-		return fmt.Errorf("senders message after decision")
+		return ErrReceivedAfterTermination
 	}
 	return i.receiveOne(msg)
 }
@@ -260,22 +264,8 @@ func (i *instance) receiveOne(msg *GMessage) error {
 	// Drop message that:
 	//  * belong to future rounds, beyond the configured max lookahead threshold, and
 	//  * carry no justification, i.e. are spammable.
-	//
-	// The only messages that are spammable are COMMIT for bottom. QUALITY and
-	// PREPARE messages may also not carry justification, but they are not
-	// spammable. Because:
-	//  * QUALITY is only valid for round zero.
-	//  * PREPARE must carry justification for non-zero rounds.
-	//
-	// Therefore, we are only left with COMMIT for bottom messages as potentially
-	// spammable for rounds beyond zero.
-	//
-	// To drop such messages, the implementation below defensively uses a stronger
-	// condition of "nil justification with round larger than zero" to determine
-	// whether a message is "spammable".
 	beyondMaxLookaheadRounds := msg.Vote.Round > i.round+i.participant.maxLookaheadRounds
-	spammable := msg.Justification == nil && msg.Vote.Round > 0
-	if beyondMaxLookaheadRounds && spammable {
+	if beyondMaxLookaheadRounds && isSpammable(msg) {
 		return nil
 	}
 
@@ -372,25 +362,18 @@ func (i *instance) tryCurrentPhase() error {
 }
 
 // Checks message validity, including justification and signatures.
-func (i *instance) validateMessage(msg *GMessage) error {
-	// Check the message is for this instance.
-	// The caller should ensure this is always the case.
-	if msg.Vote.Instance != i.instanceID {
-		return xerrors.Errorf("message for wrong instance %d, expected %d", msg.Vote.Instance, i.instanceID)
-	}
+// An invalid message can never become valid, so may be dropped.
+// This is a pure function and does not modify its arguments.
+func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMessage) error {
 	// Check sender is eligible.
-	senderPower, senderPubKey := i.powerTable.Get(msg.Sender)
+	senderPower, senderPubKey := powerTable.Get(msg.Sender)
 	if senderPower == nil || senderPower.Sign() == 0 {
-		return xerrors.Errorf("sender with zero power or not in power table")
+		return xerrors.Errorf("sender %d with zero power or not in power table", msg.Sender)
 	}
 
 	// Check that message value is a valid chain.
 	if err := msg.Vote.Value.Validate(); err != nil {
 		return xerrors.Errorf("invalid message vote value chain: %w", err)
-	}
-	// Check the value is acceptable.
-	if !(msg.Vote.Value.IsZero() || msg.Vote.Value.HasBase(i.input.Base())) {
-		return xerrors.Errorf("unexpected base %s", &msg.Vote.Value)
 	}
 
 	// Check phase-specific constraints.
@@ -409,7 +392,7 @@ func (i *instance) validateMessage(msg *GMessage) error {
 		if msg.Vote.Value.IsZero() {
 			return xerrors.Errorf("unexpected zero value for converge phase")
 		}
-		if !VerifyTicket(i.beacon, i.instanceID, msg.Vote.Round, senderPubKey, i.participant.host, msg.Ticket) {
+		if !VerifyTicket(beacon, msg.Vote.Instance, msg.Vote.Round, senderPubKey, host, msg.Ticket) {
 			return xerrors.Errorf("failed to verify ticket from %v", msg.Sender)
 		}
 	case DECIDE_PHASE:
@@ -426,8 +409,8 @@ func (i *instance) validateMessage(msg *GMessage) error {
 	}
 
 	// Check vote signature.
-	sigPayload := i.participant.host.MarshalPayloadForSigning(&msg.Vote)
-	if err := i.participant.host.Verify(senderPubKey, sigPayload, msg.Signature); err != nil {
+	sigPayload := host.MarshalPayloadForSigning(&msg.Vote)
+	if err := host.Verify(senderPubKey, sigPayload, msg.Signature); err != nil {
 		return xerrors.Errorf("invalid signature on %v, %v", msg, err)
 	}
 
@@ -497,22 +480,22 @@ func (i *instance) validateMessage(msg *GMessage) error {
 		justificationPower := NewStoragePower(0)
 		signers := make([]PubKey, 0)
 		if err := msg.Justification.Signers.ForEach(func(bit uint64) error {
-			if int(bit) >= len(i.powerTable.Entries) {
+			if int(bit) >= len(powerTable.Entries) {
 				return fmt.Errorf("invalid signer index: %d", bit)
 			}
-			justificationPower.Add(justificationPower, i.powerTable.Entries[bit].Power)
-			signers = append(signers, i.powerTable.Entries[bit].PubKey)
+			justificationPower.Add(justificationPower, powerTable.Entries[bit].Power)
+			signers = append(signers, powerTable.Entries[bit].PubKey)
 			return nil
 		}); err != nil {
 			return fmt.Errorf("failed to iterate over signers: %w", err)
 		}
 
-		if !hasStrongQuorum(justificationPower, i.powerTable.Total) {
+		if !hasStrongQuorum(justificationPower, powerTable.Total) {
 			return fmt.Errorf("message %v has justification with insufficient power: %v", msg, justificationPower)
 		}
 
-		payload := i.participant.host.MarshalPayloadForSigning(&msg.Justification.Vote)
-		if err := i.participant.host.VerifyAggregate(payload, msg.Justification.Signature, signers); err != nil {
+		payload := host.MarshalPayloadForSigning(&msg.Justification.Vote)
+		if err := host.VerifyAggregate(payload, msg.Justification.Signature, signers); err != nil {
 			return xerrors.Errorf("verification of the aggregate failed: %+v: %w", msg.Justification, err)
 		}
 	} else if msg.Justification != nil {
@@ -1242,6 +1225,22 @@ func (c *convergeState) FindProposalFor(chain ECChain) (ConvergeValue, bool) {
 }
 
 ///// General helpers /////
+
+// The only messages that are spammable are COMMIT for bottom. QUALITY and
+// PREPARE messages may also not carry justification, but they are not
+// spammable. Because:
+//   - QUALITY is only valid for round zero.
+//   - PREPARE must carry justification for non-zero rounds.
+//
+// Therefore, we are only left with COMMIT for bottom messages as potentially
+// spammable for rounds beyond zero.
+//
+// To drop such messages, the implementation below defensively uses a stronger
+// condition of "nil justification with round larger than zero" to determine
+// whether a message is "spammable".
+func isSpammable(msg *GMessage) bool {
+	return msg.Justification == nil && msg.Vote.Round > 0
+}
 
 // Returns the first candidate value that is a prefix of the preferred value, or the base of preferred.
 func findFirstPrefixOf(preferred ECChain, candidates []ECChain) ECChain {

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -3,6 +3,7 @@ package gpbft
 import (
 	"errors"
 	"fmt"
+	"sort"
 )
 
 // An F3 participant runs repeated instances of Granite to finalise longer chains.
@@ -11,14 +12,14 @@ type Participant struct {
 	id   ActorID
 	host Host
 
-	// Instance identifier for the next Granite instance.
-	nextInstance uint64
+	// Instance identifier for the current (or, if none, next to start) GPBFT instance.
+	currentInstance uint64
 	// Current Granite instance.
-	granite *instance
+	gpbft *instance
+	// Cache of committees for the current or future instances.
+	committees map[uint64]*committee
 	// Messages queued for future instances.
-	// Unbounded queues are a denial-of-service risk.
-	// See https://github.com/filecoin-project/go-f3/issues/12
-	mqueue map[uint64][]*GMessage
+	mqueue *messageQueue
 	// The output from the last terminated Granite instance.
 	finalised *Justification
 	// The round number during which the last instance was terminated.
@@ -27,6 +28,16 @@ type Participant struct {
 	// which may not be known to the participant.
 	terminatedDuringRound uint64
 }
+
+type validatedMessage struct {
+	msg *GMessage
+}
+
+func (v *validatedMessage) Message() *GMessage {
+	return v.msg
+}
+
+var _ Receiver = (*Participant)(nil)
 
 type PanicError struct {
 	Err any
@@ -42,11 +53,12 @@ func NewParticipant(id ActorID, host Host, o ...Option) (*Participant, error) {
 		return nil, err
 	}
 	return &Participant{
-		options:      opts,
-		id:           id,
-		host:         host,
-		mqueue:       make(map[uint64][]*GMessage),
-		nextInstance: opts.initialInstance,
+		options:         opts,
+		id:              id,
+		host:            host,
+		committees:      make(map[uint64]*committee),
+		mqueue:          newMessageQueue(opts.maxLookaheadRounds),
+		currentInstance: opts.initialInstance,
 	}, nil
 }
 
@@ -66,63 +78,66 @@ func (p *Participant) Start() (err error) {
 }
 
 func (p *Participant) CurrentRound() uint64 {
-	if p.granite == nil {
+	if p.gpbft == nil {
 		return 0
 	}
-	return p.granite.round
+	return p.gpbft.round
 }
 
-// Validates a message received from another participant, if possible.
-// An invalid message can never become valid, so may be dropped.
-// A message can only be validated if it is for the currently-executing protocol instance.
-// Returns whether the message could be validated, and an error if it was invalid.
-func (p *Participant) ValidateMessage(msg *GMessage) (checked bool, err error) {
+// Validates a message
+func (p *Participant) ValidateMessage(msg *GMessage) (valid ValidatedMessage, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = &PanicError{Err: r}
 		}
 	}()
 
-	if p.granite != nil && msg.Vote.Instance == p.granite.instanceID {
-		return true, p.granite.Validate(msg)
+	// Reject messages for past instances.
+	if msg.Vote.Instance < p.currentInstance {
+		return nil, fmt.Errorf("message %d, current instance %d: %w",
+			msg.Vote.Instance, p.currentInstance, ErrValidationTooOld)
 	}
-	return false, nil
+
+	// Fetch the committee against which to validate the message.
+	comt, err := p.getCommittee(msg.Vote.Instance)
+	if err != nil {
+		return nil, fmt.Errorf("instance %d: %w: %w",
+			msg.Vote.Instance, ErrValidationNoCommittee, err)
+	}
+
+	// Validate the message.
+	if err = ValidateMessage(comt.power, comt.beacon, p.host, msg); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrValidationInvalid, err)
+	}
+	return &validatedMessage{msg: msg}, nil
 }
 
-// Receives a Granite message from some other participant.
-// If the message is for the current instance, it is delivered immediately.
-// If it is for a future instance, it is locally queued, to be delivered when that instance begins.
-// If it is for a previous instance, it is dropped.
-//
-// This method checks message validity only if the validated parameter is false.
-// Validity can only be checked when the messages instance begins.
-// Returns whether the message was for the current instance, and an error if it was invalid or
-// could not be processed.
-func (p *Participant) ReceiveMessage(msg *GMessage, validated bool) (accepted bool, err error) {
+// Receives a validated Granite message from some other participant.
+func (p *Participant) ReceiveMessage(vmsg ValidatedMessage) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = &PanicError{Err: r}
 		}
 	}()
+	msg := vmsg.Message()
 
-	if p.granite != nil && msg.Vote.Instance == p.granite.instanceID {
-		// Validate message for the current instance if it wasn't already.
-		if !validated {
-			if err := p.granite.Validate(msg); err != nil {
-				return true, err
-			}
-		}
-		// Deliver message for the current instance.
-		if err := p.granite.Receive(msg); err != nil {
-			return true, fmt.Errorf("receiving message: %w", err)
-		}
-		return true, p.handleDecision()
-	} else if msg.Vote.Instance >= p.nextInstance {
-		// Locally queue message for a future instance.
-		p.mqueue[msg.Vote.Instance] = append(p.mqueue[msg.Vote.Instance], msg)
+	// Drop messages for past instances.
+	if msg.Vote.Instance < p.currentInstance {
+		return fmt.Errorf("message %d, current instance %d: %w",
+			msg.Vote.Instance, p.currentInstance, ErrValidationTooOld)
 	}
-	// Drop message for a previous instance.
-	return false, nil
+
+	// If the message is for the current instance, deliver immediately.
+	if p.gpbft != nil && msg.Vote.Instance == p.currentInstance {
+		if err := p.gpbft.Receive(msg); err != nil {
+			return fmt.Errorf("%w: %w", ErrReceivedInternalError, err)
+		}
+		p.handleDecision()
+	} else {
+		// Otherwise queue it for a future instance.
+		p.mqueue.Add(msg)
+	}
+	return nil
 }
 
 func (p *Participant) ReceiveAlarm() (err error) {
@@ -132,21 +147,21 @@ func (p *Participant) ReceiveAlarm() (err error) {
 		}
 	}()
 
-	if p.granite == nil {
+	if p.gpbft == nil {
 		// The alarm is for fetching the next chain and beginning a new instance.
 		return p.beginInstance()
-	} else {
-		if err := p.granite.ReceiveAlarm(); err != nil {
-			return fmt.Errorf("failed receiving alarm: %w", err)
-		}
-		return p.handleDecision()
 	}
+	if err := p.gpbft.ReceiveAlarm(); err != nil {
+		return fmt.Errorf("failed receiving alarm: %w", err)
+	}
+	p.handleDecision()
+	return nil
 }
 
 func (p *Participant) beginInstance() error {
-	chain, err := p.host.GetChainForInstance(p.nextInstance)
+	chain, err := p.host.GetChainForInstance(p.currentInstance)
 	if err != nil {
-		return fmt.Errorf("failed fetching chain for instance %d: %w", p.nextInstance, err)
+		return fmt.Errorf("failed fetching chain for instance %d: %w", p.currentInstance, err)
 	}
 	// Limit length of the chain to be proposed.
 	if chain.IsZero() {
@@ -157,57 +172,133 @@ func (p *Participant) beginInstance() error {
 		return fmt.Errorf("invalid canonical chain: %w", err)
 	}
 
-	power, beacon, err := p.host.GetCommitteeForInstance(p.nextInstance)
+	comm, err := p.getCommittee(p.currentInstance)
 	if err != nil {
-		return fmt.Errorf("failed fetching power table for instance %d: %w", p.nextInstance, err)
+		return err
 	}
-	if err := power.Validate(); err != nil {
-		return fmt.Errorf("invalid power table: %w", err)
+	if p.gpbft, err = newInstance(p, p.currentInstance, chain, *comm.power, comm.beacon); err != nil {
+		return fmt.Errorf("failed creating new gpbft instance: %w", err)
 	}
-	if p.granite, err = newInstance(p, p.nextInstance, chain, *power, beacon); err != nil {
-		return fmt.Errorf("failed creating new granite instance: %w", err)
-	}
-	p.nextInstance += 1
-	if err := p.granite.Start(); err != nil {
-		return fmt.Errorf("failed starting granite instance: %w", err)
+	if err := p.gpbft.Start(); err != nil {
+		return fmt.Errorf("failed starting gpbft instance: %w", err)
 	}
 	// Deliver any queued messages for the new instance.
-	for _, msg := range p.mqueue[p.granite.instanceID] {
+	for _, msg := range p.mqueue.Drain(p.gpbft.instanceID) {
 		if p.terminated() {
 			break
 		}
 		if p.tracer != nil {
-			p.tracer.Log("Delivering queued P%d{%d} ← P%d: %v", p.id, p.granite.instanceID, msg.Sender, msg)
+			p.tracer.Log("Delivering queued P%d{%d} ← P%d: %v", p.id, p.gpbft.instanceID, msg.Sender, msg)
 		}
-		if err := p.granite.Receive(msg); err != nil {
-			return fmt.Errorf("delivering queued message: %w", err)
+		if err := p.gpbft.Receive(msg); err != nil {
+			if errors.Is(err, ErrValidationWrongBase) {
+				// Silently ignore this late-binding validation error
+			} else {
+				return fmt.Errorf("delivering queued message: %w", err)
+			}
 		}
 	}
-	delete(p.mqueue, p.granite.instanceID)
-	return p.handleDecision()
+	p.handleDecision()
+	return nil
 }
 
-func (p *Participant) handleDecision() error {
+func (p *Participant) getCommittee(instance uint64) (*committee, error) {
+	c, ok := p.committees[instance]
+	if !ok {
+		power, beacon, err := p.host.GetCommitteeForInstance(instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed fetching committee for instance %d: %w", instance, err)
+		}
+		if err := power.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid power table: %w", err)
+		}
+		c = &committee{power: power, beacon: beacon}
+		p.committees[instance] = c
+	}
+	return c, nil
+}
+
+func (p *Participant) handleDecision() {
 	if p.terminated() {
-		p.finalised = p.granite.terminationValue
-		p.terminatedDuringRound = p.granite.round
-		p.granite = nil
+		p.finalised = p.gpbft.terminationValue
+		p.terminatedDuringRound = p.gpbft.round
+		delete(p.committees, p.gpbft.instanceID)
+		p.gpbft = nil
+		p.currentInstance++
 		nextStart := p.host.ReceiveDecision(p.finalised)
 
 		// Set an alarm at which to fetch the next chain and begin a new instance.
 		p.host.SetAlarm(nextStart)
-		return nil
 	}
-	return nil
 }
 
 func (p *Participant) terminated() bool {
-	return p.granite != nil && p.granite.phase == TERMINATED_PHASE
+	return p.gpbft != nil && p.gpbft.phase == TERMINATED_PHASE
 }
 
 func (p *Participant) Describe() string {
-	if p.granite == nil {
+	if p.gpbft == nil {
 		return "nil"
 	}
-	return p.granite.Describe()
+	return p.gpbft.Describe()
+}
+
+// A power table and beacon value used as the committee inputs to an instance.
+type committee struct {
+	power  *PowerTable
+	beacon []byte
+}
+
+// A collection of messages queued for delivery for a future instance.
+// The queue drops equivocations and unjustified messages beyond some round number.
+type messageQueue struct {
+	maxRound uint64
+	// Maps instance -> sender -> messages.
+	// Note the relative order of messages is lost.
+	messages map[uint64]map[ActorID][]*GMessage
+}
+
+func newMessageQueue(maxRound uint64) *messageQueue {
+	return &messageQueue{
+		maxRound: maxRound,
+		messages: make(map[uint64]map[ActorID][]*GMessage),
+	}
+}
+
+func (q *messageQueue) Add(msg *GMessage) {
+	instanceQueue, ok := q.messages[msg.Vote.Instance]
+	if !ok {
+		// There's no check on instance number being within a reasonable range here.
+		// It's assumed that spam messages for far future instances won't get this far.
+		instanceQueue = make(map[ActorID][]*GMessage)
+		q.messages[msg.Vote.Instance] = instanceQueue
+	}
+	// Drop unjustified messages beyond some round limit.
+	if msg.Vote.Round > q.maxRound && isSpammable(msg) {
+		return
+	}
+	// Drop equivocations and duplicates (messages with the same sender, round and step).
+	for _, m := range instanceQueue[msg.Sender] {
+		if m.Vote.Round == msg.Vote.Round && m.Vote.Step == msg.Vote.Step {
+			return
+		}
+	}
+	// Queue remaining good messages.
+	instanceQueue[msg.Sender] = append(instanceQueue[msg.Sender], msg)
+}
+
+func (q *messageQueue) Drain(instance uint64) []*GMessage {
+	var msgs []*GMessage
+	for _, ms := range q.messages[instance] {
+		msgs = append(msgs, ms...)
+	}
+	// Sort by round and then step so messages will be processed in a useful order.
+	sort.SliceStable(msgs, func(i, j int) bool {
+		if msgs[i].Vote.Round != msgs[j].Vote.Round {
+			return msgs[i].Vote.Round < msgs[j].Vote.Round
+		}
+		return msgs[i].Vote.Step < msgs[j].Vote.Step
+	})
+	delete(q.messages, instance)
+	return msgs
 }

--- a/sim/adversary/absent.go
+++ b/sim/adversary/absent.go
@@ -32,22 +32,22 @@ func (a *Absent) ID() gpbft.ActorID {
 	return a.id
 }
 
-func (a *Absent) Start() error {
+func (*Absent) Start() error {
 	return nil
 }
 
-func (a *Absent) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
-	return true, nil
+func (*Absent) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
+	return Validated(msg), nil
 }
 
-func (a *Absent) ReceiveMessage(_ *gpbft.GMessage, _ bool) (bool, error) {
-	return true, nil
-}
-
-func (a *Absent) ReceiveAlarm() error {
+func (*Absent) ReceiveMessage(_ gpbft.ValidatedMessage) error {
 	return nil
 }
 
-func (a *Absent) AllowMessage(_ gpbft.ActorID, _ gpbft.ActorID, _ gpbft.GMessage) bool {
+func (*Absent) ReceiveAlarm() error {
+	return nil
+}
+
+func (*Absent) AllowMessage(_ gpbft.ActorID, _ gpbft.ActorID, _ gpbft.GMessage) bool {
 	return true
 }

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -74,25 +74,24 @@ func (i *ImmediateDecide) Start() error {
 	return nil
 }
 
-func (i *ImmediateDecide) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
-	return true, nil
+func (*ImmediateDecide) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
+	return Validated(msg), nil
 }
 
-func (i *ImmediateDecide) ReceiveMessage(_ *gpbft.GMessage, _ bool) (bool, error) {
-	return true, nil
-}
-
-func (i *ImmediateDecide) ReceiveAlarm() error {
+func (*ImmediateDecide) ReceiveMessage(_ gpbft.ValidatedMessage) error {
 	return nil
 }
 
-func (i *ImmediateDecide) AllowMessage(_ gpbft.ActorID, _ gpbft.ActorID, _ gpbft.GMessage) bool {
+func (*ImmediateDecide) ReceiveAlarm() error {
+	return nil
+}
+
+func (*ImmediateDecide) AllowMessage(_ gpbft.ActorID, _ gpbft.ActorID, _ gpbft.GMessage) bool {
 	// Allow all messages
 	return true
 }
 
 func (i *ImmediateDecide) broadcast(payload gpbft.Payload, justification *gpbft.Justification, powertable *gpbft.PowerTable) {
-
 	pS := i.host.MarshalPayloadForSigning(&payload)
 	_, pubkey := powertable.Get(i.id)
 	sig, err := i.host.Sign(pubkey, pS)

--- a/sim/adversary/deny.go
+++ b/sim/adversary/deny.go
@@ -59,7 +59,9 @@ func (d *Deny) isTargeted(id gpbft.ActorID) bool {
 	return found
 }
 
-func (*Deny) Start() error                                       { return nil }
-func (*Deny) ValidateMessage(*gpbft.GMessage) (bool, error)      { return true, nil }
-func (*Deny) ReceiveMessage(*gpbft.GMessage, bool) (bool, error) { return true, nil }
-func (*Deny) ReceiveAlarm() error                                { return nil }
+func (*Deny) Start() error { return nil }
+func (*Deny) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
+	return Validated(msg), nil
+}
+func (*Deny) ReceiveMessage(_ gpbft.ValidatedMessage) error { return nil }
+func (*Deny) ReceiveAlarm() error                           { return nil }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -69,10 +69,15 @@ func NewRepeatGenerator(power *gpbft.StoragePower, sampler RepetitionSampler) Ge
 	}
 }
 
-func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
+func (*Repeat) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
+	return Validated(msg), nil
+}
+
+func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
+	msg := vmsg.Message()
 	echoCount := r.repetitionSampler(msg)
 	if echoCount <= 0 {
-		return true, nil
+		return nil
 	}
 
 	sigPayload := r.host.MarshalPayloadForSigning(&msg.Vote)
@@ -104,11 +109,10 @@ func (r *Repeat) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
 			r.host.RequestBroadcast(echo)
 		}
 	}
-	return true, nil
+	return nil
 }
 
 func (r *Repeat) ID() gpbft.ActorID                                              { return r.id }
 func (r *Repeat) Start() error                                                   { return nil }
-func (r *Repeat) ValidateMessage(*gpbft.GMessage) (bool, error)                  { return true, nil }
 func (r *Repeat) ReceiveAlarm() error                                            { return nil }
 func (r *Repeat) AllowMessage(gpbft.ActorID, gpbft.ActorID, gpbft.GMessage) bool { return true }

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -43,13 +43,18 @@ func (s *Spam) Start() error {
 	return nil
 }
 
-func (s *Spam) ReceiveMessage(msg *gpbft.GMessage, _ bool) (bool, error) {
+func (*Spam) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
+	return Validated(msg), nil
+}
+
+func (s *Spam) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
+	msg := vmsg.Message()
 	// Watch for increase in instance, and when increased spam again.
 	if msg.Vote.Instance > s.latestObservedInstance {
 		s.spamAtInstance(msg.Vote.Instance)
 		s.latestObservedInstance = msg.Vote.Instance
 	}
-	return true, nil
+	return nil
 }
 
 func (s *Spam) spamAtInstance(instance uint64) {
@@ -80,6 +85,5 @@ func (s *Spam) spamAtInstance(instance uint64) {
 }
 
 func (s *Spam) ID() gpbft.ActorID                                              { return s.id }
-func (s *Spam) ValidateMessage(*gpbft.GMessage) (bool, error)                  { return true, nil }
 func (s *Spam) ReceiveAlarm() error                                            { return nil }
 func (s *Spam) AllowMessage(gpbft.ActorID, gpbft.ActorID, gpbft.GMessage) bool { return true }

--- a/sim/adversary/util.go
+++ b/sim/adversary/util.go
@@ -1,0 +1,17 @@
+package adversary
+
+import "github.com/filecoin-project/go-f3/gpbft"
+
+type validatedMessage struct {
+	msg *gpbft.GMessage
+}
+
+var _ gpbft.ValidatedMessage = (*validatedMessage)(nil)
+
+func Validated(msg *gpbft.GMessage) gpbft.ValidatedMessage {
+	return &validatedMessage{msg: msg}
+}
+
+func (v *validatedMessage) Message() *gpbft.GMessage {
+	return v.msg
+}

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -114,15 +114,15 @@ func (w *WithholdCommit) Start() error {
 	return nil
 }
 
-func (a *WithholdCommit) ValidateMessage(_ *gpbft.GMessage) (bool, error) {
-	return true, nil
+func (*WithholdCommit) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
+	return Validated(msg), nil
 }
 
-func (a *WithholdCommit) ReceiveMessage(_ *gpbft.GMessage, _ bool) (bool, error) {
-	return true, nil
+func (*WithholdCommit) ReceiveMessage(_ gpbft.ValidatedMessage) error {
+	return nil
 }
 
-func (w *WithholdCommit) ReceiveAlarm() error {
+func (*WithholdCommit) ReceiveAlarm() error {
 	return nil
 }
 

--- a/sim/network.go
+++ b/sim/network.go
@@ -1,6 +1,7 @@
 package sim
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -163,10 +164,14 @@ func (n *Network) Tick(adv *adversary.Adversary) (bool, error) {
 		}
 		validated, err := receiver.ValidateMessage(&payload)
 		if err != nil {
+			if errors.Is(err, gpbft.ErrValidationTooOld) {
+				// Silently drop old messages.
+				break
+			}
 			return false, fmt.Errorf("invalid message from %d to %d: %w", msg.source, msg.dest, err)
 		}
 		n.log(TraceRecvd, "P%d ← P%d: %v", msg.dest, msg.source, msg.payload)
-		if _, err := receiver.ReceiveMessage(&payload, validated); err != nil {
+		if err := receiver.ReceiveMessage(validated); err != nil {
 			return false, fmt.Errorf("failed to deliver message from %d to %d: %w", msg.source, msg.dest, err)
 		}
 	default:


### PR DESCRIPTION
This covers the main parts of https://github.com/filecoin-project/go-f3/issues/151 except testing/validation. I added new tasks for follow-up items of optimising skipping rounds, and supporting parallel validation.

FYI @Kubuxu on the API change.