### PR TITLE
Rebroadcast last round of messages if instance has not progressed

### DIFF
--- a/sim/adversary/deny.go
+++ b/sim/adversary/deny.go
@@ -10,6 +10,11 @@ var _ Receiver = (*Deny)(nil)
 
 // Deny adversary denies all messages to/from a given set of participants for a
 // configured duration of time.
+//
+// For this adversary to take effect global stabilisation time must be configured
+// to be at least as long as the configured deny duration.
+//
+// See  sim.WithGlobalStabilizationTime.
 type Deny struct {
 	id          gpbft.ActorID
 	host        Host

--- a/sim/adversary/drop.go
+++ b/sim/adversary/drop.go
@@ -1,0 +1,95 @@
+package adversary
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+var _ Receiver = (*Drop)(nil)
+
+// Drop adversary stochastically drops messages to/from a given set of
+// participants for a configured duration of time, mimicking at-most-once message
+// delivery semantics across a simulation network.
+//
+// When no participants are set, all exchanged messages will be targeted by this
+// adversary. For this adversary to take effect global stabilisation time must be
+// configured to be at least as long as the configured drop duration.
+//
+// See  sim.WithGlobalStabilizationTime.
+type Drop struct {
+	id              gpbft.ActorID
+	host            Host
+	targetsByID     map[gpbft.ActorID]struct{}
+	gst             time.Time
+	rng             *rand.Rand
+	dropProbability float64
+}
+
+func NewDrop(id gpbft.ActorID, host Host, seed int64, dropProbability float64, dropDuration time.Duration, targets ...gpbft.ActorID) *Drop {
+	targetsByID := make(map[gpbft.ActorID]struct{})
+	for _, target := range targets {
+		targetsByID[target] = struct{}{}
+	}
+	return &Drop{
+		id:              id,
+		host:            host,
+		rng:             rand.New(rand.NewSource(seed)),
+		dropProbability: dropProbability,
+		targetsByID:     targetsByID,
+		gst:             time.Time{}.Add(dropDuration),
+	}
+}
+
+func NewDropGenerator(power *gpbft.StoragePower, seed int64, dropProbability float64, dropDuration time.Duration, targets ...gpbft.ActorID) Generator {
+	return func(id gpbft.ActorID, host Host) *Adversary {
+		return &Adversary{
+			Receiver: NewDrop(id, host, seed, dropProbability, dropDuration, targets...),
+			Power:    power,
+		}
+	}
+}
+
+func (d *Drop) ID() gpbft.ActorID {
+	return d.id
+}
+
+func (d *Drop) AllowMessage(from gpbft.ActorID, to gpbft.ActorID, _ gpbft.GMessage) bool {
+	// Stochastically drop messages until Global Stabilisation Time has
+	// elapsed, except messages to self.
+	switch {
+	case from == to, d.host.Time().After(d.gst), !d.isTargeted(to) && !d.isTargeted(from):
+		return true
+	default:
+		return d.allowStochastically()
+	}
+}
+
+func (d *Drop) allowStochastically() bool {
+	switch {
+	case d.dropProbability <= 0:
+		return true
+	case d.dropProbability >= 1.0:
+		return false
+	default:
+		return d.rng.Float64() > d.dropProbability
+	}
+}
+
+func (d *Drop) isTargeted(id gpbft.ActorID) bool {
+	if len(d.targetsByID) == 0 {
+		// Target all participants if no explicit IDs are set.
+		return true
+	}
+	_, found := d.targetsByID[id]
+	return found
+}
+
+func (*Drop) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
+	return Validated(msg), nil
+}
+
+func (*Drop) ReceiveMessage(gpbft.ValidatedMessage) error { return nil }
+func (*Drop) ReceiveAlarm() error                         { return nil }
+func (*Drop) StartInstance(uint64) error                  { return nil }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -79,13 +79,14 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 	if echoCount <= 0 {
 		return nil
 	}
-	supplementalData, _, err := r.host.GetProposalForInstance(0)
+	instance := msg.Vote.Instance
+	supplementalData, _, err := r.host.GetProposalForInstance(instance)
 	if err != nil {
 		panic(err)
 	}
-	power, beacon, _ := r.host.GetCommitteeForInstance(0)
+	power, beacon, _ := r.host.GetCommitteeForInstance(instance)
 	p := gpbft.Payload{
-		Instance:         msg.Vote.Instance,
+		Instance:         instance,
 		Round:            msg.Vote.Round,
 		Step:             msg.Vote.Step,
 		SupplementalData: *supplementalData,

--- a/test/absent_test.go
+++ b/test/absent_test.go
@@ -14,6 +14,7 @@ func FuzzAbsentAdversary(f *testing.F) {
 	f.Add(-56)
 	f.Add(22)
 	f.Add(0)
+	f.Add(-855) // Takes 12 rounds to complete.
 	f.Fuzz(func(t *testing.T, latencySeed int) {
 		t.Parallel()
 		sm, err := sim.NewSimulation(
@@ -26,7 +27,7 @@ func FuzzAbsentAdversary(f *testing.F) {
 				sim.WithAdversary(adversary.NewAbsentGenerator(oneStoragePower)),
 			)...)
 		require.NoError(t, err)
-		require.NoErrorf(t, sm.Run(1, maxRounds), "%s", sm.Describe())
+		require.NoErrorf(t, sm.Run(1, maxRounds+2), "%s", sm.Describe())
 	},
 	)
 }

--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -29,6 +29,7 @@ var (
 	testGpbftOptions = []gpbft.Option{
 		gpbft.WithDelta(200 * time.Millisecond),
 		gpbft.WithDeltaBackOffExponent(1.300),
+		gpbft.WithRebroadcastBackoff(1.3, time.Second, 5*time.Second),
 	}
 )
 

--- a/test/deny_test.go
+++ b/test/deny_test.go
@@ -14,7 +14,7 @@ func TestDeny_SkipsToFuture(t *testing.T) {
 	t.Parallel()
 	const (
 		instanceCount = 2000
-		maxRounds     = 20
+		maxRounds     = 30
 		denialTarget  = 0
 		gst           = 100 * EcEpochDuration
 	)

--- a/test/drop_test.go
+++ b/test/drop_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/sim"
+	"github.com/filecoin-project/go-f3/sim/adversary"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrop_ReachesConsensusDespiteMessageLoss(t *testing.T) {
+	t.Parallel()
+	const (
+		instanceCount       = 5000
+		gst                 = 1000 * EcEpochDuration
+		dropAdversaryTarget = 0
+	)
+	messageLossProbabilities := []float64{0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.0}
+	tests := []struct {
+		name    string
+		options []sim.Option
+	}{
+		{
+			name:    "sync",
+			options: syncOptions(),
+		},
+		{
+			name:    "async",
+			options: asyncOptions(-9856210),
+		},
+	}
+	for _, test := range tests {
+		test := test
+		for _, lossProbability := range messageLossProbabilities {
+			lossProbability := lossProbability
+			name := fmt.Sprintf("%s %.0f%% loss", test.name, lossProbability*100)
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				ecChainGenerator := sim.NewUniformECChainGenerator(54445, 1, 1)
+				var opts []sim.Option
+				opts = append(opts, test.options...)
+				opts = append(opts,
+					sim.AddHonestParticipants(5, ecChainGenerator, uniformOneStoragePower),
+					sim.WithAdversary(adversary.NewDropGenerator(oneStoragePower, 25, lossProbability, gst, dropAdversaryTarget)),
+					sim.WithGlobalStabilizationTime(gst),
+					sim.WithIgnoreConsensusFor(dropAdversaryTarget))
+				sm, err := sim.NewSimulation(opts...)
+				require.NoError(t, err)
+				require.NoErrorf(t, sm.Run(instanceCount, maxRounds), "%s", sm.Describe())
+				chain := ecChainGenerator.GenerateECChain(instanceCount-1, gpbft.TipSet{}, math.MaxUint64)
+				requireConsensusAtInstance(t, sm, instanceCount-1, *chain.Head())
+			})
+		}
+	}
+}

--- a/test/power_evolution_test.go
+++ b/test/power_evolution_test.go
@@ -25,6 +25,9 @@ func FuzzStoragePower_AsyncIncreaseMidSimulation(f *testing.F) {
 	f.Add(-784) // Requires 29 rounds to succeed. Investigate further for potential issues.
 	f.Add(5460) // Requires 62 rounds to succeed. Investigate further for potential issues.
 	f.Add(-563) // Requires 71 rounds to succeed. Investigate further for potential issues.
+	f.Add(5513) // Took too long once on CI.
+	f.Add(5412) // Took too long on local fuzzing.
+	f.Add(-607) // Took too long on local fuzzing.
 
 	f.Fuzz(func(t *testing.T, seed int) {
 		storagePowerIncreaseMidSimulationTest(t, seed, 8, maxRounds*8, asyncOptions(seed)...)

--- a/test/repeat_test.go
+++ b/test/repeat_test.go
@@ -80,12 +80,13 @@ func FuzzRepeatAdversary(f *testing.F) {
 		{
 			name:              "COMMIT Repeater",
 			repetitionSampler: repeatBoundedCommit,
-			maxRounds:         maxRounds * 2,
+			maxRounds:         maxRounds * 3,
 		},
 	}
 	f.Add(68465)
 	f.Add(-5)
 	f.Add(-5454)
+	f.Add(-5467)
 	f.Fuzz(func(t *testing.T, seed int) {
 		t.Parallel()
 		for _, hc := range repeatAdversaryTestHonestCounts {

--- a/test/spam_test.go
+++ b/test/spam_test.go
@@ -44,15 +44,17 @@ func TestSpamAdversary(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				ecChainGenerator := sim.NewUniformECChainGenerator(651651, 1, 10)
+				var gpbdtOpts []gpbft.Option
+				gpbdtOpts = append(gpbdtOpts, testGpbftOptions...)
+				gpbdtOpts = append(gpbdtOpts, gpbft.WithMaxLookaheadRounds(test.maxLookaheadRounds))
 				sm, err := sim.NewSimulation(
 					sim.WithLatencyModeler(func() (latency.Model, error) {
 						return latency.NewLogNormal(455454, time.Second), nil
 					}),
 					sim.WithECEpochDuration(EcEpochDuration),
 					sim.WitECStabilisationDelay(EcStabilisationDelay),
-					sim.WithGpbftOptions(testGpbftOptions...),
+					sim.WithGpbftOptions(gpbdtOpts...),
 					sim.AddHonestParticipants(hc, ecChainGenerator, uniformOneStoragePower),
-					sim.WithGpbftOptions(gpbft.WithMaxLookaheadRounds(test.maxLookaheadRounds)),
 					sim.WithAdversary(adversary.NewSpamGenerator(lessThanOneThirdAdversaryStoragePower, test.spamAheadRounds)),
 				)
 				require.NoError(t, err)


### PR DESCRIPTION
When the current instance has not progressed after some time rebroadcast the last round of messages. The rebroadcast time is made configurable using a bounded exponential backoff after phase timeout expires.The rebroadcast timeout is offset by phase timeout when not expired, and by latest rebroadcast time after that.

Once the first rebroadcast is triggered successive rebroadcasts use the `Clock` alarm mechanism to daisy-chain the triggers one after another.

Introduce `Drop` adversary to simulate scenarios where for a given set of target participants messages are dropped based on some configured message loss probability. Simulate tests using the `Drop` adversary and assert that despite stochastic message loss the targeted participant reaches the expected consensus.

Fixes #243