### PR TITLE
Fix go vet issues and upgrade to latest `golangci-lint`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.58
           only-new-issues: true
       - name: Tidy go.mod
         run: go mod tidy

--- a/test/ec_divergence_test.go
+++ b/test/ec_divergence_test.go
@@ -29,6 +29,7 @@ func TestEcDivergence_AbsoluteDivergenceConvergesOnBase(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			seedFuzzer := uint64(985623)
 
@@ -117,6 +118,7 @@ func TestEcDivergence_PartitionedNetworkConvergesOnChainWithMostPower(t *testing
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			seedFuzzer := uint64(784523)
 


### PR DESCRIPTION
Fix lint build failing in merge queue and upgrade to latest linters.

See:
 * https://github.com/filecoin-project/go-f3/actions/runs/9190680236/job/25276522745