### PR TITLE
Adjust Fuzz honest multi-instance to avoid intermittent failures

### DIFF
--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -86,10 +86,12 @@ func FuzzHonestMultiInstance_SyncAgreement(f *testing.F) {
 
 func FuzzHonestMultiInstance_AsyncAgreement(f *testing.F) {
 	const (
-		instanceCount = 4000
-		honestCount   = 5
+		instanceCount = 5000
+		honestCount   = 4
 	)
 	f.Add(-7)
+	f.Add(31)
+	f.Add(33)
 	f.Fuzz(func(t *testing.T, seed int) {
 		multiAgreementTest(t, seed, honestCount, instanceCount, maxRounds*2, asyncOptions(seed)...)
 	})
@@ -103,7 +105,7 @@ func multiAgreementTest(t *testing.T, seed int, honestCount int, instanceCount u
 			honestCount,
 			// Generate a random EC chain for all participant that changes randomly at each
 			// instance.
-			sim.NewUniformECChainGenerator(rng.Uint64(), 1, 10), uniformOneStoragePower),
+			sim.NewUniformECChainGenerator(rng.Uint64(), 1, 4), uniformOneStoragePower),
 	)...)
 	require.NoError(t, err)
 	require.NoErrorf(t, sm.Run(instanceCount, maxRounds), "%s", sm.Describe())


### PR DESCRIPTION
`FuzzHonestMultiInstance_AsyncAgreement` intermittently fails on CI, most likely due to taking too long to complete a test.

To avoid intermittent failures:
* change the honest multi instance tests to cover incremental network sizes, up to 4
* reduce the length of randomly generated EC chains at each instance as this should not affect the test quality for what it is testing. But it should make it run faster due to less GC.

Additionally, add static corpus that failed locally after extended fuzz time to the fuzz test.

Fixes #251