### PR TITLE
Implement a GPBFT emulator and test state transitions

### DIFF
--- a/emulator/driver.go
+++ b/emulator/driver.go
@@ -1,0 +1,59 @@
+package emulator
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/stretchr/testify/require"
+)
+
+// Driver drives the emulation of a GPBFT instance for one honest participant,
+// and allows frame-by-frame control over progress of a GPBFT instance.
+type Driver struct {
+	require         *require.Assertions
+	subject         *gpbft.Participant
+	host            *driverHost
+	currentInstance *Instance
+}
+
+// NewDriver instantiates a new Driver with the given GPBFT options. See
+// Driver.Start.
+func NewDriver(t *testing.T, o ...gpbft.Option) *Driver {
+	h := newHost(t)
+	participant, err := gpbft.NewParticipant(h, o...)
+	require.NoError(t, err)
+	return &Driver{
+		require: require.New(t),
+		subject: participant,
+		host:    h,
+	}
+}
+
+// Start starts emulation for the given instance and signals the start of
+// instance to the emulated honest gpbft.Participant.
+//
+// See NewInstance.
+func (d *Driver) Start(instance *Instance) {
+	d.require.NoError(d.host.setInstance(instance))
+	d.require.NoError(d.subject.StartInstance(instance.id))
+	d.currentInstance = instance
+
+	// Trigger alarm once based on the implicit assumption that go-f3 uses alarm to
+	// kickstart an instance internally.
+	d.RequireDeliverAlarm()
+}
+
+func (d *Driver) deliverAlarm() (bool, error) {
+	if d.host.maybeReceiveAlarm() {
+		return true, d.subject.ReceiveAlarm()
+	}
+	return false, nil
+}
+
+func (d *Driver) deliverMessage(msg *gpbft.GMessage) error {
+	if validated, err := d.subject.ValidateMessage(msg); err != nil {
+		return err
+	} else {
+		return d.subject.ReceiveMessage(validated)
+	}
+}

--- a/emulator/driver_assertions.go
+++ b/emulator/driver_assertions.go
@@ -1,0 +1,120 @@
+package emulator
+
+import (
+	"bytes"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+// ValidTicket is a sentinel value to generate and set a valid gpbft.Ticket when
+// delivering messages via Driver.RequireDeliverMessage.
+var ValidTicket gpbft.Ticket = []byte("filled by driver when non-empty")
+
+func (d *Driver) RequireDeliverMessage(message *gpbft.GMessage) {
+	// A small hack to fill the ticket with the right value as whatever "right" is
+	// dictated to be by signing. This keeps the signing swappable without ripple
+	// effect across the driver.
+	withTicket := bytes.Equal(message.Ticket, ValidTicket)
+	mb := d.currentInstance.NewMessageBuilder(message.Vote, message.Justification, withTicket)
+	mb.SetNetworkName(d.host.NetworkName())
+	mb.SetSigningMarshaler(d.host.adhocSigning)
+	msg, err := mb.Build(d.host.adhocSigning, message.Sender)
+	d.require.NoError(err)
+	d.require.NotNil(msg)
+
+	d.require.NoError(d.deliverMessage(msg))
+}
+
+func (d *Driver) RequireDeliverAlarm() {
+	delivered, err := d.deliverAlarm()
+	d.require.NoError(err)
+	d.require.True(delivered)
+}
+
+func (d *Driver) RequireNoBroadcast() {
+	d.require.Nil(d.host.popReceivedBroadcast())
+}
+
+func (d *Driver) RequireQuality() {
+	msg := d.host.popReceivedBroadcast()
+	d.require.NotNil(msg)
+	d.require.Equal(gpbft.QUALITY_PHASE, msg.Vote.Step)
+	d.require.Zero(msg.Vote.Round)
+	d.require.Equal(d.currentInstance.proposal, msg.Vote.Value)
+	d.require.Equal(d.currentInstance.id, msg.Vote.Instance)
+	d.require.Equal(d.currentInstance.supplementalData, msg.Vote.SupplementalData)
+	d.require.Nil(msg.Justification)
+	d.require.Empty(msg.Ticket)
+
+	d.require.NoError(d.deliverMessage(msg))
+}
+
+func (d *Driver) RequirePrepare(value gpbft.ECChain) {
+	d.RequirePrepareAtRound(0, value, nil)
+}
+
+func (d *Driver) RequirePrepareAtRound(round uint64, value gpbft.ECChain, justification *gpbft.Justification) {
+	msg := d.host.popReceivedBroadcast()
+	d.require.NotNil(msg)
+	d.require.Equal(gpbft.PREPARE_PHASE, msg.Vote.Step)
+	d.require.Equal(round, msg.Vote.Round)
+	d.require.Equal(value, msg.Vote.Value)
+	d.require.Equal(d.currentInstance.id, msg.Vote.Instance)
+	d.require.Equal(d.currentInstance.supplementalData, msg.Vote.SupplementalData)
+	d.require.Equal(justification, msg.Justification)
+	d.require.Empty(msg.Ticket)
+
+	d.require.NoError(d.deliverMessage(msg))
+}
+
+func (d *Driver) RequireCommitForBottom(round uint64) {
+	d.RequireCommit(round, gpbft.ECChain{}, nil)
+}
+
+func (d *Driver) RequireCommit(round uint64, vote gpbft.ECChain, justification *gpbft.Justification) {
+	msg := d.host.popReceivedBroadcast()
+	d.require.NotNil(msg)
+	d.require.Equal(gpbft.COMMIT_PHASE, msg.Vote.Step)
+	d.require.Equal(round, msg.Vote.Round)
+	d.require.Equal(d.currentInstance.supplementalData, msg.Vote.SupplementalData)
+	d.require.Equal(d.currentInstance.id, msg.Vote.Instance)
+	d.require.Equal(vote, msg.Vote.Value)
+	d.require.Equal(justification, justification)
+	d.require.Empty(msg.Ticket)
+
+	d.require.NoError(d.deliverMessage(msg))
+}
+
+func (d *Driver) RequireConverge(round uint64, vote gpbft.ECChain, justification *gpbft.Justification) {
+	msg := d.host.popReceivedBroadcast()
+	d.require.NotNil(msg)
+	d.require.Equal(gpbft.CONVERGE_PHASE, msg.Vote.Step)
+	d.require.Equal(round, msg.Vote.Round)
+	d.require.Equal(vote, msg.Vote.Value)
+	d.require.Equal(d.currentInstance.id, msg.Vote.Instance)
+	d.require.Equal(d.currentInstance.supplementalData, msg.Vote.SupplementalData)
+	d.require.Equal(justification, msg.Justification)
+	d.require.NotEmpty(msg.Ticket)
+
+	d.require.NoError(d.deliverMessage(msg))
+}
+
+func (d *Driver) RequireDecide(vote gpbft.ECChain, justification *gpbft.Justification) {
+	msg := d.host.popReceivedBroadcast()
+	d.require.NotNil(msg)
+	d.require.Equal(gpbft.DECIDE_PHASE, msg.Vote.Step)
+	d.require.Zero(msg.Vote.Round)
+	d.require.Equal(vote, msg.Vote.Value)
+	d.require.Equal(d.currentInstance.id, msg.Vote.Instance)
+	d.require.Equal(d.currentInstance.supplementalData, msg.Vote.SupplementalData)
+	d.require.Equal(justification, msg.Justification)
+	d.require.Empty(msg.Ticket)
+
+	d.require.NoError(d.deliverMessage(msg))
+}
+
+func (d *Driver) RequireDecision(expect gpbft.ECChain) {
+	decision := d.currentInstance.GetDecision()
+	d.require.NotNil(decision)
+	d.require.Equal(expect, decision.Vote.Value)
+}

--- a/emulator/instance.go
+++ b/emulator/instance.go
@@ -1,0 +1,145 @@
+package emulator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/stretchr/testify/require"
+)
+
+// Instance represents a GPBFT instance capturing all the information necessary
+// for GPBFT to function, along with the final decision reached if any.
+type Instance struct {
+	id               uint64
+	supplementalData gpbft.SupplementalData
+	proposal         gpbft.ECChain
+	powerTable       *gpbft.PowerTable
+	beacon           []byte
+	decision         *gpbft.Justification
+}
+
+// NewInstance instantiates a new Instance for emulation. If absent, the
+// constructor will implicitly generate any missing but required values such as
+// public keys Power Table CID, etc. for the given params. The given proposal
+// must contain at least one tipset.
+//
+// See Driver.Start.
+func NewInstance(t *testing.T, id uint64, powerEntries gpbft.PowerEntries, proposal ...gpbft.TipSet) *Instance {
+	// UX of the gpbft API is pretty painful; encapsulate the pain of getting an
+	// instance going here at the price of accepting partial data and implicitly
+	// filling what's missing.
+
+	for i, entry := range powerEntries {
+		if len(entry.PubKey) == 0 {
+			// Populate missing public key to avoid power table validation errors.
+			powerEntries[i].PubKey = []byte(fmt.Sprintf("🪪%d", entry.ID))
+		}
+	}
+	ptCid, err := certs.MakePowerTableCID(powerEntries)
+	require.NoError(t, err)
+	pt := gpbft.NewPowerTable()
+	require.NoError(t, pt.Add(powerEntries...))
+	for i, tipset := range proposal {
+		if len(tipset.PowerTable) == 0 {
+			// Populate missing power table CIDs to avoid validation error when constructing
+			// ECChain.
+			proposal[i].PowerTable = ptCid
+		}
+	}
+	if len(proposal) < 1 {
+		require.Fail(t, "at least one proposal tipset must be specified")
+	}
+	proposalChain, err := gpbft.NewChain(proposal[0], proposal[1:]...)
+	require.NoError(t, err)
+	return &Instance{
+		id:         id,
+		powerTable: pt,
+		beacon:     []byte(fmt.Sprintf("🥓%d", id)),
+		proposal:   proposalChain,
+	}
+}
+
+func (i *Instance) Proposal() gpbft.ECChain                  { return i.proposal }
+func (i *Instance) GetDecision() *gpbft.Justification        { return i.decision }
+func (i *Instance) ID() uint64                               { return i.id }
+func (i *Instance) SupplementalData() gpbft.SupplementalData { return i.supplementalData }
+
+func (i *Instance) NewQuality(proposal gpbft.ECChain) gpbft.Payload {
+	return i.NewPayload(0, gpbft.QUALITY_PHASE, proposal)
+}
+
+func (i *Instance) NewPrepare(round uint64, proposal gpbft.ECChain) gpbft.Payload {
+	return i.NewPayload(round, gpbft.PREPARE_PHASE, proposal)
+}
+
+func (i *Instance) NewCommit(round uint64, proposal gpbft.ECChain) gpbft.Payload {
+	return i.NewPayload(round, gpbft.COMMIT_PHASE, proposal)
+}
+
+func (i *Instance) NewConverge(round uint64, proposal gpbft.ECChain) gpbft.Payload {
+	return i.NewPayload(round, gpbft.CONVERGE_PHASE, proposal)
+}
+
+func (i *Instance) NewDecide(round uint64, proposal gpbft.ECChain) gpbft.Payload {
+	return i.NewPayload(round, gpbft.DECIDE_PHASE, proposal)
+}
+
+func (i *Instance) NewPayload(round uint64, step gpbft.Phase, value gpbft.ECChain) gpbft.Payload {
+	return gpbft.Payload{
+		Instance:         i.id,
+		Round:            round,
+		Step:             step,
+		SupplementalData: i.supplementalData,
+		Value:            value,
+	}
+}
+
+func (i *Instance) NewMessageBuilder(payload gpbft.Payload, justification *gpbft.Justification, withTicket bool) *gpbft.MessageBuilder {
+
+	payload.SupplementalData = i.supplementalData
+	payload.Instance = i.id
+	builder := gpbft.NewMessageBuilder(i.powerTable)
+	builder.SetPayload(payload)
+	if justification != nil {
+		builder.SetJustification(justification)
+	}
+	if withTicket {
+		builder.SetBeaconForTicket(i.beacon)
+	}
+	return builder
+}
+
+func (d *Driver) NewJustification(round uint64, step gpbft.Phase, vote gpbft.ECChain, from ...gpbft.ActorID) *gpbft.Justification {
+	payload := gpbft.Payload{
+		Instance:         d.currentInstance.ID(),
+		Round:            round,
+		Step:             step,
+		SupplementalData: d.currentInstance.SupplementalData(),
+		Value:            vote,
+	}
+	msg := signing.MarshalPayloadForSigning(d.host.NetworkName(), &payload)
+	qr := gpbft.QuorumResult{
+		Signers:    make([]int, len(from)),
+		PubKeys:    make([]gpbft.PubKey, len(from)),
+		Signatures: make([][]byte, len(from)),
+	}
+	for i, actor := range from {
+		index, found := d.currentInstance.powerTable.Lookup[actor]
+		d.require.True(found)
+		entry := d.currentInstance.powerTable.Entries[index]
+		signature, err := signing.Sign(entry.PubKey, msg)
+		d.require.NoError(err)
+		qr.Signatures[i] = signature
+		qr.PubKeys[i] = entry.PubKey
+		qr.Signers[i] = index
+	}
+	aggregate, err := signing.Aggregate(qr.PubKeys, qr.Signatures)
+	d.require.NoError(err)
+	return &gpbft.Justification{
+		Vote:      payload,
+		Signers:   qr.SignersBitfield(),
+		Signature: aggregate,
+	}
+}

--- a/emulator/signing.go
+++ b/emulator/signing.go
@@ -1,0 +1,85 @@
+package emulator
+
+import (
+	"bytes"
+	"errors"
+	"hash/crc32"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+var (
+	_ gpbft.Verifier         = (*adhocSigning)(nil)
+	_ gpbft.Signer           = (*adhocSigning)(nil)
+	_ gpbft.SigningMarshaler = (*adhocSigning)(nil)
+
+	signing adhocSigning
+)
+
+// adhocSigning marshals, signs and verifies messages on behalf of any given
+// public key but uniquely and deterministically so using crc32 hash function for
+// performance. This implementation is not secure nor collision resistant. A
+// typical Instance power table is small enough to make the risk of collisions
+// negligible.
+type adhocSigning struct{}
+
+func (s adhocSigning) Sign(sender gpbft.PubKey, msg []byte) ([]byte, error) {
+	hasher := crc32.NewIEEE()
+	if _, err := hasher.Write(sender); err != nil {
+		return nil, err
+	}
+	if _, err := hasher.Write(msg); err != nil {
+		return nil, err
+	}
+	return hasher.Sum(nil), nil
+}
+
+func (s adhocSigning) Verify(sender gpbft.PubKey, msg, got []byte) error {
+	switch want, err := s.Sign(sender, msg); {
+	case err != nil:
+		return err
+	case !bytes.Equal(want, got):
+		return errors.New("invalid signature")
+	default:
+		return nil
+	}
+}
+
+func (s adhocSigning) Aggregate(signers []gpbft.PubKey, sigs [][]byte) ([]byte, error) {
+	if len(signers) != len(sigs) {
+		return nil, errors.New("public keys and signatures length mismatch")
+	}
+	hasher := crc32.NewIEEE()
+	for i, signer := range signers {
+		if _, err := hasher.Write(signer); err != nil {
+			return nil, err
+		}
+		if _, err := hasher.Write(sigs[i]); err != nil {
+			return nil, err
+		}
+	}
+	return hasher.Sum(nil), nil
+}
+
+func (s adhocSigning) VerifyAggregate(payload, got []byte, signers []gpbft.PubKey) error {
+	signatures := make([][]byte, len(signers))
+	var err error
+	for i, signer := range signers {
+		signatures[i], err = s.Sign(signer, payload)
+		if err != nil {
+			return err
+		}
+	}
+	want, err := s.Aggregate(signers, signatures)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(want, got) {
+		return errors.New("invalid aggregate")
+	}
+	return nil
+}
+
+func (s adhocSigning) MarshalPayloadForSigning(name gpbft.NetworkName, payload *gpbft.Payload) []byte {
+	return payload.MarshalForSigning(name)
+}

--- a/gpbft/gpbft_test.go
+++ b/gpbft/gpbft_test.go
@@ -1,0 +1,222 @@
+package gpbft_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-f3/emulator"
+	"github.com/filecoin-project/go-f3/gpbft"
+)
+
+var (
+	tipset0 = gpbft.TipSet{Epoch: 0, Key: []byte("bigbang")}
+	tipSet1 = gpbft.TipSet{Epoch: 1, Key: []byte("fish")}
+	tipSet2 = gpbft.TipSet{Epoch: 2, Key: []byte("lobster")}
+)
+
+func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
+	newInstanceAndDriver := func(t *testing.T) (*emulator.Instance, *emulator.Driver) {
+		driver := emulator.NewDriver(t)
+		instance := emulator.NewInstance(t,
+			0,
+			gpbft.PowerEntries{
+				gpbft.PowerEntry{
+					ID:    0,
+					Power: gpbft.NewStoragePower(1),
+				},
+				gpbft.PowerEntry{
+					ID:    1,
+					Power: gpbft.NewStoragePower(1),
+				},
+			},
+			tipset0, tipSet1, tipSet2,
+		)
+		driver.Start(instance)
+		return instance, driver
+	}
+
+	t.Run("Decides proposal on strong quorum", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		driver.RequireQuality()
+		driver.RequireNoBroadcast()
+
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewQuality(instance.Proposal()),
+		})
+		driver.RequirePrepare(instance.Proposal())
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewPrepare(0, instance.Proposal()),
+		})
+
+		evidenceOfPrepare := driver.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0, 1)
+		driver.RequireCommit(0, instance.Proposal(), evidenceOfPrepare)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewCommit(0, instance.Proposal()),
+			Justification: evidenceOfPrepare,
+		})
+
+		evidenceOfCommit := driver.NewJustification(0, gpbft.COMMIT_PHASE, instance.Proposal(), 0, 1)
+		driver.RequireDecide(instance.Proposal(), evidenceOfCommit)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewDecide(0, instance.Proposal()),
+			Justification: evidenceOfCommit,
+		})
+
+		driver.RequireDecision(instance.Proposal())
+	})
+
+	t.Run("Decides base on lack of quorum", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		driver.RequireQuality()
+		driver.RequireNoBroadcast()
+
+		baseChain := instance.Proposal().BaseChain()
+		alternativeProposal := baseChain.Extend([]byte("barreleye"))
+
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewQuality(alternativeProposal),
+		})
+		driver.RequireDeliverAlarm()
+		driver.RequirePrepare(baseChain)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewPrepare(0, baseChain),
+		})
+		evidenceOfPrepare := driver.NewJustification(0, gpbft.PREPARE_PHASE, baseChain, 0, 1)
+
+		driver.RequireCommit(0, baseChain, evidenceOfPrepare)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewCommit(0, baseChain),
+			Justification: evidenceOfPrepare,
+		})
+
+		evidenceOfCommit := driver.NewJustification(0, gpbft.COMMIT_PHASE, baseChain, 0, 1)
+		driver.RequireDecide(baseChain, evidenceOfCommit)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewDecide(0, baseChain),
+			Justification: evidenceOfCommit,
+		})
+		driver.RequireDecision(baseChain)
+	})
+
+	t.Run("Converges on base when quorum not possible", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		driver.RequireQuality()
+		driver.RequireNoBroadcast()
+
+		baseChain := instance.Proposal().BaseChain()
+		alternativeProposal := baseChain.Extend([]byte("barreleye"))
+
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewQuality(alternativeProposal),
+		})
+		driver.RequireDeliverAlarm()
+		driver.RequirePrepare(baseChain)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewPrepare(0, alternativeProposal),
+		})
+
+		driver.RequireCommitForBottom(0)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewCommit(0, gpbft.ECChain{}),
+		})
+
+		evidenceOfCommitForBottom := driver.NewJustification(0, gpbft.COMMIT_PHASE, gpbft.ECChain{}, 0, 1)
+
+		driver.RequireConverge(1, baseChain, evidenceOfCommitForBottom)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewConverge(1, baseChain),
+			Justification: evidenceOfCommitForBottom,
+			Ticket:        emulator.ValidTicket,
+		})
+		driver.RequireDeliverAlarm()
+
+		driver.RequirePrepareAtRound(1, baseChain, evidenceOfCommitForBottom)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewPrepare(1, baseChain),
+			Justification: evidenceOfCommitForBottom,
+		})
+
+		evidenceOfPrepare := driver.NewJustification(1, gpbft.PREPARE_PHASE, baseChain, 0, 1)
+
+		driver.RequireCommit(1, baseChain, evidenceOfPrepare)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewCommit(1, baseChain),
+			Justification: evidenceOfPrepare,
+		})
+
+		evidenceOfCommit := driver.NewJustification(1, gpbft.COMMIT_PHASE, baseChain, 0, 1)
+		driver.RequireDecide(baseChain, evidenceOfCommit)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewDecide(0, baseChain),
+			Justification: evidenceOfCommit,
+		})
+		driver.RequireDecision(baseChain)
+	})
+
+}
+
+func TestGPBFT_SoloParticipant(t *testing.T) {
+	newInstanceAndDriver := func(t *testing.T) (*emulator.Instance, *emulator.Driver) {
+		driver := emulator.NewDriver(t)
+		instance := emulator.NewInstance(t,
+			0,
+			gpbft.PowerEntries{
+				gpbft.PowerEntry{
+					ID:    0,
+					Power: gpbft.NewStoragePower(1),
+				},
+			},
+			tipset0, tipSet1, tipSet2,
+		)
+		driver.Start(instance)
+		return instance, driver
+	}
+
+	t.Run("Decides proposal with no timeout", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		driver.RequireQuality()
+		driver.RequirePrepare(instance.Proposal())
+		driver.RequireCommit(
+			0,
+			instance.Proposal(),
+			driver.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0),
+		)
+		driver.RequireDecide(
+			instance.Proposal(),
+			driver.NewJustification(0, gpbft.COMMIT_PHASE, instance.Proposal(), 0),
+		)
+		driver.RequireDecision(instance.Proposal())
+	})
+
+	t.Run("Decides base on QUALITY timeout", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		baseChain := instance.Proposal().BaseChain()
+		driver.RequireDeliverAlarm()
+		driver.RequireQuality()
+		driver.RequirePrepare(baseChain)
+		driver.RequireCommit(
+			0,
+			baseChain,
+			driver.NewJustification(0, gpbft.PREPARE_PHASE, baseChain, 0),
+		)
+		driver.RequireDecide(
+			baseChain,
+			driver.NewJustification(0, gpbft.COMMIT_PHASE, baseChain, 0),
+		)
+		driver.RequireDecision(baseChain)
+	})
+}


### PR DESCRIPTION
Implement an emulator to test the core GPBFT protocol, with fine-grained control and assertion over message-by-message progress of a participant.

Add utility functions to reduce the boilerplate code during testing and implement state transition tests that assert state transition occurs:
 * for proposal when there is strong evidence of prepare.
 * for base when there is no strong support for any proposal
 * for base by timeout alone for a sole participant.

Part of #9