### PR TITLE
Commit to a next power table and additional commitments

### DIFF
--- a/gen/main.go
+++ b/gen/main.go
@@ -14,6 +14,7 @@ func main() {
 	err := gen.WriteTupleEncodersToFile("../gpbft/gen.go", "gpbft",
 		gpbft.TipSet{},
 		gpbft.GMessage{},
+		gpbft.InstanceData{},
 		gpbft.Payload{},
 		gpbft.Justification{},
 	)

--- a/gen/main.go
+++ b/gen/main.go
@@ -14,7 +14,7 @@ func main() {
 	err := gen.WriteTupleEncodersToFile("../gpbft/gen.go", "gpbft",
 		gpbft.TipSet{},
 		gpbft.GMessage{},
-		gpbft.InstanceData{},
+		gpbft.SupplementalData{},
 		gpbft.Payload{},
 		gpbft.Justification{},
 	)

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -60,7 +60,7 @@ type Chain interface {
 	// Returns the chain to propose for a new GPBFT instance.
 	// This should be a suffix of the chain finalised by the immediately prior instance.
 	// Returns an error if the chain for the instance is not available.
-	GetChainForInstance(instance uint64) (chain ECChain, err error)
+	GetProposalForInstance(instance uint64) (data *InstanceData, chain ECChain, err error)
 
 	// Returns the power table and beacon value to be used for a GPBFT instance.
 	// These values should be derived from a chain previously received as final by the host,
@@ -68,10 +68,6 @@ type Chain interface {
 	// The offset (how many instances to look back) is determined by the host.
 	// Returns an error if the committee for the instance is not available.
 	GetCommitteeForInstance(instance uint64) (power *PowerTable, beacon []byte, err error)
-
-	// Returns the instance data for the given instance. All participants will propose the exact
-	// same instance data and all messages proposing _different_ instance data will be dropped.
-	GetDataForInstance(instance uint64) (data *InstanceData, err error)
 }
 
 // Endpoint to which participants can send messages.

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -68,6 +68,10 @@ type Chain interface {
 	// The offset (how many instances to look back) is determined by the host.
 	// Returns an error if the committee for the instance is not available.
 	GetCommitteeForInstance(instance uint64) (power *PowerTable, beacon []byte, err error)
+
+	// Returns the instance data for the given instance. All participants will propose the exact
+	// same instance data and all messages proposing _different_ instance data will be dropped.
+	GetDataForInstance(instance uint64) (data *InstanceData, err error)
 }
 
 // Endpoint to which participants can send messages.

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -57,10 +57,13 @@ type Receiver interface {
 }
 
 type Chain interface {
-	// Returns the chain to propose for a new GPBFT instance.
-	// This should be a suffix of the chain finalised by the immediately prior instance.
+	// Returns the supplemental data and the chain to propose for a new GPBFT instance.
+	// The chain must be a suffix of the chain finalised by the immediately prior instance.
+	// The supplemental data must be derived entirely from prior instances and all participants
+	// must propose the same supplemental data.
+	//
 	// Returns an error if the chain for the instance is not available.
-	GetProposalForInstance(instance uint64) (data *InstanceData, chain ECChain, err error)
+	GetProposalForInstance(instance uint64) (data *SupplementalData, chain ECChain, err error)
 
 	// Returns the power table and beacon value to be used for a GPBFT instance.
 	// These values should be derived from a chain previously received as final by the host,

--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -157,7 +157,7 @@ func (c ECChain) Prefix(to int) ECChain {
 		panic("can't get prefix from zero-valued chain")
 	}
 	length := min(to+1, len(c))
-	return c[:length : length]
+	return c[:length:length]
 }
 
 // Compares two ECChains for equality.

--- a/gpbft/gen.go
+++ b/gpbft/gen.go
@@ -370,9 +370,9 @@ func (t *GMessage) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
-var lengthBufInstanceData = []byte{130}
+var lengthBufSupplementalData = []byte{130}
 
-func (t *InstanceData) MarshalCBOR(w io.Writer) error {
+func (t *SupplementalData) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -380,7 +380,7 @@ func (t *InstanceData) MarshalCBOR(w io.Writer) error {
 
 	cw := cbg.NewCborWriter(w)
 
-	if _, err := cw.Write(lengthBufInstanceData); err != nil {
+	if _, err := cw.Write(lengthBufSupplementalData); err != nil {
 		return err
 	}
 
@@ -413,8 +413,8 @@ func (t *InstanceData) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *InstanceData) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = InstanceData{}
+func (t *SupplementalData) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = SupplementalData{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -513,8 +513,8 @@ func (t *Payload) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Data (gpbft.InstanceData) (struct)
-	if err := t.Data.MarshalCBOR(cw); err != nil {
+	// t.SupplementalData (gpbft.SupplementalData) (struct)
+	if err := t.SupplementalData.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -599,12 +599,12 @@ func (t *Payload) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("integer in input was too large for uint8 field")
 	}
 	t.Step = Phase(extra)
-	// t.Data (gpbft.InstanceData) (struct)
+	// t.SupplementalData (gpbft.SupplementalData) (struct)
 
 	{
 
-		if err := t.Data.UnmarshalCBOR(cr); err != nil {
-			return xerrors.Errorf("unmarshaling t.Data: %w", err)
+		if err := t.SupplementalData.UnmarshalCBOR(cr); err != nil {
+			return xerrors.Errorf("unmarshaling t.SupplementalData: %w", err)
 		}
 
 	}

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -79,17 +79,17 @@ type Justification struct {
 }
 
 type InstanceData struct {
-	// The blake2b hash of the power table used to validate the next instance, taking lookback
-	// into account.
-	PowerTable [32]byte
 	// Merkle-tree of instance-specific commitments. Currently empty but this will eventually
 	// include things like snark-friendly power-table commitments.
 	Commitments [32]byte
+	// The DagCBOR-blake2b256 CID of the power table used to validate the next instance, taking
+	// lookback into account.
+	PowerTable CID // []PowerEntry
 }
 
 func (d *InstanceData) Eq(other *InstanceData) bool {
 	return d.Commitments == other.Commitments &&
-		d.PowerTable == other.PowerTable
+		bytes.Equal(d.PowerTable, other.PowerTable)
 }
 
 // Fields of the message that make up the signature payload.
@@ -131,8 +131,8 @@ func (p *Payload) MarshalForSigning(nn NetworkName) []byte {
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
 	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
 	_, _ = buf.Write(p.Data.Commitments[:])
-	_, _ = buf.Write(p.Data.PowerTable[:])
 	_, _ = buf.Write(root[:])
+	_, _ = buf.Write(p.Data.PowerTable)
 	return buf.Bytes()
 }
 

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -158,6 +158,8 @@ type instance struct {
 	// For QUALITY, PREPARE, and COMMIT, this is the latest time (the phase can end sooner).
 	// For CONVERGE, this is the exact time (the timeout solely defines the phase end).
 	phaseTimeout time.Time
+	// Instance data that all participants must agree on.
+	instanceData *InstanceData
 	// This instance's proposal for the current round. Never bottom.
 	// This is set after the QUALITY phase, and changes only at the end of a full round.
 	proposal ECChain
@@ -181,8 +183,6 @@ type instance struct {
 	// Decision state. Collects DECIDE messages until a decision can be made,
 	// independently of protocol phases/rounds.
 	decision *quorumState
-	// Instance data that all participants must agree on.
-	instanceData *InstanceData
 	// tracer traces logic logs for debugging and simulation purposes.
 	tracer Tracer
 }
@@ -198,23 +198,23 @@ func newInstance(
 		return nil, fmt.Errorf("input is empty")
 	}
 	return &instance{
-		participant: participant,
-		instanceID:  instanceID,
-		input:       input,
-		powerTable:  powerTable,
-		beacon:      beacon,
-		round:       0,
-		phase:       INITIAL_PHASE,
-		proposal:    input,
-		value:       ECChain{},
-		candidates:  []ECChain{input.BaseChain()},
-		quality:     newQuorumState(powerTable),
+		participant:  participant,
+		instanceID:   instanceID,
+		input:        input,
+		powerTable:   powerTable,
+		beacon:       beacon,
+		round:        0,
+		phase:        INITIAL_PHASE,
+		instanceData: data,
+		proposal:     input,
+		value:        ECChain{},
+		candidates:   []ECChain{input.BaseChain()},
+		quality:      newQuorumState(powerTable),
 		rounds: map[uint64]*roundState{
 			0: newRoundState(powerTable),
 		},
-		instanceData: data,
-		decision:     newQuorumState(powerTable),
-		tracer:       participant.tracer,
+		decision: newQuorumState(powerTable),
+		tracer:   participant.tracer,
 	}, nil
 }
 

--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -148,24 +148,24 @@ func (_c *MockHost_GetCommitteeForInstance_Call) RunAndReturn(run func(uint64) (
 }
 
 // GetProposalForInstance provides a mock function with given fields: instance
-func (_m *MockHost) GetProposalForInstance(instance uint64) (*InstanceData, ECChain, error) {
+func (_m *MockHost) GetProposalForInstance(instance uint64) (*SupplementalData, ECChain, error) {
 	ret := _m.Called(instance)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetProposalForInstance")
 	}
 
-	var r0 *InstanceData
+	var r0 *SupplementalData
 	var r1 ECChain
 	var r2 error
-	if rf, ok := ret.Get(0).(func(uint64) (*InstanceData, ECChain, error)); ok {
+	if rf, ok := ret.Get(0).(func(uint64) (*SupplementalData, ECChain, error)); ok {
 		return rf(instance)
 	}
-	if rf, ok := ret.Get(0).(func(uint64) *InstanceData); ok {
+	if rf, ok := ret.Get(0).(func(uint64) *SupplementalData); ok {
 		r0 = rf(instance)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*InstanceData)
+			r0 = ret.Get(0).(*SupplementalData)
 		}
 	}
 
@@ -204,12 +204,12 @@ func (_c *MockHost_GetProposalForInstance_Call) Run(run func(instance uint64)) *
 	return _c
 }
 
-func (_c *MockHost_GetProposalForInstance_Call) Return(data *InstanceData, chain ECChain, err error) *MockHost_GetProposalForInstance_Call {
+func (_c *MockHost_GetProposalForInstance_Call) Return(data *SupplementalData, chain ECChain, err error) *MockHost_GetProposalForInstance_Call {
 	_c.Call.Return(data, chain, err)
 	return _c
 }
 
-func (_c *MockHost_GetProposalForInstance_Call) RunAndReturn(run func(uint64) (*InstanceData, ECChain, error)) *MockHost_GetProposalForInstance_Call {
+func (_c *MockHost_GetProposalForInstance_Call) RunAndReturn(run func(uint64) (*SupplementalData, ECChain, error)) *MockHost_GetProposalForInstance_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -80,64 +80,6 @@ func (_c *MockHost_Aggregate_Call) RunAndReturn(run func([]PubKey, [][]byte) ([]
 	return _c
 }
 
-// GetChainForInstance provides a mock function with given fields: instance
-func (_m *MockHost) GetChainForInstance(instance uint64) (ECChain, error) {
-	ret := _m.Called(instance)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetChainForInstance")
-	}
-
-	var r0 ECChain
-	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64) (ECChain, error)); ok {
-		return rf(instance)
-	}
-	if rf, ok := ret.Get(0).(func(uint64) ECChain); ok {
-		r0 = rf(instance)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(ECChain)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(uint64) error); ok {
-		r1 = rf(instance)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockHost_GetChainForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetChainForInstance'
-type MockHost_GetChainForInstance_Call struct {
-	*mock.Call
-}
-
-// GetChainForInstance is a helper method to define mock.On call
-//   - instance uint64
-func (_e *MockHost_Expecter) GetChainForInstance(instance interface{}) *MockHost_GetChainForInstance_Call {
-	return &MockHost_GetChainForInstance_Call{Call: _e.mock.On("GetChainForInstance", instance)}
-}
-
-func (_c *MockHost_GetChainForInstance_Call) Run(run func(instance uint64)) *MockHost_GetChainForInstance_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(uint64))
-	})
-	return _c
-}
-
-func (_c *MockHost_GetChainForInstance_Call) Return(chain ECChain, err error) *MockHost_GetChainForInstance_Call {
-	_c.Call.Return(chain, err)
-	return _c
-}
-
-func (_c *MockHost_GetChainForInstance_Call) RunAndReturn(run func(uint64) (ECChain, error)) *MockHost_GetChainForInstance_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetCommitteeForInstance provides a mock function with given fields: instance
 func (_m *MockHost) GetCommitteeForInstance(instance uint64) (*PowerTable, []byte, error) {
 	ret := _m.Called(instance)
@@ -205,17 +147,18 @@ func (_c *MockHost_GetCommitteeForInstance_Call) RunAndReturn(run func(uint64) (
 	return _c
 }
 
-// GetDataForInstance provides a mock function with given fields: instance
-func (_m *MockHost) GetDataForInstance(instance uint64) (*InstanceData, error) {
+// GetProposalForInstance provides a mock function with given fields: instance
+func (_m *MockHost) GetProposalForInstance(instance uint64) (*InstanceData, ECChain, error) {
 	ret := _m.Called(instance)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetDataForInstance")
+		panic("no return value specified for GetProposalForInstance")
 	}
 
 	var r0 *InstanceData
-	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64) (*InstanceData, error)); ok {
+	var r1 ECChain
+	var r2 error
+	if rf, ok := ret.Get(0).(func(uint64) (*InstanceData, ECChain, error)); ok {
 		return rf(instance)
 	}
 	if rf, ok := ret.Get(0).(func(uint64) *InstanceData); ok {
@@ -226,39 +169,47 @@ func (_m *MockHost) GetDataForInstance(instance uint64) (*InstanceData, error) {
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(uint64) error); ok {
+	if rf, ok := ret.Get(1).(func(uint64) ECChain); ok {
 		r1 = rf(instance)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(ECChain)
+		}
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(uint64) error); ok {
+		r2 = rf(instance)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
-// MockHost_GetDataForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDataForInstance'
-type MockHost_GetDataForInstance_Call struct {
+// MockHost_GetProposalForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetProposalForInstance'
+type MockHost_GetProposalForInstance_Call struct {
 	*mock.Call
 }
 
-// GetDataForInstance is a helper method to define mock.On call
+// GetProposalForInstance is a helper method to define mock.On call
 //   - instance uint64
-func (_e *MockHost_Expecter) GetDataForInstance(instance interface{}) *MockHost_GetDataForInstance_Call {
-	return &MockHost_GetDataForInstance_Call{Call: _e.mock.On("GetDataForInstance", instance)}
+func (_e *MockHost_Expecter) GetProposalForInstance(instance interface{}) *MockHost_GetProposalForInstance_Call {
+	return &MockHost_GetProposalForInstance_Call{Call: _e.mock.On("GetProposalForInstance", instance)}
 }
 
-func (_c *MockHost_GetDataForInstance_Call) Run(run func(instance uint64)) *MockHost_GetDataForInstance_Call {
+func (_c *MockHost_GetProposalForInstance_Call) Run(run func(instance uint64)) *MockHost_GetProposalForInstance_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(uint64))
 	})
 	return _c
 }
 
-func (_c *MockHost_GetDataForInstance_Call) Return(data *InstanceData, err error) *MockHost_GetDataForInstance_Call {
-	_c.Call.Return(data, err)
+func (_c *MockHost_GetProposalForInstance_Call) Return(data *InstanceData, chain ECChain, err error) *MockHost_GetProposalForInstance_Call {
+	_c.Call.Return(data, chain, err)
 	return _c
 }
 
-func (_c *MockHost_GetDataForInstance_Call) RunAndReturn(run func(uint64) (*InstanceData, error)) *MockHost_GetDataForInstance_Call {
+func (_c *MockHost_GetProposalForInstance_Call) RunAndReturn(run func(uint64) (*InstanceData, ECChain, error)) *MockHost_GetProposalForInstance_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -205,6 +205,64 @@ func (_c *MockHost_GetCommitteeForInstance_Call) RunAndReturn(run func(uint64) (
 	return _c
 }
 
+// GetDataForInstance provides a mock function with given fields: instance
+func (_m *MockHost) GetDataForInstance(instance uint64) (*InstanceData, error) {
+	ret := _m.Called(instance)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDataForInstance")
+	}
+
+	var r0 *InstanceData
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint64) (*InstanceData, error)); ok {
+		return rf(instance)
+	}
+	if rf, ok := ret.Get(0).(func(uint64) *InstanceData); ok {
+		r0 = rf(instance)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*InstanceData)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(uint64) error); ok {
+		r1 = rf(instance)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockHost_GetDataForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDataForInstance'
+type MockHost_GetDataForInstance_Call struct {
+	*mock.Call
+}
+
+// GetDataForInstance is a helper method to define mock.On call
+//   - instance uint64
+func (_e *MockHost_Expecter) GetDataForInstance(instance interface{}) *MockHost_GetDataForInstance_Call {
+	return &MockHost_GetDataForInstance_Call{Call: _e.mock.On("GetDataForInstance", instance)}
+}
+
+func (_c *MockHost_GetDataForInstance_Call) Run(run func(instance uint64)) *MockHost_GetDataForInstance_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint64))
+	})
+	return _c
+}
+
+func (_c *MockHost_GetDataForInstance_Call) Return(data *InstanceData, err error) *MockHost_GetDataForInstance_Call {
+	_c.Call.Return(data, err)
+	return _c
+}
+
+func (_c *MockHost_GetDataForInstance_Call) RunAndReturn(run func(uint64) (*InstanceData, error)) *MockHost_GetDataForInstance_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MarshalPayloadForSigning provides a mock function with given fields: _a0, _a1
 func (_m *MockHost) MarshalPayloadForSigning(_a0 NetworkName, _a1 *Payload) []byte {
 	ret := _m.Called(_a0, _a1)

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -170,10 +170,10 @@ func (p *Participant) beginInstance() error {
 	if err != nil {
 		return err
 	}
-
-	// XXX: Need the the power table for the next instance after this one:
-	// GetCommitteeForInstance(p.nextInstance + 1)
-	data := new(InstanceData)
+	data, err := p.host.GetDataForInstance(p.currentInstance)
+	if err != nil {
+		return fmt.Errorf("failed fetching extra data for instance %d: %w", p.currentInstance, err)
+	}
 	if p.gpbft, err = newInstance(p, p.currentInstance, chain, data, *comm.power, comm.beacon); err != nil {
 		return fmt.Errorf("failed creating new gpbft instance: %w", err)
 	}

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -170,7 +170,11 @@ func (p *Participant) beginInstance() error {
 	if err != nil {
 		return err
 	}
-	if p.gpbft, err = newInstance(p, p.currentInstance, chain, *comm.power, comm.beacon); err != nil {
+
+	// XXX: Need the the power table for the next instance after this one:
+	// GetCommitteeForInstance(p.nextInstance + 1)
+	data := new(InstanceData)
+	if p.gpbft, err = newInstance(p, p.currentInstance, chain, data, *comm.power, comm.beacon); err != nil {
 		return fmt.Errorf("failed creating new gpbft instance: %w", err)
 	}
 	if err := p.gpbft.Start(); err != nil {

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -153,7 +153,7 @@ func (p *Participant) ReceiveAlarm() (err error) {
 }
 
 func (p *Participant) beginInstance() error {
-	chain, err := p.host.GetChainForInstance(p.currentInstance)
+	data, chain, err := p.host.GetProposalForInstance(p.currentInstance)
 	if err != nil {
 		return fmt.Errorf("failed fetching chain for instance %d: %w", p.currentInstance, err)
 	}
@@ -169,10 +169,6 @@ func (p *Participant) beginInstance() error {
 	comm, err := p.getCommittee(p.currentInstance)
 	if err != nil {
 		return err
-	}
-	data, err := p.host.GetDataForInstance(p.currentInstance)
-	if err != nil {
-		return fmt.Errorf("failed fetching extra data for instance %d: %w", p.currentInstance, err)
 	}
 	if p.gpbft, err = newInstance(p, p.currentInstance, chain, data, *comm.power, comm.beacon); err != nil {
 		return fmt.Errorf("failed creating new gpbft instance: %w", err)

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -36,6 +36,7 @@ type participantTestSubject struct {
 	beacon         []byte
 	time           time.Time
 	delta          time.Duration
+	instanceData   *gpbft.InstanceData
 }
 
 func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *participantTestSubject {
@@ -61,6 +62,7 @@ func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *parti
 		powerTable:     gpbft.NewPowerTable(),
 		beacon:         generateRandomBytes(rng),
 		time:           time.Now(),
+		instanceData:   new(gpbft.InstanceData),
 	}
 
 	// Assure power table contains the power entry for the test subject
@@ -84,6 +86,7 @@ func (pt *participantTestSubject) expectBeginInstance() {
 	// Prepare the test host.
 	pt.host.On("GetChainForInstance", pt.instance).Return(pt.canonicalChain, nil)
 	pt.host.On("GetCommitteeForInstance", pt.instance).Return(pt.powerTable, pt.beacon, nil)
+	pt.host.On("GetDataForInstance", pt.instance).Return(pt.instanceData, nil)
 	pt.host.On("Time").Return(pt.time)
 	pt.host.On("NetworkName").Return(pt.networkName).Maybe()
 	// We need to use `Maybe` here because `MarshalPayloadForSigning` may be called

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -32,11 +32,11 @@ type participantTestSubject struct {
 	instance       uint64
 	networkName    gpbft.NetworkName
 	canonicalChain gpbft.ECChain
+	instanceData   *gpbft.InstanceData
 	powerTable     *gpbft.PowerTable
 	beacon         []byte
 	time           time.Time
 	delta          time.Duration
-	instanceData   *gpbft.InstanceData
 }
 
 func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *participantTestSubject {
@@ -59,10 +59,10 @@ func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *parti
 		instance:       instance,
 		networkName:    "fish",
 		canonicalChain: canonicalChain,
+		instanceData:   new(gpbft.InstanceData),
 		powerTable:     gpbft.NewPowerTable(),
 		beacon:         generateRandomBytes(rng),
 		time:           time.Now(),
-		instanceData:   new(gpbft.InstanceData),
 	}
 
 	// Assure power table contains the power entry for the test subject

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -27,16 +27,16 @@ type participantTestSubject struct {
 	rng  *rand.Rand
 	host *gpbft.MockHost
 
-	id             gpbft.ActorID
-	pubKey         gpbft.PubKey
-	instance       uint64
-	networkName    gpbft.NetworkName
-	canonicalChain gpbft.ECChain
-	instanceData   *gpbft.InstanceData
-	powerTable     *gpbft.PowerTable
-	beacon         []byte
-	time           time.Time
-	delta          time.Duration
+	id               gpbft.ActorID
+	pubKey           gpbft.PubKey
+	instance         uint64
+	networkName      gpbft.NetworkName
+	canonicalChain   gpbft.ECChain
+	supplementalData *gpbft.SupplementalData
+	powerTable       *gpbft.PowerTable
+	beacon           []byte
+	time             time.Time
+	delta            time.Duration
 }
 
 func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *participantTestSubject {
@@ -51,18 +51,18 @@ func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *parti
 
 	rng := rand.New(rand.NewSource(seed))
 	subject := participantTestSubject{
-		t:              t,
-		rng:            rng,
-		id:             gpbft.ActorID(rng.Uint64()),
-		pubKey:         generateRandomBytes(rng),
-		delta:          delta,
-		instance:       instance,
-		networkName:    "fish",
-		canonicalChain: canonicalChain,
-		instanceData:   new(gpbft.InstanceData),
-		powerTable:     gpbft.NewPowerTable(),
-		beacon:         generateRandomBytes(rng),
-		time:           time.Now(),
+		t:                t,
+		rng:              rng,
+		id:               gpbft.ActorID(rng.Uint64()),
+		pubKey:           generateRandomBytes(rng),
+		delta:            delta,
+		instance:         instance,
+		networkName:      "fish",
+		canonicalChain:   canonicalChain,
+		supplementalData: new(gpbft.SupplementalData),
+		powerTable:       gpbft.NewPowerTable(),
+		beacon:           generateRandomBytes(rng),
+		time:             time.Now(),
 	}
 
 	// Assure power table contains the power entry for the test subject
@@ -84,7 +84,7 @@ func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *parti
 
 func (pt *participantTestSubject) expectBeginInstance() {
 	// Prepare the test host.
-	pt.host.On("GetProposalForInstance", pt.instance).Return(pt.instanceData, pt.canonicalChain, nil)
+	pt.host.On("GetProposalForInstance", pt.instance).Return(pt.supplementalData, pt.canonicalChain, nil)
 	pt.host.On("GetCommitteeForInstance", pt.instance).Return(pt.powerTable, pt.beacon, nil)
 	pt.host.On("Time").Return(pt.time)
 	pt.host.On("NetworkName").Return(pt.networkName).Maybe()
@@ -269,8 +269,8 @@ func TestParticipant(t *testing.T) {
 			t.Run("on zero canonical chain", func(t *testing.T) {
 				subject := newParticipantTestSubject(t, seed, 0)
 				var zeroChain gpbft.ECChain
-				emptyInstanceData := new(gpbft.InstanceData)
-				subject.host.On("GetProposalForInstance", subject.instance).Return(emptyInstanceData, zeroChain, nil)
+				emptySupplementalData := new(gpbft.SupplementalData)
+				subject.host.On("GetProposalForInstance", subject.instance).Return(emptySupplementalData, zeroChain, nil)
 				require.ErrorContains(t, subject.Start(), "cannot be zero-valued")
 				subject.assertHostExpectations()
 				subject.requireNotStarted()
@@ -278,8 +278,8 @@ func TestParticipant(t *testing.T) {
 			t.Run("on invalid canonical chain", func(t *testing.T) {
 				subject := newParticipantTestSubject(t, seed, 0)
 				invalidChain := gpbft.ECChain{gpbft.TipSet{}}
-				emptyInstanceData := new(gpbft.InstanceData)
-				subject.host.On("GetProposalForInstance", subject.instance).Return(emptyInstanceData, invalidChain, nil)
+				emptySupplementalData := new(gpbft.SupplementalData)
+				subject.host.On("GetProposalForInstance", subject.instance).Return(emptySupplementalData, invalidChain, nil)
 				require.ErrorContains(t, subject.Start(), "invalid canonical chain")
 				subject.assertHostExpectations()
 				subject.requireNotStarted()
@@ -287,8 +287,8 @@ func TestParticipant(t *testing.T) {
 			t.Run("on failure to fetch chain", func(t *testing.T) {
 				subject := newParticipantTestSubject(t, seed, 0)
 				invalidChain := gpbft.ECChain{gpbft.TipSet{}}
-				emptyInstanceData := new(gpbft.InstanceData)
-				subject.host.On("GetProposalForInstance", subject.instance).Return(emptyInstanceData, invalidChain, errors.New("fish"))
+				emptySupplementalData := new(gpbft.SupplementalData)
+				subject.host.On("GetProposalForInstance", subject.instance).Return(emptySupplementalData, invalidChain, errors.New("fish"))
 				require.ErrorContains(t, subject.Start(), "fish")
 				subject.assertHostExpectations()
 				subject.requireNotStarted()
@@ -301,10 +301,10 @@ func TestParticipant(t *testing.T) {
 					PowerTable:  []byte("pt"),
 					Commitments: [32]byte{},
 				}}
-				instanceData := &gpbft.InstanceData{
+				supplementalData := &gpbft.SupplementalData{
 					PowerTable: chain[0].PowerTable,
 				}
-				subject.host.On("GetProposalForInstance", subject.instance).Return(instanceData, chain, nil)
+				subject.host.On("GetProposalForInstance", subject.instance).Return(supplementalData, chain, nil)
 				subject.host.On("GetCommitteeForInstance", subject.instance).Return(nil, nil, errors.New("fish"))
 				require.ErrorContains(t, subject.Start(), "fish")
 				subject.assertHostExpectations()

--- a/gpbft/signature_test.go
+++ b/gpbft/signature_test.go
@@ -19,7 +19,7 @@ func TestPayloadMarshalForSigning(t *testing.T) {
 		Step:     3,
 		Data: gpbft.InstanceData{
 			Commitments: [32]byte{0x42},
-			PowerTable:  [32]byte{0x43},
+			PowerTable:  []byte{0x43},
 		},
 		Value: nil, // not valid in f3, but an empty merkle-tree is defined to hash to all zeros.
 	}).MarshalForSigning(nn)
@@ -29,8 +29,8 @@ func TestPayloadMarshalForSigning(t *testing.T) {
 	assert.Equal(t, binary.BigEndian.Uint64(encoded[16:24]), uint64(2)) // round
 	assert.Equal(t, binary.BigEndian.Uint64(encoded[24:32]), uint64(1)) // instance (32-byte right aligned)
 	assert.EqualValues(t, encoded[32:64], [32]byte{0x42})               // commitments root
-	assert.EqualValues(t, encoded[64:96], [32]byte{0x43})               // next power table
-	assert.EqualValues(t, encoded[96:128], [32]byte{})                  // tipsets
+	assert.EqualValues(t, encoded[64:96], [32]byte{})                   // tipsets
+	assert.EqualValues(t, encoded[96:128], [32]byte{0x43})              // next power table
 
 	// Simulate a signe decide message, the one we'll need to verify as a part of finality certificates.
 	encoded = (&gpbft.Payload{

--- a/gpbft/signature_test.go
+++ b/gpbft/signature_test.go
@@ -18,7 +18,7 @@ func TestPayloadMarshalForSigning(t *testing.T) {
 		Instance: 1,
 		Round:    2,
 		Step:     3,
-		Data: gpbft.InstanceData{
+		SupplementalData: gpbft.SupplementalData{
 			Commitments: [32]byte{0x42},
 			PowerTable:  powerTableCid,
 		},
@@ -38,7 +38,7 @@ func TestPayloadMarshalForSigning(t *testing.T) {
 		Instance: 29,
 		Round:    0,
 		Step:     gpbft.DECIDE_PHASE,
-		Data: gpbft.InstanceData{
+		SupplementalData: gpbft.SupplementalData{
 			Commitments: [32]byte{},
 			PowerTable:  powerTableCid,
 		},

--- a/gpbft/signature_test.go
+++ b/gpbft/signature_test.go
@@ -13,39 +13,45 @@ import (
 
 func TestPayloadMarshalForSigning(t *testing.T) {
 	nn := gpbft.NetworkName("filecoin")
+	powerTableCid := gpbft.MakeCid([]byte("foo"))
 	encoded := (&gpbft.Payload{
 		Instance: 1,
 		Round:    2,
 		Step:     3,
 		Data: gpbft.InstanceData{
 			Commitments: [32]byte{0x42},
-			PowerTable:  []byte{0x43},
+			PowerTable:  powerTableCid,
 		},
 		Value: nil, // not valid in f3, but an empty merkle-tree is defined to hash to all zeros.
 	}).MarshalForSigning(nn)
-	require.Len(t, encoded, 128)
+	require.Len(t, encoded, 96+len(powerTableCid))
 	assert.Equal(t, encoded[:15], []byte("GPBFT:filecoin:"))            // separators
 	assert.Equal(t, encoded[15], uint8(3))                              // step
 	assert.Equal(t, binary.BigEndian.Uint64(encoded[16:24]), uint64(2)) // round
 	assert.Equal(t, binary.BigEndian.Uint64(encoded[24:32]), uint64(1)) // instance (32-byte right aligned)
 	assert.EqualValues(t, encoded[32:64], [32]byte{0x42})               // commitments root
 	assert.EqualValues(t, encoded[64:96], [32]byte{})                   // tipsets
-	assert.EqualValues(t, encoded[96:128], [32]byte{0x43})              // next power table
+	assert.EqualValues(t, encoded[96:], powerTableCid)                  // next power table
 
-	// Simulate a signe decide message, the one we'll need to verify as a part of finality certificates.
+	// Simulate a signed decide message, the one we'll need to verify as a part of finality certificates.
 	encoded = (&gpbft.Payload{
 		Instance: 29,
 		Round:    0,
 		Step:     gpbft.DECIDE_PHASE,
-		Value:    nil, // not valid in f3, but an empty merkle-tree is defined to hash to all zeros.
+		Data: gpbft.InstanceData{
+			Commitments: [32]byte{},
+			PowerTable:  powerTableCid,
+		},
+		Value: nil, // not valid in f3, but an empty merkle-tree is defined to hash to all zeros.
 	}).MarshalForSigning(nn)
-	expected := make([]byte, 128)
+	expected := make([]byte, 96)
 
 	// We expect it to be prefixed with "GPBFT:filecoin:\x05
 	copy(expected, []byte("GPBFT:filecoin:\x05"))
 
 	// We expect the instance to be encoded in the last 8 bytes, 32-byte right-aligned.
 	expected[31] = 29
+	expected = append(expected, powerTableCid...)
 
 	assert.Equal(t, expected, encoded)
 }

--- a/host.go
+++ b/host.go
@@ -151,6 +151,11 @@ func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable,
 	return table, []byte{'A'}, nil
 }
 
+func (h *gpbftHost) GetDataForInstance(instance uint64) (*gpbft.InstanceData, error) {
+	// TODO: use lookback to return the correct next power table commitment and commitments hash.
+	return new(gpbft.InstanceData), nil
+}
+
 // Returns the network's name (for signature separation)
 func (h *gpbftHost) NetworkName() gpbft.NetworkName {
 	return h.runner.manifest.NetworkName

--- a/host.go
+++ b/host.go
@@ -125,13 +125,12 @@ func (h *gpbftRunner) deliverMessage(msg *gpbft.GMessage) error {
 
 // Returns inputs to the next GPBFT instance.
 // These are:
-// - the EC chain to propose,
-// - the power table specifying the participants,
-// - the beacon value for generating tickets.
+// - the supplemental data.
+// - the EC chain to propose.
 // These will be used as input to a subsequent instance of the protocol.
 // The chain should be a suffix of the last chain notified to the host via
 // ReceiveDecision (or known to be final via some other channel).
-func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.InstanceData, gpbft.ECChain, error) {
+func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
 	// TODO: this is just a complete fake
 	ts := sim.NewTipSetGenerator(1)
 	chain, err := gpbft.NewChain(gpbft.TipSet{Epoch: 0, Key: ts.Sample()}, gpbft.TipSet{Epoch: 1, Key: ts.Sample()})
@@ -140,7 +139,7 @@ func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.InstanceData
 	}
 
 	// TODO: use lookback to return the correct next power table commitment and commitments hash.
-	return new(gpbft.InstanceData), chain, nil
+	return new(gpbft.SupplementalData), chain, nil
 }
 
 func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable, []byte, error) {

--- a/host.go
+++ b/host.go
@@ -131,15 +131,16 @@ func (h *gpbftRunner) deliverMessage(msg *gpbft.GMessage) error {
 // These will be used as input to a subsequent instance of the protocol.
 // The chain should be a suffix of the last chain notified to the host via
 // ReceiveDecision (or known to be final via some other channel).
-func (h *gpbftHost) GetChainForInstance(instance uint64) (gpbft.ECChain, error) {
+func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.InstanceData, gpbft.ECChain, error) {
 	// TODO: this is just a complete fake
 	ts := sim.NewTipSetGenerator(1)
 	chain, err := gpbft.NewChain(gpbft.TipSet{Epoch: 0, Key: ts.Sample()}, gpbft.TipSet{Epoch: 1, Key: ts.Sample()})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return chain, nil
+	// TODO: use lookback to return the correct next power table commitment and commitments hash.
+	return new(gpbft.InstanceData), chain, nil
 }
 
 func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable, []byte, error) {
@@ -149,11 +150,6 @@ func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable,
 		return nil, nil, err
 	}
 	return table, []byte{'A'}, nil
-}
-
-func (h *gpbftHost) GetDataForInstance(instance uint64) (*gpbft.InstanceData, error) {
-	// TODO: use lookback to return the correct next power table commitment and commitments hash.
-	return new(gpbft.InstanceData), nil
 }
 
 // Returns the network's name (for signature separation)

--- a/sim/host.go
+++ b/sim/host.go
@@ -54,11 +54,11 @@ func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg Storag
 	}
 }
 
-func (v *simHost) GetProposalForInstance(instance uint64) (*gpbft.InstanceData, gpbft.ECChain, error) {
+func (v *simHost) GetProposalForInstance(instance uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
 	// Use the head of latest agreement chain as the base of next.
 	// TODO: use lookback to return the correct next power table commitment and commitments hash.
 	chain := v.ecg.GenerateECChain(instance, *v.ecChain.Head(), v.id)
-	return new(gpbft.InstanceData), chain, nil
+	return new(gpbft.SupplementalData), chain, nil
 }
 
 func (v *simHost) GetCommitteeForInstance(instance uint64) (power *gpbft.PowerTable, beacon []byte, err error) {

--- a/sim/host.go
+++ b/sim/host.go
@@ -54,10 +54,11 @@ func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg Storag
 	}
 }
 
-func (v *simHost) GetChainForInstance(instance uint64) (gpbft.ECChain, error) {
+func (v *simHost) GetProposalForInstance(instance uint64) (*gpbft.InstanceData, gpbft.ECChain, error) {
 	// Use the head of latest agreement chain as the base of next.
+	// TODO: use lookback to return the correct next power table commitment and commitments hash.
 	chain := v.ecg.GenerateECChain(instance, *v.ecChain.Head(), v.id)
-	return chain, nil
+	return new(gpbft.InstanceData), chain, nil
 }
 
 func (v *simHost) GetCommitteeForInstance(instance uint64) (power *gpbft.PowerTable, beacon []byte, err error) {
@@ -66,11 +67,6 @@ func (v *simHost) GetCommitteeForInstance(instance uint64) (power *gpbft.PowerTa
 		return nil, nil, ErrInstanceUnavailable
 	}
 	return i.PowerTable, i.Beacon, nil
-}
-
-func (v *simHost) GetDataForInstance(instance uint64) (*gpbft.InstanceData, error) {
-	// TODO: use lookback to return the correct next power table commitment and commitments hash.
-	return new(gpbft.InstanceData), nil
 }
 
 func (v *simHost) SetAlarm(at time.Time) {

--- a/sim/host.go
+++ b/sim/host.go
@@ -68,6 +68,11 @@ func (v *simHost) GetCommitteeForInstance(instance uint64) (power *gpbft.PowerTa
 	return i.PowerTable, i.Beacon, nil
 }
 
+func (v *simHost) GetDataForInstance(instance uint64) (*gpbft.InstanceData, error) {
+	// TODO: use lookback to return the correct next power table commitment and commitments hash.
+	return new(gpbft.InstanceData), nil
+}
+
 func (v *simHost) SetAlarm(at time.Time) {
 	v.sim.network.SetAlarm(v.id, at)
 }

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -114,8 +114,8 @@ func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Pa
 	_ = binary.Write(&buf, binary.BigEndian, p.Step)
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
 	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
-	_, _ = buf.Write(p.Data.Commitments[:])
-	_, _ = buf.Write(p.Data.PowerTable)
+	_, _ = buf.Write(p.SupplementalData.Commitments[:])
+	_, _ = buf.Write(p.SupplementalData.PowerTable)
 	_ = binary.Write(&buf, binary.BigEndian, uint32(len(p.Value)))
 	for i := range p.Value {
 		ts := &p.Value[i]

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -114,6 +114,8 @@ func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Pa
 	_ = binary.Write(&buf, binary.BigEndian, p.Step)
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
 	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
+	_, _ = buf.Write(p.Data.Commitments[:])
+	_, _ = buf.Write(p.Data.PowerTable[:])
 	_ = binary.Write(&buf, binary.BigEndian, uint32(len(p.Value)))
 	for i := range p.Value {
 		ts := &p.Value[i]

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -115,7 +115,7 @@ func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Pa
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
 	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
 	_, _ = buf.Write(p.Data.Commitments[:])
-	_, _ = buf.Write(p.Data.PowerTable[:])
+	_, _ = buf.Write(p.Data.PowerTable)
 	_ = binary.Write(&buf, binary.BigEndian, uint32(len(p.Value)))
 	for i := range p.Value {
 		ts := &p.Value[i]


### PR DESCRIPTION
In addition to committing to a power table in each tipset, agree on:

1. The next power table (used to validate the next instance).
2. Arbitrary commitments (will be used by F3 for snark-friendly power tables, and other fields).

fixes #257