### PR TITLE
Extra power diff tests & validation

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -245,7 +245,7 @@ func ApplyPowerTableDiffs(prevPowerTable gpbft.PowerEntries, diffs ...[]PowerTab
 			// We assert this to make sure the finality certificate has a consistent power-table
 			// diff.
 			if i > 0 && d.ParticipantID <= lastActorId {
-				return nil, xerrors.Errorf("diff %d not sorted by participant ID")
+				return nil, xerrors.Errorf("diff %d not sorted by participant ID", j)
 			}
 
 			// Empty power diffs aren't allowed.

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -101,6 +101,42 @@ func TestPowerTableDiff(t *testing.T) {
 		}
 	}
 
+	// explicit transitions
+	{
+		// Add power
+		newPowerTable, err := certs.ApplyPowerTableDiffs(powerTable, []certs.PowerTableDelta{{
+			ParticipantID: powerTable[0].ID,
+			PowerDelta:    gpbft.NewStoragePower(1),
+		}})
+		require.NoError(t, err)
+		require.Equal(t,
+			new(gpbft.StoragePower).Sub(newPowerTable[0].Power, powerTable[0].Power),
+			gpbft.NewStoragePower(1),
+		)
+
+		// Add power with key.
+		newPowerTable, err = certs.ApplyPowerTableDiffs(powerTable, []certs.PowerTableDelta{{
+			ParticipantID: powerTable[0].ID,
+			PowerDelta:    gpbft.NewStoragePower(1),
+			SigningKey:    powerTable[1].PubKey,
+		}})
+		require.NoError(t, err)
+		require.Equal(t,
+			new(gpbft.StoragePower).Sub(newPowerTable[0].Power, powerTable[0].Power),
+			gpbft.NewStoragePower(1),
+		)
+		require.Equal(t, newPowerTable[0].PubKey, powerTable[1].PubKey)
+
+		// Change Key without power
+		newPowerTable, err = certs.ApplyPowerTableDiffs(powerTable, []certs.PowerTableDelta{{
+			ParticipantID: powerTable[0].ID,
+			PowerDelta:    gpbft.NewStoragePower(0),
+			SigningKey:    powerTable[1].PubKey,
+		}})
+		require.NoError(t, err)
+		require.Equal(t, newPowerTable[0].PubKey, powerTable[1].PubKey)
+	}
+
 	// invalid transitions
 	{
 		// Idempotent key change

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -1,4 +1,4 @@
-package test
+package certs_test
 
 import (
 	"bytes"


### PR DESCRIPTION
Addresses feedback from https://github.com/filecoin-project/go-f3/pull/266#pullrequestreview-2089396736


- [x] power gets added to the right entry
- [x] change in key is processed with/without a change in power
- [x] sequences like deletion and re-addition of an entry (requiring key to be re-specified)

Also, add a bunch of extra checks when applying power table diffs to make sure they're "minimal" and well-specified. This doesn't really matter for correctness (we hash the resulting power table anyways) but:

1. It aids in debugging.
2. It ensures we get _minimal_ power table diffs.

For the latter I'd generally just round-trip the diff, but that's more expensive when combining _many_ diffs (which I expect we'll need to do for the finality exchange protocol).
