### PR TITLE
When starting a new instance, check for skipping rounds just once after processing all queued messages.

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -7,10 +7,11 @@ import (
 
 // Sentinel errors for the message validation and reception APIs.
 var (
-	ErrValidationTooOld      = errors.New("message is for prior instance")
-	ErrValidationNoCommittee = errors.New("no committee for instance")
-	ErrValidationInvalid     = errors.New("message invalid")
-	ErrValidationWrongBase   = errors.New("unexpected base chain")
+	ErrValidationTooOld          = errors.New("message is for prior instance")
+	ErrValidationNoCommittee     = errors.New("no committee for instance")
+	ErrValidationInvalid         = errors.New("message invalid")
+	ErrValidationWrongBase       = errors.New("unexpected base chain")
+	ErrValidationWrongSupplement = errors.New("unexpected supplemental data")
 
 	ErrReceivedWrongInstance    = errors.New("received message for wrong instance")
 	ErrReceivedAfterTermination = errors.New("received message after terminating")

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -176,20 +176,14 @@ func (p *Participant) beginInstance() error {
 		return fmt.Errorf("failed starting gpbft instance: %w", err)
 	}
 	// Deliver any queued messages for the new instance.
-	for _, msg := range p.mqueue.Drain(p.gpbft.instanceID) {
-		if p.terminated() {
-			break
-		}
-		if p.tracer != nil {
+	queued := p.mqueue.Drain(p.gpbft.instanceID)
+	if p.tracer != nil {
+		for _, msg := range queued {
 			p.tracer.Log("Delivering queued {%d} ← P%d: %v", p.gpbft.instanceID, msg.Sender, msg)
 		}
-		if err := p.gpbft.Receive(msg); err != nil {
-			if errors.Is(err, ErrValidationWrongBase) {
-				// Silently ignore this late-binding validation error
-			} else {
-				return fmt.Errorf("delivering queued message: %w", err)
-			}
-		}
+	}
+	if err := p.gpbft.ReceiveMany(queued); err != nil {
+		return fmt.Errorf("delivering queued messages: %w", err)
 	}
 	p.handleDecision()
 	return nil
@@ -296,12 +290,13 @@ func (q *messageQueue) Add(msg *GMessage) {
 	instanceQueue[msg.Sender] = append(instanceQueue[msg.Sender], msg)
 }
 
+// Removes and returns all messages for an instance.
+// The returned messages are ordered by round and step.
 func (q *messageQueue) Drain(instance uint64) []*GMessage {
 	var msgs []*GMessage
 	for _, ms := range q.messages[instance] {
 		msgs = append(msgs, ms...)
 	}
-	// Sort by round and then step so messages will be processed in a useful order.
 	sort.SliceStable(msgs, func(i, j int) bool {
 		if msgs[i].Vote.Round != msgs[j].Vote.Round {
 			return msgs[i].Vote.Round < msgs[j].Vote.Round

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -52,18 +52,21 @@ func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *parti
 
 	rng := rand.New(rand.NewSource(seed))
 	subject := participantTestSubject{
-		t:                t,
-		rng:              rng,
-		id:               gpbft.ActorID(rng.Uint64()),
-		pubKey:           generateRandomBytes(rng),
-		delta:            delta,
-		instance:         instance,
-		networkName:      "fish",
-		canonicalChain:   canonicalChain,
-		supplementalData: new(gpbft.SupplementalData),
-		powerTable:       gpbft.NewPowerTable(),
-		beacon:           generateRandomBytes(rng),
-		time:             time.Now(),
+		t:              t,
+		rng:            rng,
+		id:             gpbft.ActorID(rng.Uint64()),
+		pubKey:         generateRandomBytes(rng),
+		delta:          delta,
+		instance:       instance,
+		networkName:    "fish",
+		canonicalChain: canonicalChain,
+		supplementalData: &gpbft.SupplementalData{
+			Commitments: [32]byte{},
+			PowerTable:  []byte("powertable"),
+		},
+		powerTable: gpbft.NewPowerTable(),
+		beacon:     generateRandomBytes(rng),
+		time:       time.Now(),
 	}
 
 	// Assure power table contains the power entry for the test subject
@@ -337,14 +340,36 @@ func TestParticipant(t *testing.T) {
 						return &gpbft.GMessage{
 							Sender: somePowerEntry.ID,
 							Vote: gpbft.Payload{
-								Instance: initialInstance,
-								Step:     gpbft.QUALITY_PHASE,
-								Value:    gpbft.ECChain{gpbft.TipSet{Epoch: 0, Key: []byte("wrong")}},
+								Instance:         initialInstance,
+								Step:             gpbft.QUALITY_PHASE,
+								SupplementalData: *subject.supplementalData,
+								Value:            gpbft.ECChain{gpbft.TipSet{Epoch: 0, Key: []byte("wrong")}},
 							},
 							Signature: signature,
 						}
 					},
 					wantErr: "unexpected base",
+				},
+				{
+					name: "current instance message with unexpected supplement is rejected",
+					message: func(subject *participantTestSubject) *gpbft.GMessage {
+						require.NoError(subject.t, subject.powerTable.Add(somePowerEntry))
+						return &gpbft.GMessage{
+							Sender: somePowerEntry.ID,
+							Vote: gpbft.Payload{
+								Instance: initialInstance,
+								Step:     gpbft.QUALITY_PHASE,
+								SupplementalData: gpbft.SupplementalData{
+									Commitments: [32]byte{},
+									PowerTable:  []byte("wrong"),
+								},
+								Value: subject.canonicalChain,
+							},
+
+							Signature: signature,
+						}
+					},
+					wantErr: "unexpected supplement",
 				},
 				{
 					name: "future instance message with unexpected base is queued",
@@ -353,9 +378,10 @@ func TestParticipant(t *testing.T) {
 						return &gpbft.GMessage{
 							Sender: somePowerEntry.ID,
 							Vote: gpbft.Payload{
-								Instance: initialInstance + 1,
-								Step:     gpbft.QUALITY_PHASE,
-								Value:    gpbft.ECChain{gpbft.TipSet{Epoch: 0, Key: []byte("wrong")}},
+								Instance:         initialInstance + 1,
+								Step:             gpbft.QUALITY_PHASE,
+								SupplementalData: *subject.supplementalData,
+								Value:            gpbft.ECChain{gpbft.TipSet{Epoch: 0, Key: []byte("wrong")}},
 							},
 							Signature: signature,
 						}
@@ -368,9 +394,10 @@ func TestParticipant(t *testing.T) {
 						return &gpbft.GMessage{
 							Sender: somePowerEntry.ID,
 							Vote: gpbft.Payload{
-								Instance: initialInstance,
-								Step:     gpbft.QUALITY_PHASE,
-								Value:    subject.canonicalChain,
+								Instance:         initialInstance,
+								Step:             gpbft.QUALITY_PHASE,
+								SupplementalData: *subject.supplementalData,
+								Value:            subject.canonicalChain,
 							},
 							Signature: signature,
 						}


### PR DESCRIPTION
See #151