### PR TITLE
Group validation errors as top level `ValidationError`

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -1,21 +1,7 @@
 package gpbft
 
 import (
-	"errors"
 	"time"
-)
-
-// Sentinel errors for the message validation and reception APIs.
-var (
-	ErrValidationTooOld          = errors.New("message is for prior instance")
-	ErrValidationNoCommittee     = errors.New("no committee for instance")
-	ErrValidationInvalid         = errors.New("message invalid")
-	ErrValidationWrongBase       = errors.New("unexpected base chain")
-	ErrValidationWrongSupplement = errors.New("unexpected supplemental data")
-
-	ErrReceivedWrongInstance    = errors.New("received message for wrong instance")
-	ErrReceivedAfterTermination = errors.New("received message after terminating")
-	ErrReceivedInternalError    = errors.New("error processing message")
 )
 
 type MessageValidator interface {

--- a/gpbft/errors.go
+++ b/gpbft/errors.go
@@ -1,0 +1,41 @@
+package gpbft
+
+import "errors"
+
+var (
+	_ error = (*ValidationError)(nil)
+
+	// ErrValidationTooOld signals that a message is invalid because belongs to prior
+	// instances of gpbft.
+	ErrValidationTooOld = newValidationError("message is for prior instance")
+	// ErrValidationNoCommittee signals that a message is invalid because there is no
+	// committee for the instance to which it belongs.
+	//
+	// See: Chain.GetCommitteeForInstance.
+	ErrValidationNoCommittee = newValidationError("no committee for instance")
+	// ErrValidationInvalid signals that a message violates the validity rules of
+	// gpbft protocol.
+	ErrValidationInvalid = newValidationError("message invalid")
+	// ErrValidationWrongBase signals that a message is invalid due to having an
+	// unexpected base ECChain.
+	//
+	// See: ECChain, TipSet, ECChain.Base
+	ErrValidationWrongBase = newValidationError("unexpected base chain")
+	//ErrValidationWrongSupplement signals that a message is invalid due to unexpected supplemental data.
+	//
+	// See SupplementalData.
+	ErrValidationWrongSupplement = newValidationError("unexpected supplemental data")
+
+	// ErrReceivedWrongInstance signals that a message is received with mismatching instance ID.
+	ErrReceivedWrongInstance = errors.New("received message for wrong instance")
+	// ErrReceivedAfterTermination signals that a message is received after the gpbft instance is terminated.
+	ErrReceivedAfterTermination = errors.New("received message after terminating")
+	// ErrReceivedInternalError signals that an error has occurred during message processing.
+	ErrReceivedInternalError = errors.New("error processing message")
+)
+
+// ValidationError signals that an error has occurred while validating a GMessage.
+type ValidationError struct{ message string }
+
+func newValidationError(message string) ValidationError { return ValidationError{message: message} }
+func (e ValidationError) Error() string                 { return e.message }

--- a/gpbft/errors_test.go
+++ b/gpbft/errors_test.go
@@ -1,0 +1,28 @@
+package gpbft
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidationError_SentinelValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject error
+	}{
+		{name: "ErrValidationTooOld", subject: ErrValidationTooOld},
+		{name: "ErrValidationNoCommittee", subject: ErrValidationNoCommittee},
+		{name: "ErrValidationInvalid", subject: ErrValidationInvalid},
+		{name: "ErrValidationWrongBase", subject: ErrValidationWrongBase},
+		{name: "ErrValidationWrongSupplement", subject: ErrValidationWrongSupplement},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			require.True(t, errors.As(test.subject, &ValidationError{}))
+			require.True(t, errors.As(test.subject, &ValidationError{message: "fish"}))
+		})
+	}
+}

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -269,7 +269,7 @@ func (i *instance) ReceiveMany(msgs []*GMessage) error {
 	for _, msg := range msgs {
 		stateChanged, err := i.receiveOne(msg)
 		if err != nil {
-			if errors.Is(err, ErrValidationWrongBase) || errors.Is(err, ErrValidationWrongSupplement) {
+			if errors.As(err, &ValidationError{}) {
 				// Drop late-binding validation errors.
 				i.log("dropping invalid message: %s", err)
 			} else {


### PR DESCRIPTION
The validation errors are numerous enough to grant the presence of some higher level grouping for convenient API usage. This allows the users to infer whether an error was caused by validation without having to list every sentinel error associated with validation errors.

Relates to: https://github.com/filecoin-project/go-f3/pull/294#discussion_r1626602926