### PR TITLE
Broadcast supplemental data as part of `GMessage`

### DIFF
--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -895,10 +895,11 @@ func (i *instance) terminated() bool {
 
 func (i *instance) broadcast(round uint64, step Phase, value ECChain, createTicket bool, justification *Justification) {
 	p := Payload{
-		Instance: i.instanceID,
-		Round:    round,
-		Step:     step,
-		Value:    value,
+		Instance:         i.instanceID,
+		Round:            round,
+		Step:             step,
+		SupplementalData: *i.supplementalData,
+		Value:            value,
 	}
 	mb := NewMessageBuilder(&i.powerTable)
 	mb.SetPayload(p)
@@ -929,10 +930,11 @@ func (i *instance) buildJustification(quorum QuorumResult, round uint64, phase P
 	}
 	return &Justification{
 		Vote: Payload{
-			Instance: i.instanceID,
-			Round:    round,
-			Step:     phase,
-			Value:    value,
+			Instance:         i.instanceID,
+			Round:            round,
+			Step:             phase,
+			Value:            value,
+			SupplementalData: *i.supplementalData,
 		},
 		Signers:   quorum.SignersBitfield(),
 		Signature: aggSignature,

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -36,19 +36,28 @@ func (i *ImmediateDecide) ID() gpbft.ActorID {
 }
 
 func (i *ImmediateDecide) Start() error {
-	powertable, _, _ := i.host.GetCommitteeForInstance(0)
+	supplementalData, _, err := i.host.GetProposalForInstance(0)
+	if err != nil {
+		panic(err)
+	}
+	powertable, _, err := i.host.GetCommitteeForInstance(0)
+	if err != nil {
+		panic(err)
+	}
 	// Immediately send a DECIDE message
 	payload := gpbft.Payload{
-		Instance: 0,
-		Round:    0,
-		Step:     gpbft.DECIDE_PHASE,
-		Value:    i.value,
+		Instance:         0,
+		Round:            0,
+		Step:             gpbft.DECIDE_PHASE,
+		Value:            i.value,
+		SupplementalData: *supplementalData,
 	}
 	justificationPayload := gpbft.Payload{
-		Instance: 0,
-		Round:    0,
-		Step:     gpbft.COMMIT_PHASE,
-		Value:    i.value,
+		Instance:         0,
+		Round:            0,
+		Step:             gpbft.COMMIT_PHASE,
+		Value:            i.value,
+		SupplementalData: *supplementalData,
 	}
 	sigPayload := i.host.MarshalPayloadForSigning(i.host.NetworkName(), &justificationPayload)
 	_, pubkey := powertable.Get(i.id)

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -79,18 +79,21 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 	if echoCount <= 0 {
 		return nil
 	}
-
+	supplementalData, _, err := r.host.GetProposalForInstance(0)
+	if err != nil {
+		panic(err)
+	}
 	power, beacon, _ := r.host.GetCommitteeForInstance(0)
 	p := gpbft.Payload{
-		Instance: msg.Vote.Instance,
-		Round:    msg.Vote.Round,
-		Step:     msg.Vote.Step,
-		Value:    msg.Vote.Value,
+		Instance:         msg.Vote.Instance,
+		Round:            msg.Vote.Round,
+		Step:             msg.Vote.Step,
+		SupplementalData: *supplementalData,
+		Value:            msg.Vote.Value,
 	}
 	mt := gpbft.NewMessageBuilderWithPowerTable(power)
 	mt.SetPayload(p)
 	mt.SetJustification(msg.Justification)
-
 	if len(msg.Ticket) != 0 {
 		mt.SetBeaconForTicket(beacon)
 	}

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -61,14 +61,19 @@ func (s *Spam) spamAtInstance(instance uint64) {
 	// Spam the network with COMMIT messages by incrementing rounds up to
 	// roundsAhead.
 	for spamRound := uint64(0); spamRound < s.roundsAhead; spamRound++ {
+		supplementalData, _, err := s.host.GetProposalForInstance(instance)
+		if err != nil {
+			panic(err)
+		}
 		power, _, err := s.host.GetCommitteeForInstance(instance)
 		if err != nil {
 			panic(err)
 		}
 		p := gpbft.Payload{
-			Instance: instance,
-			Round:    spamRound,
-			Step:     gpbft.COMMIT_PHASE,
+			Instance:         instance,
+			Round:            spamRound,
+			SupplementalData: *supplementalData,
+			Step:             gpbft.COMMIT_PHASE,
 		}
 		mt := gpbft.NewMessageBuilderWithPowerTable(power)
 		mt.SetPayload(p)

--- a/sim/ec.go
+++ b/sim/ec.go
@@ -32,6 +32,8 @@ type ECInstance struct {
 	PowerTable *gpbft.PowerTable
 	// The beacon value to use for this instance.
 	Beacon []byte
+	// SupplementalData is the additional data for this instance.
+	SupplementalData *gpbft.SupplementalData
 
 	ec        *simEC
 	decisions map[gpbft.ActorID]*gpbft.Justification
@@ -60,13 +62,17 @@ func (ec *simEC) BeginInstance(baseChain gpbft.ECChain, pt *gpbft.PowerTable) *E
 	// Take beacon value from the head of the base chain.
 	// Note a real beacon value will come from a finalised chain with some lookback.
 	beacon := baseChain.Head().Key
+	nextInstanceID := uint64(ec.Len())
 	instance := &ECInstance{
-		Instance:   uint64(ec.Len()),
+		Instance:   nextInstanceID,
 		BaseChain:  baseChain,
 		PowerTable: pt,
 		Beacon:     beacon,
-		ec:         ec,
-		decisions:  make(map[gpbft.ActorID]*gpbft.Justification),
+		SupplementalData: &gpbft.SupplementalData{
+			PowerTable: gpbft.CID(fmt.Sprintf("supp-data-pt@%d", nextInstanceID)),
+		},
+		ec:        ec,
+		decisions: make(map[gpbft.ActorID]*gpbft.Justification),
 	}
 	ec.instances = append(ec.instances, instance)
 	return instance

--- a/sim/host.go
+++ b/sim/host.go
@@ -59,7 +59,8 @@ func (v *simHost) GetProposalForInstance(instance uint64) (*gpbft.SupplementalDa
 	// Use the head of latest agreement chain as the base of next.
 	// TODO: use lookback to return the correct next power table commitment and commitments hash.
 	chain := v.ecg.GenerateECChain(instance, *v.ecChain.Head(), v.id)
-	return new(gpbft.SupplementalData), chain, nil
+	i := v.sim.ec.GetInstance(instance)
+	return i.SupplementalData, chain, nil
 }
 
 func (v *simHost) GetCommitteeForInstance(instance uint64) (power *gpbft.PowerTable, beacon []byte, err error) {


### PR DESCRIPTION
The supplemental data provided by host is required for additional validation. It is already present in the payload of message builder but not the final `GMessaage`s built from it.

The changes here broadcast supplemental data as part of `GMessage` and enhances simulation to generate a unique supplemental data per instance that is required to be consistent across participant for a given instance.

Fixes #335