### PR TITLE
Fix plumbing of per-participant logger.

### DIFF
--- a/sim/host.go
+++ b/sim/host.go
@@ -34,6 +34,7 @@ type simHost struct {
 
 type SimNetwork interface {
 	gpbft.Network
+	gpbft.Tracer
 	// sends a message to all other participants immediately.
 	BroadcastSynchronous(msg *gpbft.GMessage)
 }
@@ -93,4 +94,8 @@ func (v *simHost) PublicKey( /*instance */ uint64) gpbft.PubKey {
 
 func (v *simHost) ID() gpbft.ActorID {
 	return v.id
+}
+
+func (v *simHost) Log(format string, args ...any) {
+	v.SimNetwork.Log(format, args...)
 }

--- a/sim/network.go
+++ b/sim/network.go
@@ -137,10 +137,6 @@ func (n *Network) SetAlarm(sender gpbft.ActorID, at time.Time) {
 	)
 }
 
-func (n *Network) Log(format string, args ...any) {
-	n.log(TraceLogic, format, args...)
-}
-
 // Tick disseminates one message among participants and returns whether there are
 // any more messages to process.
 func (n *Network) Tick(adv *adversary.Adversary) (bool, error) {
@@ -164,7 +160,7 @@ func (n *Network) Tick(adv *adversary.Adversary) (bool, error) {
 		// If GST has not elapsed, check if adversary allows the propagation of message.
 		if adv != nil && !n.globalStabilisationElapsed {
 			if n.hasGlobalStabilizationTimeElapsed() {
-				n.Log("GST elapsed")
+				n.log(TraceRecvd, "GST elapsed")
 				n.globalStabilisationElapsed = true
 			} else if !adv.AllowMessage(msg.source, msg.dest, payload) {
 				// GST has not passed and adversary blocks the delivery of message; proceed to

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -143,11 +143,11 @@ func (s *Simulation) getPowerTable(instance uint64) (*gpbft.PowerTable, error) {
 }
 
 func (s *Simulation) initParticipants() error {
-	pOpts := append(s.gpbftOptions, gpbft.WithTracer(s.network))
 	var nextID gpbft.ActorID
 	for _, archetype := range s.honestParticipantArchetypes {
 		for i := 0; i < archetype.count; i++ {
 			host := newHost(nextID, s, archetype.ecChainGenerator, archetype.storagePowerGenerator)
+			pOpts := append(s.gpbftOptions, gpbft.WithTracer(host))
 			participant, err := newParticipant(nextID, host, pOpts...)
 			if err != nil {
 				return err


### PR DESCRIPTION
Logs were being plumbed directly to the network rather than the per-participant wrapper.