### PR TITLE
Reduce GC during fuzz tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test/cover: GOTEST_ARGS=-coverprofile=coverage.txt -covermode=atomic -coverpkg=.
 .PHONY: test/cover
 
 fuzz: FUZZTIME ?= 10s # The duration to run fuzz testing, default to 10s if unset.
-fuzz: GOGC ?= 400 # Reduce GC frequency during testing, default to 200 if unset.
+fuzz: GOGC ?= 400 # Reduce GC frequency during testing, default to 400 if unset.
 fuzz: # List all fuzz tests across the repo, and run them one at a time with the configured fuzztime.
 	@set -e; \
 	go list ./... | while read -r package; do \

--- a/test/absent_test.go
+++ b/test/absent_test.go
@@ -21,7 +21,7 @@ func FuzzAbsentAdversary(f *testing.F) {
 				// Total network size of 3 + 1, where the adversary has 1/4 of power.
 				sim.AddHonestParticipants(
 					3,
-					sim.NewUniformECChainGenerator(tipSetGeneratorSeed, 1, 10),
+					sim.NewUniformECChainGenerator(tipSetGeneratorSeed, 1, 5),
 					uniformOneStoragePower),
 				sim.WithAdversary(adversary.NewAbsentGenerator(oneStoragePower)),
 			)...)

--- a/test/decide_test.go
+++ b/test/decide_test.go
@@ -27,7 +27,7 @@ func FuzzImmediateDecideAdversary(f *testing.F) {
 			asyncOptions(rng.Int(),
 				sim.AddHonestParticipants(
 					1,
-					sim.NewUniformECChainGenerator(rng.Uint64(), 1, 10),
+					sim.NewUniformECChainGenerator(rng.Uint64(), 1, 5),
 					uniformOneStoragePower),
 				sim.WithBaseChain(&baseChain),
 				// Add the adversary to the simulation with 3/4 of total power.

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -216,19 +216,19 @@ func FuzzHonest_SyncMajorityCommonPrefix(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int) {
 		t.Parallel()
 		rng := rand.New(rand.NewSource(int64(seed)))
-		majorityCommonPrefixGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 10, 20)
+		majorityCommonPrefixGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 1, 5)
 		sm, err := sim.NewSimulation(append(syncOptions(),
 			sim.AddHonestParticipants(20, sim.NewAppendingECChainGenerator(
 				majorityCommonPrefixGenerator,
-				sim.NewRandomECChainGenerator(rng.Uint64(), 1, 8),
+				sim.NewRandomECChainGenerator(rng.Uint64(), 1, 3),
 			), uniformOneStoragePower),
 			sim.AddHonestParticipants(5, sim.NewAppendingECChainGenerator(
-				sim.NewUniformECChainGenerator(rng.Uint64(), 1, 20),
-				sim.NewRandomECChainGenerator(rng.Uint64(), 5, 8),
+				sim.NewUniformECChainGenerator(rng.Uint64(), 1, 4),
+				sim.NewRandomECChainGenerator(rng.Uint64(), 2, 4),
 			), uniformOneStoragePower),
 			sim.AddHonestParticipants(1, sim.NewAppendingECChainGenerator(
-				sim.NewUniformECChainGenerator(rng.Uint64(), 10, 20),
-				sim.NewRandomECChainGenerator(rng.Uint64(), 2, 8),
+				sim.NewUniformECChainGenerator(rng.Uint64(), 1, 5),
+				sim.NewRandomECChainGenerator(rng.Uint64(), 1, 3),
 			), uniformOneStoragePower),
 		)...)
 		require.NoError(t, err)
@@ -258,19 +258,19 @@ func FuzzHonest_AsyncMajorityCommonPrefix(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int) {
 		t.Parallel()
 		rng := rand.New(rand.NewSource(int64(seed)))
-		majorityCommonPrefixGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 10, 20)
+		majorityCommonPrefixGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 1, 3)
 		sm, err := sim.NewSimulation(append(asyncOptions(rng.Int()),
 			sim.AddHonestParticipants(20, sim.NewAppendingECChainGenerator(
 				majorityCommonPrefixGenerator,
-				sim.NewRandomECChainGenerator(rng.Uint64(), 1, 8),
+				sim.NewRandomECChainGenerator(rng.Uint64(), 1, 4),
 			), uniformOneStoragePower),
 			sim.AddHonestParticipants(5, sim.NewAppendingECChainGenerator(
-				sim.NewUniformECChainGenerator(rng.Uint64(), 1, 20),
-				sim.NewRandomECChainGenerator(rng.Uint64(), 5, 8),
+				sim.NewUniformECChainGenerator(rng.Uint64(), 1, 4),
+				sim.NewRandomECChainGenerator(rng.Uint64(), 2, 3),
 			), uniformOneStoragePower),
 			sim.AddHonestParticipants(1, sim.NewAppendingECChainGenerator(
-				sim.NewUniformECChainGenerator(rng.Uint64(), 10, 20),
-				sim.NewRandomECChainGenerator(rng.Uint64(), 2, 8),
+				sim.NewUniformECChainGenerator(rng.Uint64(), 1, 3),
+				sim.NewRandomECChainGenerator(rng.Uint64(), 2, 3),
 			), uniformOneStoragePower),
 		)...)
 		require.NoError(t, err)

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -63,8 +63,8 @@ func FuzzHonestMultiInstance_AsyncDisagreement(f *testing.F) {
 		baseChain := generateECChain(t, tsg)
 		sm, err := sim.NewSimulation(asyncOptions(seed,
 			sim.WithBaseChain(&baseChain),
-			sim.AddHonestParticipants(honestCount/2, sim.NewUniformECChainGenerator(rand.Uint64(), 4, 10), uniformOneStoragePower),
-			sim.AddHonestParticipants(honestCount/2, sim.NewUniformECChainGenerator(rand.Uint64(), 1, 5), uniformOneStoragePower),
+			sim.AddHonestParticipants(honestCount/2, sim.NewUniformECChainGenerator(rand.Uint64(), 1, 3), uniformOneStoragePower),
+			sim.AddHonestParticipants(honestCount/2, sim.NewUniformECChainGenerator(rand.Uint64(), 2, 4), uniformOneStoragePower),
 		)...)
 		require.NoError(t, err)
 		require.NoErrorf(t, sm.Run(instanceCount, maxRounds), "%s", sm.Describe())
@@ -76,7 +76,7 @@ func FuzzHonestMultiInstance_AsyncDisagreement(f *testing.F) {
 func FuzzHonestMultiInstance_SyncAgreement(f *testing.F) {
 	const (
 		instanceCount = 4000
-		honestCount   = 5
+		honestCount   = 4
 	)
 	f.Add(-47)
 	f.Fuzz(func(t *testing.T, seed int) {
@@ -86,7 +86,7 @@ func FuzzHonestMultiInstance_SyncAgreement(f *testing.F) {
 
 func FuzzHonestMultiInstance_AsyncAgreement(f *testing.F) {
 	const (
-		instanceCount = 5000
+		instanceCount = 4000
 		honestCount   = 4
 	)
 	f.Add(-7)

--- a/test/power_evolution_test.go
+++ b/test/power_evolution_test.go
@@ -53,8 +53,8 @@ func storagePowerIncreaseMidSimulationTest(t *testing.T, seed int, instanceCount
 
 	tsg := sim.NewTipSetGenerator(tipSetGeneratorSeed)
 	baseChain := generateECChain(t, tsg)
-	groupOneEcGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 5, 10)
-	groupTwoEcGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 5, 10)
+	groupOneEcGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 1, 4)
+	groupTwoEcGenerator := sim.NewUniformECChainGenerator(rng.Uint64(), 1, 4)
 	sm, err := sim.NewSimulation(
 		append(o,
 			sim.WithBaseChain(&baseChain),
@@ -115,7 +115,7 @@ func FuzzStoragePower_AsyncDecreaseRevertsToBase(f *testing.F) {
 	f.Add(-44)
 	f.Add(11151)
 	f.Fuzz(func(t *testing.T, seed int) {
-		storagePowerDecreaseRevertsToBaseTest(t, seed, 100, maxRounds, asyncOptions(seed)...)
+		storagePowerDecreaseRevertsToBaseTest(t, seed, 100, maxRounds*2, asyncOptions(seed)...)
 	})
 }
 
@@ -138,7 +138,7 @@ func storagePowerDecreaseRevertsToBaseTest(t *testing.T, seed int, instanceCount
 			// decreasing by 1 per instance per participant.
 			sim.AddHonestParticipants(
 				10,
-				sim.NewUniformECChainGenerator(rng.Uint64(), 5, 10),
+				sim.NewUniformECChainGenerator(rng.Uint64(), 1, 5),
 				func(instance uint64, id gpbft.ActorID) *gpbft.StoragePower {
 					// Decrease storage power of each participant by 1 per instance.
 					// The plus one is there to avoid zero powered actors as it is an error.

--- a/test/repeat_test.go
+++ b/test/repeat_test.go
@@ -99,7 +99,7 @@ func FuzzRepeatAdversary(f *testing.F) {
 					sm, err := sim.NewSimulation(asyncOptions(rng.Int(),
 						sim.AddHonestParticipants(
 							hc,
-							sim.NewUniformECChainGenerator(rng.Uint64(), 1, 10),
+							sim.NewUniformECChainGenerator(rng.Uint64(), 1, 4),
 							uniformOneStoragePower),
 						sim.WithAdversary(adversary.NewRepeatGenerator(oneStoragePower, dist)),
 					)...)


### PR DESCRIPTION
Reduce GC by reducing the size of EC chain generated by the fuzz tests. The size of EC chain makes no difference to the coverage.

In one case reduce the honest count from 5 to 4 in order to avoid intermittent failures due to fuzz tests taking too long.