### PR TITLE
Fix typo in interface method name

### DIFF
--- a/f3.go
+++ b/f3.go
@@ -58,7 +58,7 @@ func (mc clientImpl) BroadcastMessage(ctx context.Context, mb *gpbft.MessageBuil
 	return mc.topic.Publish(ctx, bw.Bytes())
 }
 
-func (mc clientImpl) IncommingMessages() <-chan *gpbft.GMessage {
+func (mc clientImpl) IncomingMessages() <-chan *gpbft.GMessage {
 	return mc.messageQueue
 }
 

--- a/host.go
+++ b/host.go
@@ -15,7 +15,7 @@ type Client interface {
 	gpbft.Tracer
 
 	BroadcastMessage(context.Context, *gpbft.MessageBuilder) error
-	IncommingMessages() <-chan *gpbft.GMessage
+	IncomingMessages() <-chan *gpbft.GMessage
 	Logger() Logger
 }
 
@@ -73,7 +73,7 @@ func (h *gpbftRunner) Run(ctx context.Context) error {
 		return xerrors.Errorf("starting a participant: %w", err)
 	}
 
-	messageQueue := h.client.IncommingMessages()
+	messageQueue := h.client.IncomingMessages()
 loop:
 	for {
 		select {


### PR DESCRIPTION
Correct the spelling of `Client.IncomingMessages` receiver.