### PR TITLE
Simulate skip to future instances for lagging participants

### DIFF
--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -89,6 +89,12 @@ func (p *Participant) CurrentRound() uint64 {
 	return p.gpbft.round
 }
 
+func (p *Participant) CurrentInstance() uint64 {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.currentInstance
+}
+
 // Validates a message
 func (p *Participant) ValidateMessage(msg *GMessage) (valid ValidatedMessage, err error) {
 	defer func() {

--- a/test/deny_test.go
+++ b/test/deny_test.go
@@ -10,11 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestHonest_JumpsRounds(t *testing.T) {
+func TestDeny_SkipsToFuture(t *testing.T) {
 	t.Parallel()
-	// TODO: enable this test once message rebroadcast is implemented.
-	t.Skip("requires re-broadcast implementation to pass")
-
 	const (
 		instanceCount = 2000
 		maxRounds     = 20


### PR DESCRIPTION
The `SkipToInstance` API is intended to be called by an honest integrator whenever a finality certificate is observed from a future instance.

As a result `TestDeny_SkipsToFuture`, previously skipped, can now be run when the simulation itself (playing the role of honest integrator) notifies participants of the existence of a future round whenever it is applicable.

The changes here introduce a new participant receiver to get the current instance, and notified of future instance when it is behind the latest completed one.
