### PR TITLE
Add power tables to the Certificate Store

### DIFF
--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -3,61 +3,183 @@ package certstore
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
 	"sync"
 
 	"github.com/filecoin-project/go-f3/certs"
-	"github.com/ipfs/go-datastore"
-	"github.com/ipfs/go-datastore/namespace"
+	"github.com/filecoin-project/go-f3/gpbft"
 
 	"github.com/Kubuxu/go-broadcast"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
 	"golang.org/x/xerrors"
 )
 
 var ErrCertNotFound = errors.New("certificate not found")
 
+const defaultPowerTableFrequency = 60 * 24 // expected twice a day for Filecoin
+
+var (
+	certStoreLatestKey = datastore.NewKey("/latestCert")
+	certStoreFirstKey  = datastore.NewKey("/firstInstance")
+)
+
 // Store is responsible for storing and relaying information about new finality certificates
 type Store struct {
-	writeLk  sync.Mutex
-	ds       datastore.Datastore
-	busCerts broadcast.Channel[*certs.FinalityCertificate]
+	writeLk             sync.Mutex
+	ds                  datastore.Datastore
+	busCerts            broadcast.Channel[*certs.FinalityCertificate]
+	firstInstance       uint64
+	powerTableFrequency uint64
+
+	latestPowerTable gpbft.PowerEntries
 }
 
-// NewStore creates a certstore
-// The passed Datastore has to be thread safe.
-func NewStore(ctx context.Context, ds datastore.Datastore) (*Store, error) {
+// Internal helper function to open a certificate store that may or may not have been created.
+func open(ctx context.Context, ds datastore.Datastore) (*Store, error) {
 	cs := &Store{
-		ds: namespace.Wrap(ds, datastore.NewKey("/certstore")),
+		ds:                  namespace.Wrap(ds, datastore.NewKey("/certstore")),
+		powerTableFrequency: defaultPowerTableFrequency,
 	}
-	latestCert, err := cs.loadLatest(ctx)
+
+	latestInstance, err := cs.readInstanceNumber(ctx, certStoreLatestKey)
+	if errors.Is(err, datastore.ErrNotFound) {
+		return cs, nil
+	} else if err != nil {
+		return nil, xerrors.Errorf("determining latest cert: %w", err)
+	}
+
+	latestCert, err := cs.Get(ctx, latestInstance)
 	if err != nil {
 		return nil, xerrors.Errorf("loading latest cert: %w", err)
 	}
-	if latestCert != nil {
-		cs.busCerts.Publish(latestCert)
+
+	cs.busCerts.Publish(latestCert)
+
+	return cs, nil
+}
+
+// OpenOrCreateStore opens the certificate store if it doesn't exist, or creates it. If the
+// certificate store already exists but uses a different initial instance and/or power table, this
+// function will return an error.
+//
+// The passed Datastore has to be thread safe.
+func OpenOrCreateStore(ctx context.Context, ds datastore.Datastore, firstInstance uint64, initialPowerTable gpbft.PowerEntries) (*Store, error) {
+	if len(initialPowerTable) == 0 {
+		return nil, xerrors.New("cannot construct certificate store with an empty initial power table")
+	}
+	cs, err := open(ctx, ds)
+	if err != nil {
+		return nil, err
+	}
+	dbFirstInstance, err := cs.readInstanceNumber(ctx, certStoreFirstKey)
+	if err == nil {
+		if firstInstance != dbFirstInstance {
+			return nil, xerrors.Errorf("certificate store re-initialized with a different initial instance %d != %d", dbFirstInstance, firstInstance)
+		}
+		var buf bytes.Buffer
+		if err := initialPowerTable.MarshalCBOR(&buf); err != nil {
+			return nil, xerrors.Errorf("failed to martial initial power table: %w", err)
+		}
+		pb, err := cs.ds.Get(ctx, cs.keyForPowerTable(firstInstance))
+		if err != nil {
+			return nil, xerrors.Errorf("failed to load initial power table: %w", err)
+		}
+		if !bytes.Equal(buf.Bytes(), pb) {
+			return nil, errors.New("certificate store re-initialized with the wrong power table")
+		}
+	} else if errors.Is(err, datastore.ErrNotFound) {
+		if err := cs.putPowerTable(ctx, firstInstance, initialPowerTable); err != nil {
+			return nil, xerrors.Errorf("while storing the initial power table: %w", err)
+		}
+		if err := cs.writeInstanceNumber(ctx, certStoreFirstKey, firstInstance); err != nil {
+			return nil, xerrors.Errorf("while recording the first instance: %w", err)
+		}
+	} else {
+		return nil, xerrors.Errorf("failed to read initial instance number: %w", err)
+	}
+	cs.firstInstance = firstInstance
+	if latest := cs.Latest(); latest != nil {
+		cs.latestPowerTable, err = cs.GetPowerTable(ctx, latest.GPBFTInstance+1)
+		if err != nil {
+			return nil, xerrors.Errorf("failed to load latest power table: %w", err)
+		}
+	} else {
+		cs.latestPowerTable = initialPowerTable
 	}
 
 	return cs, nil
 }
 
-var certStoreLatestKey = datastore.NewKey("/latestCert")
+// NewStore initializes a new certificate store. It will fail if the store already exists.
+// The passed Datastore has to be thread safe.
+func CreateStore(ctx context.Context, ds datastore.Datastore, firstInstance uint64, initialPowerTable gpbft.PowerEntries) (*Store, error) {
+	if len(initialPowerTable) == 0 {
+		return nil, xerrors.New("cannot construct certificate store with an empty initial power table")
+	}
+	cs, err := open(ctx, ds)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := cs.readInstanceNumber(ctx, certStoreFirstKey); err == nil {
+		return nil, errors.New("certificate store already initialized")
+	}
+	if err := cs.putPowerTable(ctx, firstInstance, initialPowerTable); err != nil {
+		return nil, xerrors.Errorf("while storing the initial power table: %w", err)
+	}
+	if err := cs.writeInstanceNumber(ctx, certStoreFirstKey, firstInstance); err != nil {
+		return nil, xerrors.Errorf("while recording the first instance: %w", err)
+	}
+	cs.firstInstance = firstInstance
+	cs.latestPowerTable = initialPowerTable
 
-func (cs *Store) loadLatest(ctx context.Context) (*certs.FinalityCertificate, error) {
-	cb, err := cs.ds.Get(ctx, certStoreLatestKey)
-	if errors.Is(err, datastore.ErrNotFound) {
-		return nil, nil
-	}
+	return cs, nil
+}
+
+// OpenStore opens an existing certificate store.
+// The passed Datastore has to be thread safe.
+func OpenStore(ctx context.Context, ds datastore.Datastore) (*Store, error) {
+	cs, err := open(ctx, ds)
 	if err != nil {
-		return nil, xerrors.Errorf("getting latest cert: %w", err)
+		return nil, err
 	}
-	var c certs.FinalityCertificate
-	err = c.UnmarshalCBOR(bytes.NewReader(cb))
+	cs.firstInstance, err = cs.readInstanceNumber(ctx, certStoreFirstKey)
 	if err != nil {
-		return nil, xerrors.Errorf("unmarshalling latest cert: %w", err)
+		return nil, xerrors.Errorf("getting first instance: %w", err)
 	}
-	return &c, err
+	latestPowerTable := cs.firstInstance
+	if latest := cs.Latest(); latest != nil {
+		latestPowerTable = latest.GPBFTInstance + 1
+	}
+	cs.latestPowerTable, err = cs.GetPowerTable(ctx, latestPowerTable)
+	if err != nil {
+		return nil, xerrors.Errorf("getting latest power table: %w", err)
+	}
+	return cs, nil
+}
+
+// Read a big-endian unsigned integer from the specified key.
+func (cs *Store) readInstanceNumber(ctx context.Context, key datastore.Key) (uint64, error) {
+	b, err := cs.ds.Get(ctx, key)
+	if err != nil {
+		return 0, xerrors.Errorf("failed to read instance number at %q: %w", key, err)
+	}
+	if len(b) != 8 {
+		return 0, xerrors.Errorf("unexpected instance number len %d != 8 at %q", len(b), key)
+	}
+	return binary.BigEndian.Uint64(b), nil
+}
+
+// Write a big-endian unsigned integer to the specified key.
+func (cs *Store) writeInstanceNumber(ctx context.Context, key datastore.Key, value uint64) error {
+	err := cs.ds.Put(ctx, key, binary.BigEndian.AppendUint64(nil, value))
+	if err != nil {
+		return xerrors.Errorf("failed to write instance number at %q: %w", key, err)
+	}
+	return nil
 }
 
 // Latest returns the newest available certificate
@@ -65,8 +187,10 @@ func (cs *Store) Latest() *certs.FinalityCertificate {
 	return cs.busCerts.Last()
 }
 
+// Get returns the FinalityCertificate at the specified instance, or an error derived from
+// ErrCertNotFound.
 func (cs *Store) Get(ctx context.Context, instance uint64) (*certs.FinalityCertificate, error) {
-	b, err := cs.ds.Get(ctx, cs.keyForInstance(instance))
+	b, err := cs.ds.Get(ctx, cs.keyForCert(instance))
 
 	if errors.Is(err, datastore.ErrNotFound) {
 		return nil, xerrors.Errorf("cert at %d: %w", instance, ErrCertNotFound)
@@ -84,7 +208,8 @@ func (cs *Store) Get(ctx context.Context, instance uint64) (*certs.FinalityCerti
 
 // GetRange returns a range of certs from start to end inclusive by instance numbers in the
 // increasing order. Only this order of traversal is supported.
-// If it encounters missing cert, it returns a wrapped ErrCertNotFound and the available certs
+//
+// If it encounters missing cert, it returns a wrapped ErrCertNotFound and the available certs.
 func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]certs.FinalityCertificate, error) {
 	if start > end {
 		return nil, xerrors.Errorf("start is larger then end: %d > %d", start, end)
@@ -96,7 +221,7 @@ func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]cert
 	bCerts := make([][]byte, 0, end-start+1)
 
 	for i := start; i <= end; i++ {
-		b, err := cs.ds.Get(ctx, cs.keyForInstance(i))
+		b, err := cs.ds.Get(ctx, cs.keyForCert(i))
 		if errors.Is(err, datastore.ErrNotFound) {
 			break
 		}
@@ -121,44 +246,156 @@ func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]cert
 	return certs, nil
 }
 
-func (*Store) keyForInstance(i uint64) datastore.Key {
+func (cs *Store) readPowerTable(ctx context.Context, instance uint64) (gpbft.PowerEntries, error) {
+	var powerTable gpbft.PowerEntries
+	if b, err := cs.ds.Get(ctx, cs.keyForPowerTable(instance)); err != nil {
+		return nil, xerrors.Errorf("failed to load power table at instance %d: %w", instance, err)
+	} else if err := powerTable.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
+		return nil, xerrors.Errorf("failed to unmarshal power table at instance %d: %w", instance, err)
+	}
+	return powerTable, nil
+}
+
+// Store the specified power table.
+func (cs *Store) putPowerTable(ctx context.Context, instance uint64, powerTable gpbft.PowerEntries) error {
+	var buf bytes.Buffer
+	if err := powerTable.MarshalCBOR(&buf); err != nil {
+		return xerrors.Errorf("marshalling power table instance %d: %w", instance, err)
+	}
+	if err := cs.ds.Put(ctx, cs.keyForPowerTable(instance), buf.Bytes()); err != nil {
+		return xerrors.Errorf("putting power table instance %d: %w", instance, err)
+	}
+	return nil
+}
+
+// GetPowerTable returns the power table (committee) used to validate the specified instance.
+func (cs *Store) GetPowerTable(ctx context.Context, instance uint64) (gpbft.PowerEntries, error) {
+	if instance < cs.firstInstance {
+		return nil, fmt.Errorf("cannot return a power table before the first instance: %d", cs.firstInstance)
+	}
+
+	lastPowerTable := cs.firstInstance
+	if latestCert := cs.Latest(); latestCert != nil {
+		lastPowerTable = latestCert.GPBFTInstance + 1
+	}
+	if instance > lastPowerTable {
+		return nil, fmt.Errorf("cannot return future power table for instance %d > %d", instance, lastPowerTable)
+	}
+
+	// We store every `powerTableFrequency` power tables. Find the nearest multiple smaller than
+	// the requested instance.
+	startInstance := instance
+	if offset := instance % cs.powerTableFrequency; offset != 0 {
+		startInstance = max(startInstance-offset, cs.firstInstance)
+	}
+
+	powerTable, err := cs.readPowerTable(ctx, startInstance)
+	if err != nil {
+		return nil, xerrors.Errorf("failed fo find expected power table for instance %d: %w", startInstance, err)
+	}
+	if startInstance == instance {
+		return powerTable, nil
+	}
+	// Load the power table diffs up till (but not including) the target instance.
+	certificates, err := cs.GetRange(ctx, startInstance, instance-1)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply the diffs and return the result.
+	deltas := make([][]certs.PowerTableDelta, len(certificates))
+	for i := range certificates {
+		deltas[i] = certificates[i].PowerTableDelta
+	}
+	powerTable, err = certs.ApplyPowerTableDiffs(powerTable, deltas...)
+	if err != nil {
+		return nil, xerrors.Errorf("applying power deltas: %w", err)
+	}
+	return powerTable, err
+}
+
+func (*Store) keyForCert(i uint64) datastore.Key {
 	return datastore.NewKey(fmt.Sprintf("/certs/%016X", i))
 }
 
-// Put saves a certificate in a store and notifies listeners.
-// It errors if adding a cert would create a gap
-func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error {
-	key := cs.keyForInstance(cert.GPBFTInstance)
+func (*Store) keyForPowerTable(i uint64) datastore.Key {
+	return datastore.NewKey(fmt.Sprintf("/power/%016X", i))
+}
 
-	exists, err := cs.ds.Has(ctx, key)
-	if err != nil {
-		return xerrors.Errorf("checking existence of cert: %w", err)
+// Put saves a certificate in a store and notifies listeners.
+// It returns an error if the certificate is either:
+//
+// 1. Before the initial instance that the certificate store was initialized with.
+// 2. More than one instance after the last certificate stored.
+func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error {
+	if cert.GPBFTInstance < cs.firstInstance {
+		return xerrors.Errorf("certificate store only stores certificates on or after instance %d", cs.firstInstance)
 	}
-	if exists {
+
+	// Take a lock to ensure ordering.
+	cs.writeLk.Lock()
+	defer cs.writeLk.Unlock()
+
+	nextCert := cs.firstInstance
+	if latestCert := cs.Latest(); latestCert != nil {
+		nextCert = latestCert.GPBFTInstance + 1
+	}
+	if cert.GPBFTInstance > nextCert {
+		return xerrors.Errorf("attempted to add cert at %d, expected %d", cert.GPBFTInstance, nextCert)
+	}
+	if cert.GPBFTInstance < nextCert {
 		return nil
 	}
 
+	// The instance is exactly latest + 1
+
+	// Compute the next power table (if it has changed).
+	newPowerTable := cs.latestPowerTable
+	if len(cert.PowerTableDelta) > 0 {
+		var err error
+		newPowerTable, err = certs.ApplyPowerTableDiffs(cs.latestPowerTable, cert.PowerTableDelta)
+		if err != nil {
+			return xerrors.Errorf("failed to apply power table delta for instance %d: %w", cert.GPBFTInstance, err)
+		}
+	}
+
+	// Check the power table CID. This _should_ already have been checked (we're not validating
+	// the entire finality certificate, but errors here will compound and be difficult to fix
+	// later.
+	if ptCid, err := certs.MakePowerTableCID(newPowerTable); err != nil {
+		return err
+	} else if !bytes.Equal(ptCid, cert.SupplementalData.PowerTable) {
+		return xerrors.Errorf("new power table differs from expected power table")
+	}
+
+	// Double check that we're not killing the network.
+	if len(newPowerTable) == 0 {
+		return xerrors.Errorf("finality certificate for instance %d would empty the power table", cert.GPBFTInstance)
+	}
+
+	// Write the cert/power table.
 	var buf bytes.Buffer
 	if err := cert.MarshalCBOR(&buf); err != nil {
 		return xerrors.Errorf("marshalling cert instance %d: %w", cert.GPBFTInstance, err)
 	}
 
-	cs.writeLk.Lock()
-	defer cs.writeLk.Unlock()
-
-	if cs.Latest() != nil && cert.GPBFTInstance > cs.Latest().GPBFTInstance &&
-		cert.GPBFTInstance != cs.Latest().GPBFTInstance+1 {
-		return xerrors.Errorf("attempted to add cert at %d but the previous one is %d",
-			cert.GPBFTInstance, cs.Latest().GPBFTInstance)
-	}
-
-	if err := cs.ds.Put(ctx, key, buf.Bytes()); err != nil {
+	if err := cs.ds.Put(ctx, cs.keyForCert(cert.GPBFTInstance), buf.Bytes()); err != nil {
 		return xerrors.Errorf("putting the cert: %w", err)
 	}
-	if err := cs.ds.Put(ctx, certStoreLatestKey, buf.Bytes()); err != nil {
-		return xerrors.Errorf("putting the cert: %w", err)
+
+	if cert.GPBFTInstance%cs.powerTableFrequency == 0 {
+		if err := cs.putPowerTable(ctx, cert.GPBFTInstance, cs.latestPowerTable); err != nil {
+			return err
+		}
 	}
-	cs.busCerts.Publish(cert) // Publish within the lock to ensure ordering
+
+	// Finally, advance the latest instance pointer (always do this last) and publish.
+	if err := cs.writeInstanceNumber(ctx, certStoreLatestKey, cert.GPBFTInstance); err != nil {
+		return xerrors.Errorf("putting recording the latest GPBFT instance: %w", err)
+	}
+
+	cs.latestPowerTable = newPowerTable
+	cs.busCerts.Publish(cert)
 
 	return nil
 }

--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -284,10 +284,7 @@ func (cs *Store) GetPowerTable(ctx context.Context, instance uint64) (gpbft.Powe
 
 	// We store every `powerTableFrequency` power tables. Find the nearest multiple smaller than
 	// the requested instance.
-	startInstance := instance
-	if offset := instance % cs.powerTableFrequency; offset != 0 {
-		startInstance = max(startInstance-offset, cs.firstInstance)
-	}
+	startInstance := max(instance-instance%cs.powerTableFrequency, cs.firstInstance)
 
 	powerTable, err := cs.readPowerTable(ctx, startInstance)
 	if err != nil {

--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -2,19 +2,39 @@ package certstore
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/gpbft"
 	datastore "github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/require"
 )
 
+func testPowerTable(entries int64) (gpbft.PowerEntries, gpbft.CID) {
+	powerTable := make(gpbft.PowerEntries, entries)
+
+	for i := range powerTable {
+		powerTable[i] = gpbft.PowerEntry{
+			ID:     gpbft.ActorID(i + 1),
+			Power:  gpbft.NewStoragePower(int64(len(powerTable)*2 - i/2)),
+			PubKey: []byte("fake key"),
+		}
+	}
+	k, err := certs.MakePowerTableCID(powerTable)
+	if err != nil {
+		panic(err)
+	}
+	return powerTable, k
+}
+
 func TestNewCertStore(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	_, err := NewStore(ctx, ds)
+	pt, _ := testPowerTable(10)
+	_, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 }
 
@@ -22,7 +42,8 @@ func TestLatest(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs, err := NewStore(ctx, ds)
+	pt, _ := testPowerTable(10)
+	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
 	latest := cs.Latest()
@@ -33,10 +54,16 @@ func TestPut(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs, err := NewStore(ctx, ds)
+	pt, ptCid := testPowerTable(10)
+	supp := gpbft.SupplementalData{PowerTable: ptCid}
+	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
-	cert := &certs.FinalityCertificate{GPBFTInstance: 1}
+	cert := &certs.FinalityCertificate{GPBFTInstance: 0, SupplementalData: supp}
+	err = cs.Put(ctx, cert)
+	require.Error(t, err)
+
+	cert = &certs.FinalityCertificate{GPBFTInstance: 1, SupplementalData: supp}
 	err = cs.Put(ctx, cert)
 	require.NoError(t, err)
 
@@ -47,7 +74,7 @@ func TestPut(t *testing.T) {
 	err = cs.Put(ctx, cert)
 	require.NoError(t, err)
 
-	cert = &certs.FinalityCertificate{GPBFTInstance: 3}
+	cert = &certs.FinalityCertificate{GPBFTInstance: 3, SupplementalData: supp}
 	err = cs.Put(ctx, cert)
 	require.Error(t, err)
 }
@@ -56,14 +83,16 @@ func TestGet(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs, err := NewStore(ctx, ds)
+	pt, ptCid := testPowerTable(10)
+	supp := gpbft.SupplementalData{PowerTable: ptCid}
+	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
 	_, err = cs.Get(ctx, 1)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrCertNotFound)
 
-	cert := &certs.FinalityCertificate{GPBFTInstance: 1}
+	cert := &certs.FinalityCertificate{GPBFTInstance: 1, SupplementalData: supp}
 	err = cs.Put(ctx, cert)
 	require.NoError(t, err)
 
@@ -76,14 +105,16 @@ func TestGetRange(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs, err := NewStore(ctx, ds)
+	pt, ptCid := testPowerTable(10)
+	supp := gpbft.SupplementalData{PowerTable: ptCid}
+	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
 	_, err = cs.GetRange(ctx, 1, 5)
 	require.Error(t, err)
 
 	for i := uint64(1); i <= 5; i++ {
-		cert := &certs.FinalityCertificate{GPBFTInstance: i}
+		cert := &certs.FinalityCertificate{GPBFTInstance: i, SupplementalData: supp}
 		err := cs.Put(ctx, cert)
 		require.NoError(t, err)
 	}
@@ -97,14 +128,16 @@ func TestSubscribeForNewCerts(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs, err := NewStore(ctx, ds)
+	pt, ptCid := testPowerTable(10)
+	supp := gpbft.SupplementalData{PowerTable: ptCid}
+	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
 	ch := make(chan *certs.FinalityCertificate, 1)
 	_, closer := cs.SubscribeForNewCerts(ch)
 	defer closer()
 
-	cert := &certs.FinalityCertificate{GPBFTInstance: 1}
+	cert := &certs.FinalityCertificate{GPBFTInstance: 1, SupplementalData: supp}
 	err = cs.Put(ctx, cert)
 	require.NoError(t, err)
 
@@ -121,10 +154,12 @@ func TestLatestAfterPut(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs, err := NewStore(ctx, ds)
+	pt, ptCid := testPowerTable(10)
+	supp := gpbft.SupplementalData{PowerTable: ptCid}
+	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
-	cert := &certs.FinalityCertificate{GPBFTInstance: 1}
+	cert := &certs.FinalityCertificate{GPBFTInstance: 1, SupplementalData: supp}
 	err = cs.Put(ctx, cert)
 	require.NoError(t, err)
 
@@ -132,7 +167,7 @@ func TestLatestAfterPut(t *testing.T) {
 	require.NotNil(t, latest)
 	require.Equal(t, uint64(1), latest.GPBFTInstance)
 
-	cert = &certs.FinalityCertificate{GPBFTInstance: 2}
+	cert = &certs.FinalityCertificate{GPBFTInstance: 2, SupplementalData: supp}
 	err = cs.Put(ctx, cert)
 	require.NoError(t, err)
 
@@ -145,16 +180,18 @@ func TestPutSequential(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs, err := NewStore(ctx, ds)
+	pt, ptCid := testPowerTable(10)
+	supp := gpbft.SupplementalData{PowerTable: ptCid}
+	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
 	for i := uint64(1); i <= 5; i++ {
-		cert := &certs.FinalityCertificate{GPBFTInstance: i}
+		cert := &certs.FinalityCertificate{GPBFTInstance: i, SupplementalData: supp}
 		err := cs.Put(ctx, cert)
 		require.NoError(t, err)
 	}
 
-	cert := &certs.FinalityCertificate{GPBFTInstance: 7}
+	cert := &certs.FinalityCertificate{GPBFTInstance: 7, SupplementalData: supp}
 	err = cs.Put(ctx, cert)
 	require.Error(t, err)
 }
@@ -163,16 +200,18 @@ func TestPersistency(t *testing.T) {
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
-	cs1, err := NewStore(ctx, ds)
+	pt, ptCid := testPowerTable(10)
+	supp := gpbft.SupplementalData{PowerTable: ptCid}
+	cs1, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
 	for i := uint64(1); i <= 5; i++ {
-		cert := &certs.FinalityCertificate{GPBFTInstance: i}
+		cert := &certs.FinalityCertificate{GPBFTInstance: i, SupplementalData: supp}
 		err := cs1.Put(ctx, cert)
 		require.NoError(t, err)
 	}
 
-	cs2, err := NewStore(ctx, ds)
+	cs2, err := OpenStore(ctx, ds)
 	require.NoError(t, err)
 
 	for i := uint64(1); i <= 5; i++ {
@@ -182,4 +221,186 @@ func TestPersistency(t *testing.T) {
 	}
 
 	require.Equal(t, cs1.Latest().GPBFTInstance, cs2.Latest().GPBFTInstance)
+}
+
+func TestCreateOpen(t *testing.T) {
+	ctx := context.Background()
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+
+	pt, _ := testPowerTable(20)
+	newPt := slices.Clone(pt)
+	newPt[0].PubKey = []byte("other key")
+
+	// Cannot open if it doesn't exist.
+	_, err := OpenStore(ctx, ds)
+	require.Error(t, err)
+
+	// Can create with create-or-open
+	_, err = OpenOrCreateStore(ctx, ds, 0, pt)
+	require.NoError(t, err)
+
+	// Cannot re-create with "create"
+	_, err = CreateStore(ctx, ds, 0, pt)
+	require.Error(t, err)
+
+	// Can re-open with "open or create".
+	_, err = OpenOrCreateStore(ctx, ds, 0, pt)
+	require.NoError(t, err)
+
+	// Instance must agree
+	_, err = OpenOrCreateStore(ctx, ds, 1, pt)
+	require.Error(t, err)
+
+	// Power table must agree
+	_, err = OpenOrCreateStore(ctx, ds, 0, newPt)
+	require.Error(t, err)
+}
+
+func TestPowerNoData(t *testing.T) {
+	ctx := context.Background()
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	pt, _ := testPowerTable(20)
+
+	cs, err := CreateStore(ctx, ds, 0, pt)
+	require.NoError(t, err)
+	cs.powerTableFrequency = 5
+	// clobber the datastore.
+	cs.ds = ds_sync.MutexWrap(datastore.NewMapDatastore())
+
+	// Should fail to find any power tables.
+	_, err = cs.GetPowerTable(ctx, 0)
+	require.ErrorContains(t, err, "failed to load power table")
+	_, err = cs.GetPowerTable(ctx, 1)
+	require.ErrorContains(t, err, "cannot return future power table")
+
+}
+
+func TestPowerEmptyPowerTable(t *testing.T) {
+	ctx := context.Background()
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	pt, _ := testPowerTable(5)
+
+	_, err := CreateStore(ctx, ds, 0, nil)
+	require.ErrorContains(t, err, "empty initial power table")
+
+	_, err = OpenOrCreateStore(ctx, ds, 0, nil)
+	require.ErrorContains(t, err, "empty initial power table")
+
+	cs, err := CreateStore(ctx, ds, 0, pt)
+	require.NoError(t, err)
+
+	emptyPt := gpbft.PowerEntries{}
+	emptyPtCid, err := certs.MakePowerTableCID(emptyPt)
+	require.NoError(t, err)
+
+	cert := &certs.FinalityCertificate{
+		GPBFTInstance:    0,
+		PowerTableDelta:  certs.MakePowerTableDiff(pt, emptyPt),
+		SupplementalData: gpbft.SupplementalData{PowerTable: emptyPtCid},
+	}
+	err = cs.Put(ctx, cert)
+	require.ErrorContains(t, err, "empty the power table")
+
+}
+
+func TestPower(t *testing.T) {
+	t.Run("Offset", func(t *testing.T) {
+		testPowerInner(t, 2)
+	})
+	t.Run("NoOffset", func(t *testing.T) {
+		testPowerInner(t, 0)
+	})
+}
+func testPowerInner(t *testing.T, firstInstance uint64) {
+	ctx := context.Background()
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+
+	pt, ptCid := testPowerTable(20)
+	newPt := slices.Clone(pt)
+	newPt[0].PubKey = []byte("other key")
+	newPtCid, err := certs.MakePowerTableCID(newPt)
+	require.NoError(t, err)
+
+	cs, err := CreateStore(ctx, ds, firstInstance, pt)
+	require.NoError(t, err)
+
+	cs.powerTableFrequency = 5
+
+	// Before we insert any finality certificates.
+	{
+		actualPt, err := cs.GetPowerTable(ctx, firstInstance)
+		require.NoError(t, err)
+		require.Equal(t, pt, actualPt)
+
+		_, err = cs.GetPowerTable(ctx, firstInstance+1)
+		require.ErrorContains(t, err, "cannot return future power table")
+	}
+
+	for i := uint64(firstInstance); i < 8; i++ {
+		cert := &certs.FinalityCertificate{
+			GPBFTInstance:    i,
+			SupplementalData: gpbft.SupplementalData{PowerTable: ptCid},
+		}
+		err := cs.Put(ctx, cert)
+		require.NoError(t, err)
+	}
+
+	{
+		cert := &certs.FinalityCertificate{
+			GPBFTInstance:    8,
+			PowerTableDelta:  certs.MakePowerTableDiff(pt, newPt),
+			SupplementalData: gpbft.SupplementalData{PowerTable: newPtCid},
+		}
+		err = cs.Put(ctx, cert)
+		require.NoError(t, err)
+	}
+
+	for i := uint64(9); i < 13; i++ {
+		cert := &certs.FinalityCertificate{
+			GPBFTInstance:    i,
+			SupplementalData: gpbft.SupplementalData{PowerTable: newPtCid},
+		}
+		err := cs.Put(ctx, cert)
+		require.NoError(t, err)
+	}
+
+	for i := uint64(firstInstance); i < 7; i += 2 {
+		actualPt, err := cs.GetPowerTable(ctx, i)
+		require.NoError(t, err)
+		require.Equal(t, pt, actualPt)
+	}
+
+	for i := uint64(9); i <= 13; i++ {
+		actualPt, err := cs.GetPowerTable(ctx, i)
+		require.NoError(t, err)
+		require.NotEqual(t, pt, actualPt)
+		require.Equal(t, newPt, actualPt)
+	}
+
+	// Future power table.
+	{
+		// Doesn't exist.
+		_, err = cs.GetPowerTable(ctx, 14)
+		require.ErrorContains(t, err, "cannot return future power table")
+
+		// Insert a finality certificate.
+		cert := &certs.FinalityCertificate{
+			GPBFTInstance:    13,
+			SupplementalData: gpbft.SupplementalData{PowerTable: newPtCid},
+		}
+		err = cs.Put(ctx, cert)
+		require.NoError(t, err)
+
+		// Exists now
+		actualPt, err := cs.GetPowerTable(ctx, 14)
+		require.NoError(t, err)
+		require.Equal(t, newPt, actualPt)
+	}
+
+	if firstInstance > 0 {
+		_, err = cs.GetPowerTable(ctx, firstInstance-1)
+		require.ErrorContains(t, err, "cannot return a power table before the first instance")
+		_, err = cs.GetPowerTable(ctx, 0)
+		require.ErrorContains(t, err, "cannot return a power table before the first instance")
+	}
 }

--- a/f3.go
+++ b/f3.go
@@ -76,7 +76,7 @@ func (mc clientImpl) Logger() Logger {
 func New(ctx context.Context, id gpbft.ActorID, manifest Manifest, ds datastore.Datastore, h host.Host,
 	ps *pubsub.PubSub, sigs gpbft.SignerWithMarshaler, verif gpbft.Verifier, ec ECBackend, log Logger) (*F3, error) {
 	ds = namespace.Wrap(ds, manifest.NetworkName.DatastorePrefix())
-	cs, err := certstore.NewStore(ctx, ds)
+	cs, err := certstore.OpenOrCreateStore(ctx, ds, 0, manifest.InitialPowerTable)
 	if err != nil {
 		return nil, xerrors.Errorf("creating CertStore: %w", err)
 	}


### PR DESCRIPTION
This commit adds power tables to the certificate store.

1. It stores a full power table every `60*24` instances (twice a day on Filecoin).
2. From there, it applies deltas from finality certificates to recover any requested power table.