### PR TITLE
Fix minor staticcheck issues

### DIFF
--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -121,7 +121,7 @@ func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]cert
 	return certs, nil
 }
 
-func (_ *Store) keyForInstance(i uint64) datastore.Key {
+func (*Store) keyForInstance(i uint64) datastore.Key {
 	return datastore.NewKey(fmt.Sprintf("/certs/%016X", i))
 }
 

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -71,7 +71,7 @@ func (s *FakeBackend) Verify(signer gpbft.PubKey, msg, sig []byte) error {
 	}
 }
 
-func (_ *FakeBackend) Aggregate(signers []gpbft.PubKey, sigs [][]byte) ([]byte, error) {
+func (*FakeBackend) Aggregate(signers []gpbft.PubKey, sigs [][]byte) ([]byte, error) {
 	if len(signers) != len(sigs) {
 		return nil, errors.New("public keys and signatures length mismatch")
 	}


### PR DESCRIPTION
Fix minor staticcheck issues to reduce noise in local development environment. These issues don't seem to have been picked up by golangci-lint.