### PR TITLE
Fix race conditions and Run tests with race detection in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,23 @@ jobs:
               repo: context.repo.repo,
               body: 'Fuzz test failed on commit ${{ github.event.pull_request.head.sha }}. To troubleshoot locally, download the seed corpus using [GitHub CLI](https://cli.github.com) by running:\n```shell\ngh run download ${{ github.run_id }} -n testdata\n```\nAleternatively, download directly from [here](${{ steps.testdata-upload.outputs.artifact-url }}).'
             })
-
+  
+  test-race:
+    name: Test With Race Detector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Test with race detection
+        env:
+          # Run tests with race detector, excluding fuzz tests.
+          # Fuzz tests are excluded because they will otherwise
+          # take too long to complete.
+          GOTEST_ARGS: -race -run='^[^Fuzz]' -timeout=20m
+        run: make test
+  
   generate:
     name: Generate
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix a race condition in simulation signing package key generation.

Run tests with race detection enabled in a separate CI job to avoid
slowing down the regular tests as they take significantly longer to
finish.

Fixes #288