### PR TITLE
Follow golang naming convention for constants

### DIFF
--- a/ec/fake_ec.go
+++ b/ec/fake_ec.go
@@ -79,7 +79,7 @@ func (ec *FakeEC) genTipset(epoch int64) *Tipset {
 		// from 12.5% to 1.5%
 		size = rng[0] % 8
 	}
-	tsk := make([]byte, 0, size*gpbft.CID_MAX_LEN)
+	tsk := make([]byte, 0, size*gpbft.CidMaxLen)
 
 	if size == 0 {
 		return nil

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -52,7 +52,7 @@ func (p Phase) String() string {
 	}
 }
 
-const DOMAIN_SEPARATION_TAG = "GPBFT"
+const DomainSeparationTag = "GPBFT"
 
 // A message in the Granite protocol.
 // The same message structure is used for all rounds and phases.
@@ -132,7 +132,7 @@ func (p *Payload) MarshalForSigning(nn NetworkName) []byte {
 	root := merkle.Tree(values)
 
 	var buf bytes.Buffer
-	buf.WriteString(DOMAIN_SEPARATION_TAG)
+	buf.WriteString(DomainSeparationTag)
 	buf.WriteString(":")
 	buf.WriteString(string(nn))
 	buf.WriteString(":")

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -207,7 +207,7 @@ func (p *Participant) beginInstance() error {
 	if chain.IsZero() {
 		return errors.New("canonical chain cannot be zero-valued")
 	}
-	chain = chain.Prefix(CHAIN_MAX_LEN - 1)
+	chain = chain.Prefix(ChainMaxLen - 1)
 	if err := chain.Validate(); err != nil {
 		return fmt.Errorf("invalid canonical chain: %w", err)
 	}

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -101,7 +101,7 @@ func (pt *participantTestSubject) expectBeginInstance() {
 	// Without the `Maybe` the tests immediately fails here:
 	// https://github.com/filecoin-project/go-f3/blob/d27d281109d31485fc4ac103e2af58afb86c158f/gpbft/gpbft.go#L395
 	pt.host.On("MarshalPayloadForSigning", pt.networkName, mock.AnythingOfType("*gpbft.Payload")).
-		Return([]byte(gpbft.DOMAIN_SEPARATION_TAG + ":" + pt.networkName)).Maybe()
+		Return([]byte(gpbft.DomainSeparationTag + ":" + pt.networkName)).Maybe()
 
 	// Expect calls to get the host state prior to beginning of an instance.
 	pt.host.EXPECT().GetProposalForInstance(pt.instance)
@@ -174,7 +174,7 @@ func (pt *participantTestSubject) mockInvalidTicket(target gpbft.PubKey, ticket 
 		"Verify",
 		target,
 		mock.MatchedBy(func(msg []byte) bool {
-			return bytes.HasPrefix(msg, []byte(gpbft.DOMAIN_SEPARATION_TAG_VRF+":"+pt.networkName))
+			return bytes.HasPrefix(msg, []byte(gpbft.DomainSeparationTagVRF+":"+pt.networkName))
 		}), []byte(ticket)).
 		Return(errors.New("mock verification failure"))
 }
@@ -197,13 +197,13 @@ func (pt *participantTestSubject) mockCommitteeUnavailableForInstance(instance u
 
 func (pt *participantTestSubject) matchMessageSigningPayload() any {
 	return mock.MatchedBy(func(msg []byte) bool {
-		return bytes.HasPrefix(msg, []byte(gpbft.DOMAIN_SEPARATION_TAG+":"+pt.networkName))
+		return bytes.HasPrefix(msg, []byte(gpbft.DomainSeparationTag+":"+pt.networkName))
 	})
 }
 
 func (pt *participantTestSubject) matchTicketSigningPayload() any {
 	return mock.MatchedBy(func(msg []byte) bool {
-		return bytes.HasPrefix(msg, []byte(gpbft.DOMAIN_SEPARATION_TAG_VRF+":"+pt.networkName))
+		return bytes.HasPrefix(msg, []byte(gpbft.DomainSeparationTagVRF+":"+pt.networkName))
 	})
 }
 

--- a/gpbft/payload_test.go
+++ b/gpbft/payload_test.go
@@ -97,7 +97,7 @@ func TestPayload_MarshalForSigning(t *testing.T) {
 			name:    "zero-valued with empty network name",
 			subject: gpbft.Payload{},
 			want: []byte{
-				0x47, 0x50, 0x42, 0x46, 0x54, 0x3a, 0x3a, 0x00, // DOMAIN_SEPARATION_TAG ":" network name
+				0x47, 0x50, 0x42, 0x46, 0x54, 0x3a, 0x3a, 0x00, // gpbft.DomainSeparationTag ":" network name
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -144,7 +144,7 @@ func TestPayload_MarshalForSigning(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got := test.subject.MarshalForSigning(test.networkName)
 			require.NotEmpty(t, got)
-			require.True(t, bytes.HasPrefix(got, []byte(gpbft.DOMAIN_SEPARATION_TAG+":"+test.networkName+":")))
+			require.True(t, bytes.HasPrefix(got, []byte(gpbft.DomainSeparationTag+":"+test.networkName+":")))
 			require.Equal(t, test.want, got)
 		})
 	}

--- a/gpbft/signature_test.go
+++ b/gpbft/signature_test.go
@@ -58,7 +58,7 @@ func TestPayloadMarshalForSigning(t *testing.T) {
 
 func BenchmarkPayloadMarshalForSigning(b *testing.B) {
 	nn := gpbft.NetworkName("filecoin")
-	maxChain := make([]gpbft.TipSet, gpbft.CHAIN_MAX_LEN)
+	maxChain := make([]gpbft.TipSet, gpbft.ChainMaxLen)
 	for i := range maxChain {
 		ts := make([]byte, 38*5)
 		binary.BigEndian.PutUint64(ts, uint64(i))

--- a/gpbft/vrf.go
+++ b/gpbft/vrf.go
@@ -9,6 +9,8 @@ import (
 // A ticket is a signature over some common payload.
 type Ticket []byte
 
+const DomainSeparationTagVRF = "VRF"
+
 func MakeTicket(ctx context.Context, nn NetworkName, beacon []byte, instance uint64, round uint64, source PubKey, signer Signer) (Ticket, error) {
 	return signer.Sign(ctx, source, vrfSerializeSigInput(beacon, instance, round, nn))
 }
@@ -17,14 +19,12 @@ func VerifyTicket(nn NetworkName, beacon []byte, instance uint64, round uint64, 
 	return verifier.Verify(source, vrfSerializeSigInput(beacon, instance, round, nn), ticket) == nil
 }
 
-const DOMAIN_SEPARATION_TAG_VRF = "VRF"
-
 // Serializes the input to the VRF signature for the CONVERGE step of GossiPBFT.
 // Only used for VRF ticket creation and/or verification.
 func vrfSerializeSigInput(beacon []byte, instance uint64, round uint64, networkName NetworkName) []byte {
 	var buf bytes.Buffer
 
-	buf.WriteString(DOMAIN_SEPARATION_TAG_VRF)
+	buf.WriteString(DomainSeparationTagVRF)
 	buf.WriteString(":")
 	buf.WriteString(string(networkName))
 	buf.WriteString(":")

--- a/host.go
+++ b/host.go
@@ -358,7 +358,7 @@ type gpbftHost gpbftRunner
 
 func (h *gpbftHost) collectChain(base ec.TipSet, head ec.TipSet) ([]ec.TipSet, error) {
 	// TODO: optimize when head is way beyond base
-	res := make([]ec.TipSet, 0, 2*gpbft.CHAIN_MAX_LEN)
+	res := make([]ec.TipSet, 0, 2*gpbft.ChainMaxLen)
 	res = append(res, head)
 
 	for !bytes.Equal(head.Key(), base.Key()) {
@@ -447,7 +447,7 @@ func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.Supplemental
 		return nil, nil, fmt.Errorf("computing powertable CID for base: %w", err)
 	}
 
-	suffix := make([]gpbft.TipSet, min(gpbft.CHAIN_MAX_LEN-1, len(collectedChain))) // -1 because of base
+	suffix := make([]gpbft.TipSet, min(gpbft.ChainMaxLen-1, len(collectedChain))) // -1 because of base
 	for i := range suffix {
 		suffix[i].Key = collectedChain[i].Key()
 		suffix[i].Epoch = collectedChain[i].Epoch()

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -102,7 +102,7 @@ func (s *FakeBackend) VerifyAggregate(payload, aggSig []byte, signers []gpbft.Pu
 }
 
 func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Payload) []byte {
-	length := len(gpbft.DOMAIN_SEPARATION_TAG) + 2 + len(nn)
+	length := len(gpbft.DomainSeparationTag) + 2 + len(nn)
 	length += 1 + 8 + 8 // step + round + instance
 	length += 4         // len(p.Value)
 	for i := range p.Value {
@@ -115,7 +115,7 @@ func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Pa
 
 	var buf bytes.Buffer
 	buf.Grow(length)
-	buf.WriteString(gpbft.DOMAIN_SEPARATION_TAG)
+	buf.WriteString(gpbft.DomainSeparationTag)
 	buf.WriteString(":")
 	buf.WriteString(string(nn))
 	buf.WriteString(":")


### PR DESCRIPTION
The codebase inconsistently follows the MaxCaps golang naming convention for constant.

Consistently use MaxCaps for all constants, except for PHASEs to keep the code easier to read.