### PR TITLE
Document and adjust alarm delivery precedence over network messages

### DIFF
--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -48,6 +48,11 @@ type MessageReceiver interface {
 	// - both ErrReceivedInternalError and a cause if there was an internal error processing the message
 	// This method is not safe for concurrent use.
 	ReceiveMessage(msg ValidatedMessage) error
+	// ReceiveAlarm signals the trigger of the alarm set by Clock.SetAlarm. Note that
+	// triggering alarms takes precedence over ReceiveMessage, i.e. when an alarm is
+	// triggered at the same time as an arrival of a message ReceiveAlarm must be
+	// called before ReceiveMessage.
+	//
 	// This method is not safe for concurrent use.
 	ReceiveAlarm() error
 }
@@ -93,11 +98,13 @@ type Network interface {
 type Clock interface {
 	// Returns the current network time.
 	Time() time.Time
-	// Sets an alarm to fire after the given timestamp.
-	// At most one alarm can be set at a time.
-	// Setting an alarm replaces any previous alarm that has not yet fired.
-	// The timestamp may be in the past, in which case the alarm will fire as soon as possible
-	// (but not synchronously).
+	// SetAlarm sets an alarm to fire after the given timestamp. At most one alarm
+	// can be set at a time. Setting an alarm replaces any previous alarm that has
+	// not yet fired. The timestamp may be in the past, in which case the alarm will
+	// fire as soon as possible (but not synchronously).
+	//
+	// Note that delivery of triggered alarms must take precedence over messages
+	// that may arrive at the same time.
 	SetAlarm(at time.Time)
 }
 

--- a/sim/network.go
+++ b/sim/network.go
@@ -127,7 +127,7 @@ func (n *Network) SetAlarm(sender gpbft.ActorID, at time.Time) {
 	// Update any existing alarm or insert if no such alarm exists.
 	n.queue.UpsertFirstWhere(
 		func(m *messageInFlight) bool {
-			return m.dest == sender && m.payload == "ALARM"
+			return m.dest == sender && m.isAlarm()
 		}, &messageInFlight{
 			source:    sender,
 			dest:      sender,


### PR DESCRIPTION
Document the implicit assumption that the delivery of alarms to a participant must take precedence over broadcast messages.

Adjust simulation message queue to respect the alarm ordering.

Fixes #316