### PR TITLE
Make message validation safe for concurrent use.

### DIFF
--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -392,6 +392,7 @@ func (i *instance) tryCurrentPhase() error {
 // Checks message validity, including justification and signatures.
 // An invalid message can never become valid, so may be dropped.
 // This is a pure function and does not modify its arguments.
+// It must be safe for concurrent use.
 func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMessage) error {
 	// Check sender is eligible.
 	senderPower, senderPubKey := powerTable.Get(msg.Sender)


### PR DESCRIPTION
I'm interested in any suggestions of how to test this. I looked into the existing participant tests, but it seemed unlikely the mock is safe to use concurrently and difficult to test this without that. We could manually construct a harness. Is that worthwhile?

See #151