### PR TITLE
Maximise test parallelism and reduce duplicate code

### DIFF
--- a/test/absent_test.go
+++ b/test/absent_test.go
@@ -14,19 +14,19 @@ func FuzzAbsentAdversary(f *testing.F) {
 	f.Add(-56)
 	f.Add(22)
 	f.Add(0)
-	f.Fuzz(absentAdversaryTest)
-}
-
-func absentAdversaryTest(t *testing.T, latencySeed int) {
-	sm, err := sim.NewSimulation(
-		asyncOptions(latencySeed,
-			// Total network size of 3 + 1, where the adversary has 1/4 of power.
-			sim.AddHonestParticipants(
-				3,
-				sim.NewUniformECChainGenerator(tipSetGeneratorSeed, 1, 10),
-				uniformOneStoragePower),
-			sim.WithAdversary(adversary.NewAbsentGenerator(oneStoragePower)),
-		)...)
-	require.NoError(t, err)
-	require.NoErrorf(t, sm.Run(1, maxRounds), "%s", sm.Describe())
+	f.Fuzz(func(t *testing.T, latencySeed int) {
+		t.Parallel()
+		sm, err := sim.NewSimulation(
+			asyncOptions(latencySeed,
+				// Total network size of 3 + 1, where the adversary has 1/4 of power.
+				sim.AddHonestParticipants(
+					3,
+					sim.NewUniformECChainGenerator(tipSetGeneratorSeed, 1, 10),
+					uniformOneStoragePower),
+				sim.WithAdversary(adversary.NewAbsentGenerator(oneStoragePower)),
+			)...)
+		require.NoError(t, err)
+		require.NoErrorf(t, sm.Run(1, maxRounds), "%s", sm.Describe())
+	},
+	)
 }

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -18,12 +18,6 @@ func TestHonestMultiInstance_Agreement(t *testing.T) {
 		latencySeed    = testRNGSeed * 7
 		maxHonestCount = 10
 	)
-	// The number of honest participants for which every table test is executed.
-	participantCounts := make([]int, maxHonestCount)
-	for i := range participantCounts {
-		participantCounts[i] = i + 1
-	}
-
 	tests := []struct {
 		name    string
 		options []sim.Option
@@ -37,15 +31,17 @@ func TestHonestMultiInstance_Agreement(t *testing.T) {
 			options: asyncOptions(latencySeed),
 		},
 	}
-	for _, participantCount := range participantCounts {
-		participantCount := participantCount
-		for _, test := range tests {
-			test := test
-			name := fmt.Sprintf("%s %d", test.name, participantCount)
-			t.Run(name, func(t *testing.T) {
-				multiAgreementTest(t, testRNGSeed, participantCount, instanceCount, maxRounds, test.options...)
-			})
-		}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			for hc := 1; hc <= maxHonestCount; hc++ {
+				hc := hc
+				t.Run(fmt.Sprintf("%d", hc), func(t *testing.T) {
+					multiAgreementTest(t, testRNGSeed, hc, instanceCount, maxRounds, test.options...)
+				})
+			}
+		})
 	}
 }
 

--- a/test/spam_test.go
+++ b/test/spam_test.go
@@ -36,12 +36,13 @@ func TestSpamAdversary(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		for _, hc := range honestCounts {
-			test := test
 			hc := hc
 			lessThanOneThirdAdversaryStoragePower := gpbft.NewStoragePower(int64(max(hc/3-1, 1)))
 			name := fmt.Sprintf("%s honest count %d", test.name, hc)
 			t.Run(name, func(t *testing.T) {
+				t.Parallel()
 				ecChainGenerator := sim.NewUniformECChainGenerator(651651, 1, 10)
 				sm, err := sim.NewSimulation(
 					sim.WithLatencyModeler(func() (latency.Model, error) {

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -37,6 +37,7 @@ func TestWitholdCommitAdversary(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			nearSynchrony := func() (latency.Model, error) {
 				return latency.NewLogNormal(1413, 10*time.Millisecond), nil
 			}


### PR DESCRIPTION
Maximise the degree of parallel test execution by explicitly marking
remaining table and fuzz tests as parallel.

Refactor tests to remove duplicate code and over-refactors of functions
that are only used by the fuzz tests.
