### PR TITLE
Use deterministic latency in tests to avid intermittent failures

### DIFF
--- a/sim/cmd/f3sim/f3sim.go
+++ b/sim/cmd/f3sim/f3sim.go
@@ -31,7 +31,10 @@ func main() {
 		fmt.Printf("Iteration %d: seed=%d, mean=%f\n", i, seed, *latencyMean)
 
 		options := []sim.Option{
-			sim.WithLatencyModel(latency.NewLogNormal(*latencySeed, time.Duration(*latencyMean*float64(time.Second)))),
+			sim.WithLatencyModeler(func() (latency.Model, error) {
+				mean := time.Duration(*latencyMean * float64(time.Second))
+				return latency.NewLogNormal(*latencySeed, mean), nil
+			}),
 			sim.WithECEpochDuration(30 * time.Second),
 			sim.WithECStabilisationDelay(0),
 			sim.AddHonestParticipants(

--- a/sim/latency/latency.go
+++ b/sim/latency/latency.go
@@ -6,6 +6,9 @@ import (
 	"github.com/filecoin-project/go-f3/gpbft"
 )
 
+// Modeler instantiates a new latency Model.
+type Modeler func() (Model, error)
+
 // Model represents a latency model of cross participant communication. The model
 // offers the ability for implementation of varying latency across a simulation,
 // as well as specialised latency across specific participants.

--- a/sim/options.go
+++ b/sim/options.go
@@ -93,10 +93,11 @@ func WithSigningBackend(sb signing.Backend) Option {
 	}
 }
 
-func WithLatencyModel(lm latency.Model) Option {
+func WithLatencyModeler(lm latency.Modeler) Option {
 	return func(o *options) error {
-		o.latencyModel = lm
-		return nil
+		var err error
+		o.latencyModel, err = lm()
+		return err
 	}
 }
 

--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -34,7 +34,7 @@ var (
 
 func syncOptions(o ...sim.Option) []sim.Option {
 	return append(o,
-		sim.WithLatencyModel(latency.None),
+		sim.WithLatencyModeler(func() (latency.Model, error) { return latency.None, nil }),
 		sim.WithECEpochDuration(EcEpochDuration),
 		sim.WitECStabilisationDelay(EcStabilisationDelay),
 		sim.WithGpbftOptions(testGpbftOptions...),
@@ -43,7 +43,9 @@ func syncOptions(o ...sim.Option) []sim.Option {
 
 func asyncOptions(latencySeed int, o ...sim.Option) []sim.Option {
 	return append(o,
-		sim.WithLatencyModel(latency.NewLogNormal(int64(latencySeed), latencyAsync)),
+		sim.WithLatencyModeler(func() (latency.Model, error) {
+			return latency.NewLogNormal(int64(latencySeed), latencyAsync), nil
+		}),
 		sim.WithECEpochDuration(EcEpochDuration),
 		sim.WitECStabilisationDelay(EcStabilisationDelay),
 		sim.WithGpbftOptions(testGpbftOptions...),

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -11,8 +11,7 @@ import (
 
 // TestHonestMultiInstance_Agreement tests for multiple chained instances of the protocol with no adversaries.
 func TestHonestMultiInstance_Agreement(t *testing.T) {
-	// TODO: t.Parallel() here after https://github.com/filecoin-project/builtin-actors/issues/1541
-	//t.Parallel()
+	t.Parallel()
 	const (
 		instanceCount  = 4000
 		testRNGSeed    = 8965130
@@ -101,8 +100,7 @@ func FuzzHonestMultiInstance_AsyncAgreement(f *testing.F) {
 }
 
 func multiAgreementTest(t *testing.T, seed int, honestCount int, instanceCount uint64, maxRounds uint64, opts ...sim.Option) {
-	// TODO: t.Parallel() here after https://github.com/filecoin-project/builtin-actors/issues/1541
-	//t.Parallel()
+	t.Parallel()
 	rng := rand.New(rand.NewSource(int64(seed)))
 	sm, err := sim.NewSimulation(append(opts,
 		sim.AddHonestParticipants(

--- a/test/spam_test.go
+++ b/test/spam_test.go
@@ -44,7 +44,9 @@ func TestSpamAdversary(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				ecChainGenerator := sim.NewUniformECChainGenerator(651651, 1, 10)
 				sm, err := sim.NewSimulation(
-					sim.WithLatencyModel(latency.NewLogNormal(455454, time.Second)),
+					sim.WithLatencyModeler(func() (latency.Model, error) {
+						return latency.NewLogNormal(455454, time.Second), nil
+					}),
 					sim.WithECEpochDuration(EcEpochDuration),
 					sim.WitECStabilisationDelay(EcStabilisationDelay),
 					sim.WithGpbftOptions(testGpbftOptions...),

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -37,14 +37,16 @@ func TestWitholdCommitAdversary(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			nearSynchrony := latency.NewLogNormal(1413, 10*time.Millisecond)
+			nearSynchrony := func() (latency.Model, error) {
+				return latency.NewLogNormal(1413, 10*time.Millisecond), nil
+			}
 			tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
 			baseChain := generateECChain(t, tsg)
 			a := baseChain.Extend(tsg.Sample())
 			b := baseChain.Extend(tsg.Sample())
 			victims := []gpbft.ActorID{0, 1, 2, 3}
 			sm, err := sim.NewSimulation(
-				sim.WithLatencyModel(nearSynchrony),
+				sim.WithLatencyModeler(nearSynchrony),
 				sim.WithECEpochDuration(EcEpochDuration),
 				sim.WitECStabilisationDelay(EcStabilisationDelay),
 				sim.WithGpbftOptions(testGpbftOptions...),


### PR DESCRIPTION
The intermittent failures always occur for async tests, in form of going beyond the maximum number of rounds allowed in tests (mostly 10). The number of rounds is directly impacted by the order of message delivery to each node, dictated by the latency model.

The Async test options use a latency model that is instantiated when the simulation _options_ are instantiated, not when the simulation itself is instantiated and run. This results in the reuse of the same latency model object across multiple tests.

In go tests may be run in parallel, but the same test never runs in parallel with itself when repeated multiple times via `-count=n` flag. When test are run in parallel using the same latency object across tests becomes the root cause of indeterministic behaviour, where at times a test case can require more rounds than allowed to complete.

The changes here introduce a latency model instantiator, called `latency.Modeler` which encapsulates the responsibility of constructing a latency model object used by a simulation. The simulation is then adopted to take modelers as option, not already instantiated models. This change dramatically reduces the scope of error that was previously occurring where latency models with unclean RNG state were being used by multiple test and assures that the order of message delivery in tests is deterministic regardless of the test execution parallelism.

Additionally, maximum test parallelism is enabled across all table tests and fuzz tests to reduce the total execution runtime.

Fixes #262 