### PR TITLE
Merge participant Start and SkipToInstance into a single StartInstance method.

### DIFF
--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -30,6 +30,10 @@ var runCmd = cli.Command{
 			Name:  "id",
 			Value: 0,
 		},
+		&cli.Uint64Flag{
+			Name:  "instance",
+			Value: 0,
+		},
 	},
 	Action: func(c *cli.Context) error {
 		ctx := c.Context
@@ -77,7 +81,8 @@ var runCmd = cli.Command{
 			return xerrors.Errorf("creating module: %w", err)
 		}
 
-		return module.Run(ctx)
+		initialInstance := c.Uint64("id")
+		return module.Run(initialInstance, ctx)
 	},
 }
 

--- a/f3.go
+++ b/f3.go
@@ -156,7 +156,7 @@ func (m *F3) teardownPubsub() error {
 }
 
 // Run start the module. It will exit when context is cancelled.
-func (m *F3) Run(ctx context.Context) error {
+func (m *F3) Run(initialInstance uint64, ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -180,7 +180,7 @@ func (m *F3) Run(ctx context.Context) error {
 	runnerErrCh := make(chan error, 1)
 
 	go func() {
-		err := runner.Run(ctx)
+		err := runner.Run(initialInstance, ctx)
 		m.log.Errorf("running host: %+v", err)
 		runnerErrCh <- err
 	}()

--- a/gpbft/api.go
+++ b/gpbft/api.go
@@ -46,13 +46,10 @@ type MessageReceiver interface {
 // Calls to methods on this interface are expected to be serialized.
 // The methods are not safe for concurrent use, and may panic if called concurrently.
 type Receiver interface {
-	// Begins executing the protocol.
+	// Begins executing the protocol from some instance.
 	// The node will subsequently request the canonical chain to propose from the host.
-	Start() error
-	// SkipToInstance jumps directly to a given instance.
-	// This can be triggered by the reception of a valid finality certificate, or
-	// whenever a new instance for a participant want to be started.
-	SkipToInstance(uint64) error
+	// If the participant is already executing some instance, it will be abandoned.
+	StartInstance(uint64) error
 	MessageValidator
 	MessageReceiver
 }

--- a/gpbft/options.go
+++ b/gpbft/options.go
@@ -17,7 +17,6 @@ type options struct {
 	delta                time.Duration
 	deltaBackOffExponent float64
 
-	initialInstance    uint64
 	maxLookaheadRounds uint64
 
 	// tracer traces logic logs for debugging and simulation purposes.
@@ -64,15 +63,6 @@ func WithDeltaBackOffExponent(e float64) Option {
 			return errors.New("delta backoff exponent cannot be less than zero")
 		}
 		o.deltaBackOffExponent = e
-		return nil
-	}
-}
-
-// WithInitialInstance sets the first instance number. Defaults to zero if
-// unspecified.
-func WithInitialInstance(i uint64) Option {
-	return func(o *options) error {
-		o.initialInstance = i
 		return nil
 	}
 }

--- a/host.go
+++ b/host.go
@@ -57,7 +57,7 @@ func newRunner(id gpbft.ActorID, m Manifest, client Client) (*gpbftRunner, error
 	return runner, nil
 }
 
-func (h *gpbftRunner) Run(ctx context.Context) error {
+func (h *gpbftRunner) Run(instance uint64, ctx context.Context) error {
 	var cancel func()
 	h.runningCtx, cancel = context.WithCancel(ctx)
 	defer cancel()
@@ -65,7 +65,7 @@ func (h *gpbftRunner) Run(ctx context.Context) error {
 	// TODO(Kubuxu): temporary hack until re-broadcast and/or booststrap synchronisation are implemented
 	time.Sleep(2 * time.Second)
 
-	err := h.participant.Start()
+	err := h.participant.StartInstance(instance)
 	if err != nil {
 		return xerrors.Errorf("starting a participant: %w", err)
 	}

--- a/sim/adversary/absent.go
+++ b/sim/adversary/absent.go
@@ -32,9 +32,7 @@ func (a *Absent) ID() gpbft.ActorID {
 	return a.id
 }
 
-func (*Absent) Start() error {
-	return nil
-}
+func (*Absent) StartInstance(uint64) error { return nil }
 
 func (*Absent) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
 	return Validated(msg), nil
@@ -43,8 +41,6 @@ func (*Absent) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, err
 func (*Absent) ReceiveMessage(_ gpbft.ValidatedMessage) error {
 	return nil
 }
-
-func (*Absent) SkipToInstance(uint64) error { return nil }
 
 func (*Absent) ReceiveAlarm() error {
 	return nil

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -35,25 +35,25 @@ func (i *ImmediateDecide) ID() gpbft.ActorID {
 	return i.id
 }
 
-func (i *ImmediateDecide) Start() error {
-	supplementalData, _, err := i.host.GetProposalForInstance(0)
+func (i *ImmediateDecide) StartInstance(instance uint64) error {
+	supplementalData, _, err := i.host.GetProposalForInstance(instance)
 	if err != nil {
 		panic(err)
 	}
-	powertable, _, err := i.host.GetCommitteeForInstance(0)
+	powertable, _, err := i.host.GetCommitteeForInstance(instance)
 	if err != nil {
 		panic(err)
 	}
 	// Immediately send a DECIDE message
 	payload := gpbft.Payload{
-		Instance:         0,
+		Instance:         instance,
 		Round:            0,
 		Step:             gpbft.DECIDE_PHASE,
 		Value:            i.value,
 		SupplementalData: *supplementalData,
 	}
 	justificationPayload := gpbft.Payload{
-		Instance:         0,
+		Instance:         instance,
 		Round:            0,
 		Step:             gpbft.COMMIT_PHASE,
 		Value:            i.value,
@@ -94,8 +94,6 @@ func (*ImmediateDecide) ReceiveMessage(_ gpbft.ValidatedMessage) error {
 func (*ImmediateDecide) ReceiveAlarm() error {
 	return nil
 }
-
-func (*ImmediateDecide) SkipToInstance(uint64) error { return nil }
 
 func (*ImmediateDecide) AllowMessage(_ gpbft.ActorID, _ gpbft.ActorID, _ gpbft.GMessage) bool {
 	// Allow all messages

--- a/sim/adversary/deny.go
+++ b/sim/adversary/deny.go
@@ -59,10 +59,9 @@ func (d *Deny) isTargeted(id gpbft.ActorID) bool {
 	return found
 }
 
-func (*Deny) Start() error { return nil }
+func (*Deny) StartInstance(uint64) error { return nil }
 func (*Deny) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMessage, error) {
 	return Validated(msg), nil
 }
 func (*Deny) ReceiveMessage(_ gpbft.ValidatedMessage) error { return nil }
 func (*Deny) ReceiveAlarm() error                           { return nil }
-func (*Deny) SkipToInstance(uint64) error                   { return nil }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -107,7 +107,6 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 }
 
 func (r *Repeat) ID() gpbft.ActorID                                              { return r.id }
-func (r *Repeat) Start() error                                                   { return nil }
+func (r *Repeat) StartInstance(uint64) error                                     { return nil }
 func (r *Repeat) ReceiveAlarm() error                                            { return nil }
-func (r *Repeat) SkipToInstance(uint64) error                                    { return nil }
 func (r *Repeat) AllowMessage(gpbft.ActorID, gpbft.ActorID, gpbft.GMessage) bool { return true }

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -37,8 +37,9 @@ func NewSpamGenerator(power *gpbft.StoragePower, roundsAhead uint64) Generator {
 	}
 }
 
-func (s *Spam) Start() error {
+func (s *Spam) StartInstance(instance uint64) error {
 	// Immediately start spamming the network.
+	s.latestObservedInstance = instance
 	s.spamAtInstance(s.latestObservedInstance)
 	return nil
 }
@@ -84,5 +85,4 @@ func (s *Spam) spamAtInstance(instance uint64) {
 
 func (s *Spam) ID() gpbft.ActorID                                              { return s.id }
 func (s *Spam) ReceiveAlarm() error                                            { return nil }
-func (s *Spam) SkipToInstance(uint64) error                                    { return nil }
 func (s *Spam) AllowMessage(gpbft.ActorID, gpbft.ActorID, gpbft.GMessage) bool { return true }

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -49,16 +49,15 @@ func (w *WithholdCommit) ID() gpbft.ActorID {
 	return w.id
 }
 
-func (w *WithholdCommit) Start() error {
-
+func (w *WithholdCommit) StartInstance(instance uint64) error {
 	if len(w.victims) == 0 {
 		return errors.New("victims must be set")
 	}
-	supplementalData, _, err := w.host.GetProposalForInstance(0)
+	supplementalData, _, err := w.host.GetProposalForInstance(instance)
 	if err != nil {
 		panic(err)
 	}
-	powertable, _, err := w.host.GetCommitteeForInstance(0)
+	powertable, _, err := w.host.GetCommitteeForInstance(instance)
 	if err != nil {
 		panic(err)
 	}
@@ -66,14 +65,14 @@ func (w *WithholdCommit) Start() error {
 	// All victims need to see QUALITY and PREPARE in order to send their COMMIT,
 	// but only the one victim will see our COMMIT.
 	broadcast(gpbft.Payload{
-		Instance:         0,
+		Instance:         instance,
 		Round:            0,
 		Step:             gpbft.QUALITY_PHASE,
 		Value:            w.victimValue,
 		SupplementalData: *supplementalData,
 	}, nil)
 	preparePayload := gpbft.Payload{
-		Instance:         0,
+		Instance:         instance,
 		Round:            0,
 		Step:             gpbft.PREPARE_PHASE,
 		Value:            w.victimValue,
@@ -82,7 +81,7 @@ func (w *WithholdCommit) Start() error {
 	broadcast(preparePayload, nil)
 
 	commitPayload := gpbft.Payload{
-		Instance:         0,
+		Instance:         instance,
 		Round:            0,
 		Step:             gpbft.COMMIT_PHASE,
 		Value:            w.victimValue,
@@ -129,8 +128,6 @@ func (*WithholdCommit) ValidateMessage(msg *gpbft.GMessage) (gpbft.ValidatedMess
 func (*WithholdCommit) ReceiveMessage(_ gpbft.ValidatedMessage) error {
 	return nil
 }
-
-func (*WithholdCommit) SkipToInstance(uint64) error { return nil }
 
 func (*WithholdCommit) ReceiveAlarm() error {
 	return nil


### PR DESCRIPTION
Removes the initialInstance config option too, in favour of the runtime parameter.

The parameter is necessary for in every case except the initial instance, i.e. it's not a one-time static value like other options. Given the single entry point, if we left the config option there as well, there would be two different initial instances at bootstrap, which would be confusing. This parameter makes the data flow of the initial instance very clear, providing it exactly when it is first needed.