### PR TITLE
FFF-103: remove ID from gpbft.Participant

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -95,6 +95,7 @@ type Tracer interface {
 
 // Participant interface to the host system resources.
 type Host interface {
+	ID() ActorID
 	Chain
 	Network
 	Clock

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -236,7 +236,7 @@ func (i *instance) ReceiveAlarm() error {
 }
 
 func (i *instance) Describe() string {
-	return fmt.Sprintf("P%d{%d}, round %d, phase %s", i.participant.id, i.instanceID, i.round, i.phase)
+	return fmt.Sprintf("P%d{%d}, round %d, phase %s", i.participant.host.ID(), i.instanceID, i.round, i.phase)
 }
 
 // Processes a single message.
@@ -530,7 +530,7 @@ func (i *instance) beginConverge() {
 			panic("beginConverge called but no justification for proposal")
 		}
 	}
-	_, pubkey := i.powerTable.Get(i.participant.id)
+	_, pubkey := i.powerTable.Get(i.participant.host.ID())
 	ticket, err := MakeTicket(i.beacon, i.instanceID, i.round, pubkey, i.participant.host)
 	if err != nil {
 		i.log("error while creating VRF ticket: %v", err)
@@ -774,7 +774,7 @@ func (i *instance) broadcast(round uint64, step Phase, value ECChain, ticket Tic
 	}
 
 	gmsg := &GMessage{
-		Sender:        i.participant.id,
+		Sender:        i.participant.host.ID(),
 		Vote:          p,
 		Signature:     sig,
 		Ticket:        ticket,
@@ -815,13 +815,13 @@ func (i *instance) buildJustification(quorum QuorumResult, round uint64, phase P
 func (i *instance) log(format string, args ...interface{}) {
 	if i.tracer != nil {
 		msg := fmt.Sprintf(format, args...)
-		i.tracer.Log("P%d{%d}: %s (round %d, step %s, proposal %s, value %s)", i.participant.id, i.instanceID, msg,
+		i.tracer.Log("P%d{%d}: %s (round %d, step %s, proposal %s, value %s)", i.participant.host.ID(), i.instanceID, msg,
 			i.round, i.phase, &i.proposal, &i.value)
 	}
 }
 
 func (i *instance) sign(msg []byte) ([]byte, error) {
-	_, pubKey := i.powerTable.Get(i.participant.id)
+	_, pubKey := i.powerTable.Get(i.participant.host.ID())
 	return i.participant.host.Sign(pubKey, msg)
 }
 

--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -146,6 +146,51 @@ func (_c *MockHost_GetCanonicalChain_Call) RunAndReturn(run func() (ECChain, Pow
 	return _c
 }
 
+// ID provides a mock function with given fields:
+func (_m *MockHost) ID() ActorID {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ID")
+	}
+
+	var r0 ActorID
+	if rf, ok := ret.Get(0).(func() ActorID); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(ActorID)
+	}
+
+	return r0
+}
+
+// MockHost_ID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ID'
+type MockHost_ID_Call struct {
+	*mock.Call
+}
+
+// ID is a helper method to define mock.On call
+func (_e *MockHost_Expecter) ID() *MockHost_ID_Call {
+	return &MockHost_ID_Call{Call: _e.mock.On("ID")}
+}
+
+func (_c *MockHost_ID_Call) Run(run func()) *MockHost_ID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockHost_ID_Call) Return(_a0 ActorID) *MockHost_ID_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockHost_ID_Call) RunAndReturn(run func() ActorID) *MockHost_ID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MarshalPayloadForSigning provides a mock function with given fields: _a0
 func (_m *MockHost) MarshalPayloadForSigning(_a0 *Payload) []byte {
 	ret := _m.Called(_a0)

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -8,7 +8,6 @@ import (
 // An F3 participant runs repeated instances of Granite to finalise longer chains.
 type Participant struct {
 	*options
-	id   ActorID
 	host Host
 
 	// Instance identifier for the next Granite instance.
@@ -36,22 +35,17 @@ func (e *PanicError) Error() string {
 	return fmt.Sprintf("participant panicked: %v", e.Err)
 }
 
-func NewParticipant(id ActorID, host Host, o ...Option) (*Participant, error) {
+func NewParticipant(host Host, o ...Option) (*Participant, error) {
 	opts, err := newOptions(o...)
 	if err != nil {
 		return nil, err
 	}
 	return &Participant{
 		options:      opts,
-		id:           id,
 		host:         host,
 		mqueue:       make(map[uint64][]*GMessage),
 		nextInstance: opts.initialInstance,
 	}, nil
-}
-
-func (p *Participant) ID() ActorID {
-	return p.id
 }
 
 // Fetches the preferred EC chain for the instance and begins the GPBFT protocol.
@@ -170,7 +164,7 @@ func (p *Participant) beginInstance() error {
 			break
 		}
 		if p.tracer != nil {
-			p.tracer.Log("Delivering queued P%d{%d} ← P%d: %v", p.id, p.granite.instanceID, msg.Sender, msg)
+			p.tracer.Log("Delivering queued P%d{%d} ← P%d: %v", p.host.ID(), p.granite.instanceID, msg.Sender, msg)
 		}
 		if err := p.granite.Receive(msg); err != nil {
 			return fmt.Errorf("delivering queued message: %w", err)

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -75,6 +75,9 @@ func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *parti
 		gpbft.WithDeltaBackOffExponent(deltaBackOffExponent),
 		gpbft.WithInitialInstance(instance))
 	require.NoError(t, err)
+	subject.host.
+		On("ID").
+		Return(subject.id)
 	require.EqualValues(t, subject.id, subject.host.ID())
 	subject.requireNotStarted()
 	return &subject


### PR DESCRIPTION
Addresses #103. Continuation (and depends on) #259

This PR: 
- Removes the `id` from `gpbft.Participant`.
- Exposes an `ID()` method to access the ID of the current participant through the host interface.