### PR TITLE
Use consistent request broadcast pattern in simulated sync broadcasts

### DIFF
--- a/sim/adversary/adversary.go
+++ b/sim/adversary/adversary.go
@@ -14,7 +14,7 @@ type Host interface {
 	// Sends a message to all other participants, immediately.
 	// Note that the adversary can subsequently delay delivery to some participants,
 	// before messages are actually received.
-	BroadcastSynchronous(msg *gpbft.GMessage)
+	RequestSynchronousBroadcast(mb *gpbft.MessageBuilder) error
 }
 
 type Generator func(gpbft.ActorID, Host) *Adversary

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -61,15 +61,15 @@ func (s *Spam) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 func (s *Spam) spamAtInstance(instance uint64) {
 	// Spam the network with COMMIT messages by incrementing rounds up to
 	// roundsAhead.
+	supplementalData, _, err := s.host.GetProposalForInstance(instance)
+	if err != nil {
+		panic(err)
+	}
+	power, _, err := s.host.GetCommitteeForInstance(instance)
+	if err != nil {
+		panic(err)
+	}
 	for spamRound := uint64(0); spamRound < s.roundsAhead; spamRound++ {
-		supplementalData, _, err := s.host.GetProposalForInstance(instance)
-		if err != nil {
-			panic(err)
-		}
-		power, _, err := s.host.GetCommitteeForInstance(instance)
-		if err != nil {
-			panic(err)
-		}
 		p := gpbft.Payload{
 			Instance:         instance,
 			Round:            spamRound,
@@ -78,8 +78,9 @@ func (s *Spam) spamAtInstance(instance uint64) {
 		}
 		mt := gpbft.NewMessageBuilderWithPowerTable(power)
 		mt.SetPayload(p)
-
-		_ = s.host.RequestBroadcast(mt)
+		if err := s.host.RequestBroadcast(mt); err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/sim/host.go
+++ b/sim/host.go
@@ -32,11 +32,15 @@ type simHost struct {
 	spg     StoragePowerGenerator
 }
 
+func (v *simHost) RequestSynchronousBroadcast(mb *gpbft.MessageBuilder) error {
+	return v.SimNetwork.RequestSynchronousBroadcast(mb)
+}
+
 type SimNetwork interface {
 	gpbft.Network
 	gpbft.Tracer
 	// sends a message to all other participants immediately.
-	BroadcastSynchronous(msg *gpbft.GMessage)
+	RequestSynchronousBroadcast(mb *gpbft.MessageBuilder) error
 }
 
 func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg StoragePowerGenerator) *simHost {


### PR DESCRIPTION
To implement some adversary models the simulation package introduces an interface that allows an adversary host to immediately propagate a message across the network.

Since the original implementation the core broadcast mechanisms has evolved into async `RequestBroadcast` that takes a builder. But the pattern is not fully applied to the simulation specific flavour of synchronous broadcast.

The changes here use the same builder pattern in simulation and reflect changes across adversary models.