### PR TITLE
Skip ahead to future rounds when justified

### DIFF
--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -243,8 +243,28 @@ func (i *instance) Receive(msg *GMessage) error {
 }
 
 func (i *instance) ReceiveAlarm() error {
+	phaseBeforeAlarm := i.phase
 	if err := i.tryCurrentPhase(); err != nil {
 		return fmt.Errorf("failed completing protocol phase: %w", err)
+	}
+
+	// Check if the alarm ended QUALITY phase, i.e. transition from QUALITY to PREPARE phase.
+	qualityPhaseEnded := phaseBeforeAlarm == QUALITY_PHASE && i.phase == PREPARE_PHASE
+	if qualityPhaseEnded {
+		// Check if there are any eligible future rounds to which to skip.
+
+		// TODO: Potential optimisations:
+		//        1) Consider preferring higher rounds to jump to first. FIP does not specify
+		//           any constraints here.
+		//        2) Build an incremental index of round candidates as messages arrive, allowing
+		//           for efficient jumping to the target round without scanning all state history.
+		for round, state := range i.rounds {
+			if round > i.round {
+				if chain, justification, skipToRound := i.shouldSkipToRound(round, state); skipToRound {
+					i.skipToRound(round, chain, justification)
+				}
+			}
+		}
 	}
 
 	// A phase may have been successfully completed.
@@ -341,6 +361,11 @@ func (i *instance) receiveOne(msg *GMessage) error {
 		i.log("unexpected message %v", msg)
 	}
 
+	// Check whether the instance should skip ahead to future round.
+	if chain, justification, skip := i.shouldSkipToRound(msg.Vote.Round, round); skip {
+		i.skipToRound(msg.Vote.Round, chain, justification)
+		return nil
+	}
 	// Every COMMIT phase stays open to new messages even after the protocol moves on to
 	// a new round. Late-arriving COMMITS can still (must) cause a local decision, *in that round*.
 	// Try to complete the COMMIT phase for the round specified by the message.
@@ -349,6 +374,40 @@ func (i *instance) receiveOne(msg *GMessage) error {
 	}
 	// Try to complete the current phase in the current round.
 	return i.tryCurrentPhase()
+}
+
+// shouldSkipToRound determines whether to skip to round, and justification
+// either for a value to sway to, or of COMMIT bottom to justify our own
+// proposal. Otherwise, it returns nil chain, nil justification and false.
+//
+// See: skipToRound.
+func (i *instance) shouldSkipToRound(round uint64, state *roundState) (ECChain, *Justification, bool) {
+
+	// Check if the given round is ahead of current round and this instance is not in
+	// QUALITY nor DECIDE phase as dedicated by FIP-0086.
+	//
+	// Note that sipping ahead from QUALITY phase does not violate the correctness
+	// proof of gPBFT. The fact that QUALITY always terminates for a participant
+	// means this participant will eventually jump, but it may do it earlier.
+	// However, if a node skips to future rounds without executing the QUALITY phase
+	// it will only help reaching consensus for bottom.
+	//
+	// Future work may consider skipping ahead from QUALITY for faster census in
+	// certain scenarios. For now, this implementation conforms to the FIP.
+	if round <= i.round || i.phase == QUALITY_PHASE || i.phase == DECIDE_PHASE {
+		return nil, nil, false
+	}
+	proposal := state.converged.FindMaxTicketProposal(i.powerTable)
+	if proposal.Justification == nil {
+		// FindMaxTicketProposal returns a zero-valued ConvergeValue if no such ticket is
+		// found. Hence the check for nil. Otherwise, if found such ConvergeValue must
+		// have a non-nil justification.
+		return nil, nil, false
+	}
+	if !state.prepared.ReceivedFromWeakQuorum() {
+		return nil, nil, false
+	}
+	return proposal.Chain, proposal.Justification, true
 }
 
 // Attempts to complete the current phase and round.
@@ -567,26 +626,15 @@ func (i *instance) tryQuality() error {
 	return nil
 }
 
-func (i *instance) beginConverge() {
-	i.phase = CONVERGE_PHASE
-
-	i.phaseTimeout = i.alarmAfterSynchrony()
-	prevRoundState := i.roundState(i.round - 1)
-
-	// Proposal was updated at the end of COMMIT phase to be some value for which
-	// this node received a COMMIT message (bearing justification), if there were any.
-	// If there were none, there must have been a strong quorum for bottom instead.
-	var justification *Justification
-	if quorum, ok := prevRoundState.committed.FindStrongQuorumFor(""); ok {
-		// Build justification for strong quorum of COMMITs for bottom in the previous round.
-		justification = i.buildJustification(quorum, i.round-1, COMMIT_PHASE, ECChain{})
-	} else {
-		// Extract the justification received from some participant (possibly this node itself).
-		justification, ok = prevRoundState.committed.receivedJustification[i.proposal.Key()]
-		if !ok {
-			panic("beginConverge called but no justification for proposal")
-		}
+// beginConverge initiates CONVERGE_PHASE justified by the given justification.
+func (i *instance) beginConverge(justification *Justification) {
+	if justification.Vote.Round != i.round-1 {
+		// For safety assert that the justification given blongs to the right round
+		panic("justification for which to begin converge does not belong to expected round")
 	}
+	i.phase = CONVERGE_PHASE
+	i.phaseTimeout = i.alarmAfterSynchrony()
+
 	_, pubkey := i.powerTable.Get(i.participant.id)
 	ticket, err := MakeTicket(i.beacon, i.instanceID, i.round, pubkey, i.participant.host)
 	if err != nil {
@@ -790,7 +838,43 @@ func (i *instance) roundState(r uint64) *roundState {
 func (i *instance) beginNextRound() {
 	i.round += 1
 	i.log("moving to round %d with %s", i.round, i.proposal.String())
-	i.beginConverge()
+
+	prevRoundState := i.roundState(i.round - 1)
+	// Proposal was updated at the end of COMMIT phase to be some value for which
+	// this node received a COMMIT message (bearing justification), if there were any.
+	// If there were none, there must have been a strong quorum for bottom instead.
+	var justification *Justification
+	if quorum, ok := prevRoundState.committed.FindStrongQuorumFor(""); ok {
+		// Build justification for strong quorum of COMMITs for bottom in the previous round.
+		justification = i.buildJustification(quorum, i.round-1, COMMIT_PHASE, ECChain{})
+	} else {
+		// Extract the justification received from some participant (possibly this node itself).
+		justification, ok = prevRoundState.committed.receivedJustification[i.proposal.Key()]
+		if !ok {
+			panic("beginConverge called but no justification for proposal")
+		}
+	}
+
+	i.beginConverge(justification)
+}
+
+// skipToRound jumps ahead to the given round by initiating CONVERGE with the given justification.
+//
+// See shouldSkipToRound.
+func (i *instance) skipToRound(round uint64, chain ECChain, justification *Justification) {
+	i.log("skipping from round %d to round %d with %s", i.round, round, i.proposal.String())
+	i.round = round
+
+	// TODO: Also update rebroadcast timeout once implemented according to the
+	//       following pseudocode borrowed from the FIP:
+	//          107:      timeout_rebroadcast ← max(timeout+1, timeout_rebroadcast)
+
+	if justification.Vote.Step == PREPARE_PHASE {
+		i.log("⚠️ swaying from %s to %s by skip to round %d", &i.proposal, chain, i.round)
+		i.candidates = append(i.candidates, chain)
+		i.proposal = chain
+	}
+	i.beginConverge(justification)
 }
 
 // Returns whether a chain is acceptable as a proposal for this instance to vote for.
@@ -1009,6 +1093,12 @@ func (q *quorumState) ListAllValues() []ECChain {
 // Checks whether at least one message has been senders from a strong quorum of senders.
 func (q *quorumState) ReceivedFromStrongQuorum() bool {
 	return hasStrongQuorum(q.sendersTotalPower, q.powerTable.Total)
+}
+
+// ReceivedFromWeakQuorum checks whether at least one message has been received
+// from a weak quorum of senders.
+func (q *quorumState) ReceivedFromWeakQuorum() bool {
+	return hasWeakQuorum(q.sendersTotalPower, q.powerTable.Total)
 }
 
 // Checks whether a chain has reached a strong quorum.

--- a/sim/adversary/deny.go
+++ b/sim/adversary/deny.go
@@ -1,0 +1,65 @@
+package adversary
+
+import (
+	"time"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+var _ Receiver = (*Deny)(nil)
+
+// Deny adversary denies all messages to/from a given set of participants for a
+// configured duration of time.
+type Deny struct {
+	id          gpbft.ActorID
+	host        Host
+	targetsByID map[gpbft.ActorID]struct{}
+	gst         time.Time
+}
+
+func NewDeny(id gpbft.ActorID, host Host, denialDuration time.Duration, targets ...gpbft.ActorID) *Deny {
+	targetsByID := make(map[gpbft.ActorID]struct{})
+	for _, target := range targets {
+		targetsByID[target] = struct{}{}
+	}
+	return &Deny{
+		id:          id,
+		host:        host,
+		targetsByID: targetsByID,
+		gst:         time.Time{}.Add(denialDuration),
+	}
+}
+
+func NewDenyGenerator(power *gpbft.StoragePower, denialDuration time.Duration, targets ...gpbft.ActorID) Generator {
+	return func(id gpbft.ActorID, host Host) *Adversary {
+		return &Adversary{
+			Receiver: NewDeny(id, host, denialDuration, targets...),
+			Power:    power,
+		}
+	}
+}
+
+func (d *Deny) ID() gpbft.ActorID {
+	return d.id
+}
+
+func (d *Deny) AllowMessage(from gpbft.ActorID, to gpbft.ActorID, msg gpbft.GMessage) bool {
+	// Deny all messages to or from targets until Global Stabilisation Time has
+	// elapsed, except messages to self.
+	switch {
+	case from == to, d.host.Time().After(d.gst):
+		return true
+	default:
+		return !(d.isTargeted(from) || d.isTargeted(to))
+	}
+}
+
+func (d *Deny) isTargeted(id gpbft.ActorID) bool {
+	_, found := d.targetsByID[id]
+	return found
+}
+
+func (*Deny) Start() error                                       { return nil }
+func (*Deny) ValidateMessage(*gpbft.GMessage) (bool, error)      { return true, nil }
+func (*Deny) ReceiveMessage(*gpbft.GMessage, bool) (bool, error) { return true, nil }
+func (*Deny) ReceiveAlarm() error                                { return nil }

--- a/sim/options.go
+++ b/sim/options.go
@@ -49,6 +49,7 @@ type options struct {
 	baseChain          *gpbft.ECChain
 	adversaryGenerator adversary.Generator
 	adversaryCount     uint64
+	ignoreConsensusFor []gpbft.ActorID
 }
 
 type participantArchetype struct {
@@ -173,6 +174,16 @@ func WithTraceLevel(i int) Option {
 func WithGlobalStabilizationTime(d time.Duration) Option {
 	return func(o *options) error {
 		o.globalStabilizationTime = d
+		return nil
+	}
+}
+
+// WithIgnoreConsensusFor sets the participant IDs for which the simulation will
+// not error if they do not reach consensus at the end of each instance. Defaults
+// to none.
+func WithIgnoreConsensusFor(id ...gpbft.ActorID) Option {
+	return func(o *options) error {
+		o.ignoreConsensusFor = id
 		return nil
 	}
 }

--- a/test/skip_to_rounds_test.go
+++ b/test/skip_to_rounds_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/sim"
+	"github.com/filecoin-project/go-f3/sim/adversary"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHonest_JumpsRounds(t *testing.T) {
+	t.Parallel()
+	// TODO: enable this test once message rebroadcast is implemented.
+	t.Skip("requires re-broadcast implementation to pass")
+
+	const (
+		instanceCount = 2000
+		maxRounds     = 20
+		denialTarget  = 0
+		gst           = 100 * EcEpochDuration
+	)
+
+	ecChainGenerator := sim.NewUniformECChainGenerator(54445, 1, 5)
+	sm, err := sim.NewSimulation(
+		asyncOptions(2342342,
+			sim.AddHonestParticipants(6, ecChainGenerator, uniformOneStoragePower),
+			sim.WithAdversary(adversary.NewDenyGenerator(oneStoragePower, gst, denialTarget)),
+			sim.WithGlobalStabilizationTime(gst),
+			sim.WithIgnoreConsensusFor(denialTarget),
+		)...,
+	)
+	require.NoError(t, err)
+	require.NoErrorf(t, sm.Run(instanceCount, maxRounds), "%s", sm.Describe())
+	chain := ecChainGenerator.GenerateECChain(instanceCount-1, gpbft.TipSet{}, math.MaxUint64)
+	requireConsensusAtInstance(t, sm, instanceCount-1, *chain.Head())
+}


### PR DESCRIPTION
Implement a rebroadcast protocol improvement where upon receiving sufficient justification a participant jumps ahead to future rounds. Justification from a future rounds is considered sufficient when the participant receives:
 * at least one `CONVERGE` message, and
 * a weak quorum of `PREPARE` messages

for that round.

The changes here introduce a test that should trigger skipping to future rounds once reboradcast is implemented. The test uses a `Deny` adversary where all messages to and from a set of targets are dropped until GST has elapsed. For now, however, the test is skipped.

Fixes #241