### PR TITLE
Rename Module to F3, pass network name to Client, fix error wrapping

### DIFF
--- a/f3.go
+++ b/f3.go
@@ -71,9 +71,9 @@ func (mc moduleClient) Logger() Logger {
 	return mc.logger
 }
 
-// NewModule creates and setups new libp2p f3 module
+// New creates and setups f3 with libp2p
 // The context is used for initialization not runtime.
-func NewModule(ctx context.Context, id gpbft.ActorID, manifest Manifest, ds datastore.Datastore, h host.Host,
+func New(ctx context.Context, id gpbft.ActorID, manifest Manifest, ds datastore.Datastore, h host.Host,
 	ps *pubsub.PubSub, sigs gpbft.SignerWithMarshaler, verif gpbft.Verifier, ec ECBackend, log Logger) (*Module, error) {
 	ds = namespace.Wrap(ds, manifest.NetworkName.DatastorePrefix())
 	cs, err := certstore.NewStore(ctx, ds)
@@ -96,6 +96,7 @@ func NewModule(ctx context.Context, id gpbft.ActorID, manifest Manifest, ds data
 		log:    log,
 
 		client: moduleClient{
+			nn:                  manifest.NetworkName,
 			id:                  id,
 			Verifier:            verif,
 			SignerWithMarshaler: sigs,

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+
+	xerrors "golang.org/x/xerrors"
 )
 
 // An F3 participant runs repeated instances of Granite to finalise longer chains.
@@ -100,7 +102,7 @@ func (p *Participant) ValidateMessage(msg *GMessage) (valid ValidatedMessage, er
 
 	// Validate the message.
 	if err = ValidateMessage(comt.power, comt.beacon, p.host, msg); err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrValidationInvalid, err)
+		return nil, xerrors.Errorf("%v: %w", err, ErrValidationInvalid)
 	}
 	return &validatedMessage{msg: msg}, nil
 }

--- a/host.go
+++ b/host.go
@@ -34,6 +34,7 @@ type gpbftRunner struct {
 	log        Logger
 }
 
+// gpbftHost is a newtype of gpbftRunner exposing APIs required by the gpbft.Participant
 type gpbftHost gpbftRunner
 
 func newRunner(id gpbft.ActorID, m Manifest, client Client) (*gpbftRunner, error) {

--- a/host.go
+++ b/host.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Client interface {
-	gpbft.Signer
+	gpbft.SignerWithMarshaler
 	gpbft.Verifier
 	gpbft.Tracer
 
@@ -19,6 +19,8 @@ type Client interface {
 	Logger() Logger
 }
 
+// gpbftRunner is responsible for running gpbft.Participant, taking in all concurrent events and
+// passing them to gpbft in a single thread.
 type gpbftRunner struct {
 	client      Client
 	participant *gpbft.Participant
@@ -30,14 +32,9 @@ type gpbftRunner struct {
 
 	runningCtx context.Context
 	log        Logger
-
-	host *gpbftHost
 }
 
-type gpbftHost struct {
-	Client
-	runner *gpbftRunner
-}
+type gpbftHost gpbftRunner
 
 func newRunner(id gpbft.ActorID, m Manifest, client Client) (*gpbftRunner, error) {
 	runner := &gpbftRunner{
@@ -46,11 +43,6 @@ func newRunner(id gpbft.ActorID, m Manifest, client Client) (*gpbftRunner, error
 		selfMessageQueue: make(chan *gpbft.GMessage, 20),
 		log:              client.Logger(),
 	}
-	host := &gpbftHost{
-		Client: client,
-		runner: runner,
-	}
-	runner.host = host
 
 	// create a stopped timer to facilitate alerts requested from gpbft
 	runner.alertTimer = time.NewTimer(100 * time.Hour)
@@ -59,7 +51,7 @@ func newRunner(id gpbft.ActorID, m Manifest, client Client) (*gpbftRunner, error
 	}
 
 	runner.log.Infof("starting host for P%d", id)
-	p, err := gpbft.NewParticipant(host, gpbft.WithTracer(client))
+	p, err := gpbft.NewParticipant((*gpbftHost)(runner), gpbft.WithTracer(client))
 	if err != nil {
 		return nil, xerrors.Errorf("creating participant: %w", err)
 	}
@@ -118,7 +110,7 @@ loop:
 func (h *gpbftRunner) deliverMessage(msg *gpbft.GMessage) error {
 	valid, err := h.participant.ValidateMessage(msg)
 	if err != nil {
-		return err
+		return xerrors.Errorf("validating message: %w", err)
 	}
 	return h.participant.ReceiveMessage(valid)
 }
@@ -144,7 +136,7 @@ func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.Supplemental
 
 func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable, []byte, error) {
 	table := gpbft.NewPowerTable()
-	err := table.Add(h.runner.manifest.InitialPowerTable...)
+	err := table.Add(h.manifest.InitialPowerTable...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -153,15 +145,15 @@ func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable,
 
 // Returns the network's name (for signature separation)
 func (h *gpbftHost) NetworkName() gpbft.NetworkName {
-	return h.runner.manifest.NetworkName
+	return h.manifest.NetworkName
 }
 
 // Sends a message to all other participants.
 // The message's sender must be one that the network interface can sign on behalf of.
 func (h *gpbftHost) RequestBroadcast(mb *gpbft.MessageBuilder) error {
-	err := h.Client.BroadcastMessage(h.runner.runningCtx, mb)
+	err := h.client.BroadcastMessage(h.runningCtx, mb)
 	if err != nil {
-		h.runner.log.Errorf("broadcasting GMessage: %+v", err)
+		h.log.Errorf("broadcasting GMessage: %+v", err)
 		return err
 	}
 	return nil
@@ -178,10 +170,10 @@ func (h *gpbftHost) Time() time.Time {
 // The timestamp may be in the past, in which case the alarm will fire as soon as possible
 // (but not synchronously).
 func (h *gpbftHost) SetAlarm(at time.Time) {
-	h.runner.log.Infof("set alarm for %v", at)
+	h.log.Infof("set alarm for %v", at)
 	// we cannot reuse the timer because we don't know if it was read or not
-	h.runner.alertTimer.Stop()
-	h.runner.alertTimer = time.NewTimer(time.Until(at))
+	h.alertTimer.Stop()
+	h.alertTimer = time.NewTimer(time.Until(at))
 }
 
 // Receives a finality decision from the instance, with signatures from a strong quorum
@@ -191,7 +183,7 @@ func (h *gpbftHost) SetAlarm(at time.Time) {
 // based on the decision received (which may be in the past).
 // E.g. this might be: finalised tipset timestamp + epoch duration + stabilisation delay.
 func (h *gpbftHost) ReceiveDecision(decision *gpbft.Justification) time.Time {
-	h.runner.log.Infof("got decision: %+v", decision)
+	h.log.Infof("got decision: %+v", decision)
 	//TODO propagate and save this for use in GetCanonicalChain
 	return time.Now().Add(2 * time.Second)
 }
@@ -200,5 +192,27 @@ func (h *gpbftHost) ReceiveDecision(decision *gpbft.Justification) time.Time {
 // This should usually call `Payload.MarshalForSigning(NetworkName)` except when testing as
 // that method is slow (computes a merkle tree that's necessary for testing).
 func (h *gpbftHost) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Payload) []byte {
-	return p.MarshalForSigning(nn)
+	return h.client.MarshalPayloadForSigning(nn, p)
+}
+
+// Verifies a signature for the given public key.
+// Implementations must be safe for concurrent use.
+func (h *gpbftHost) Verify(pubKey gpbft.PubKey, msg []byte, sig []byte) error {
+	return h.client.Verify(pubKey, msg, sig)
+}
+
+// Aggregates signatures from a participants.
+func (h *gpbftHost) Aggregate(pubKeys []gpbft.PubKey, sigs [][]byte) ([]byte, error) {
+	return h.client.Aggregate(pubKeys, sigs)
+}
+
+// VerifyAggregate verifies an aggregate signature.
+// Implementations must be safe for concurrent use.
+func (h *gpbftHost) VerifyAggregate(payload []byte, aggSig []byte, signers []gpbft.PubKey) error {
+	return h.client.VerifyAggregate(payload, aggSig, signers)
+}
+
+// Signs a message with the secret key corresponding to a public key.
+func (h *gpbftHost) Sign(sender gpbft.PubKey, msg []byte) ([]byte, error) {
+	return h.client.Sign(sender, msg)
 }


### PR DESCRIPTION
It simplifies the structure of F3, gpbftHost/Runner. gpbftHost becomes a newtype of gpbftRunner to isolate exposure of APIs.