### PR TITLE
Relax the need for synchronous broadcast of `COMMIT` messages to self

### DIFF
--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -759,6 +759,12 @@ func (i *instance) beginCommit() {
 		if quorum, ok := i.getRound(i.round).prepared.FindStrongQuorumFor(i.value.Key()); ok {
 			// Found a strong quorum of PREPARE, build the justification for it.
 			justification = i.buildJustification(quorum, i.round, PREPARE_PHASE, i.value)
+
+			// Update the round's committed quorumState with the self participant
+			// justification for non-zero value. This is to relax the need for guarantee that
+			// the justification from COMMIT message broadcasts are delivered to self
+			// synchronously.
+			i.getRound(i.round).committed.ReceiveJustification(i.value, justification)
 		} else {
 			panic("beginCommit with no strong quorum for non-bottom value")
 		}


### PR DESCRIPTION
The message broadcast mechanism cannot guarantee that broadcasts to self are delivered synchronously. This means it is possible for next round with justification for non-bottom value from self to begin before the justification for it is delivered.

Relax this assumption by directly updating the committed quorum state when the participant itself finds a strong quorum of PREPARE and builds a justification for it. This change guarantees that regardless of the order of message delivery in broadcast the next round can begin when initiated by a justification from self.

Fixes #351