### PR TITLE
F3-229: dynamic manifest handler, manifest sender, f3 integration tests

### DIFF
--- a/cmd/f3/manifest.go
+++ b/cmd/f3/manifest.go
@@ -31,7 +31,7 @@ var manifestGenCmd = cli.Command{
 
 	Action: func(c *cli.Context) error {
 		path := c.String("manifest")
-		m := manifest.LocalDevnettManifest()
+		m := manifest.LocalDevnetManifest()
 
 		fsig := signing.NewFakeBackend()
 		for i := 0; i < c.Int("N"); i++ {

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -103,6 +103,7 @@ var runCmd = cli.Command{
 		}
 
 		initialInstance := c.Uint64("instance")
+		mprovider.SetManifestChangeCallback(f3.ManifestChangeCallback(module))
 		return module.Run(initialInstance, ctx)
 	},
 }

--- a/f3.go
+++ b/f3.go
@@ -246,7 +246,6 @@ func (m *F3) Run(initialInstance uint64, ctx context.Context) error {
 
 	// teardown pubsub on shutdown
 	var err error
-	defer m.teardownPubsub(m.Manifest.Manifest())
 	defer func() {
 		teardownErr := m.teardownPubsub(m.Manifest.Manifest())
 		err = multierr.Append(err, teardownErr)

--- a/f3.go
+++ b/f3.go
@@ -269,7 +269,9 @@ loop:
 		}
 	}
 
-	m.teardownPubsub(m.Manifest.Manifest())
+	if err := m.teardownPubsub(m.Manifest.Manifest()); err != nil {
+		m.log.Errorf("tearing down message pubsub returned an error: %+v", err)
+	}
 }
 
 // Callback to be triggered when there is a dynamic manifest change

--- a/f3.go
+++ b/f3.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"sync"
 
+	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
@@ -39,7 +41,7 @@ type F3 struct {
 type client struct {
 	certstore *certstore.Store
 	id        gpbft.ActorID
-	nn        gpbft.NetworkName
+	manifest  manifest.ManifestProvider
 	ec        ec.Backend
 
 	gpbft.Verifier
@@ -48,12 +50,14 @@ type client struct {
 	loggerWithSkip Logger
 
 	// Populated after Run is called
-	messageQueue <-chan gpbft.ValidatedMessage
-	topic        *pubsub.Topic
+	messageQueue   <-chan gpbft.ValidatedMessage
+	manifestUpdate <-chan struct{}
+	topic          *pubsub.Topic
+	psLock         sync.Mutex
 }
 
 func (mc *client) BroadcastMessage(ctx context.Context, mb *gpbft.MessageBuilder) error {
-	msg, err := mb.Build(mc.nn, mc.SignerWithMarshaler, mc.id)
+	msg, err := mb.Build(mc.manifest.Manifest().NetworkName, mc.SignerWithMarshaler, mc.id)
 	if err != nil {
 		if errors.Is(err, gpbft.ErrNoPower) {
 			return nil
@@ -75,6 +79,15 @@ func (mc *client) BroadcastMessage(ctx context.Context, mb *gpbft.MessageBuilder
 	}
 	return nil
 
+}
+
+func (mc *client) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.PowerEntries, error) {
+	// Apply power table deltas from the manifest
+	pt, err := mc.ec.GetPowerTable(ctx, ts)
+	if err != nil {
+		return nil, xerrors.Errorf("getting power table: %w", err)
+	}
+	return certs.ApplyPowerTableDiffs(pt, mc.manifest.Manifest().PowerUpdate)
 }
 
 func (mc *client) IncomingMessages() <-chan gpbft.ValidatedMessage {
@@ -119,7 +132,7 @@ func New(ctx context.Context, id gpbft.ActorID, manifest manifest.ManifestProvid
 		client: &client{
 			certstore:           cs,
 			ec:                  ec,
-			nn:                  manifest.Manifest().NetworkName,
+			manifest:            manifest,
 			id:                  id,
 			Verifier:            verif,
 			SignerWithMarshaler: sigs,
@@ -228,6 +241,9 @@ func (m *F3) Run(initialInstance uint64, ctx context.Context) error {
 	// If it is a static manifest it does nothing.
 	go m.Manifest.Run(ctx, manifestErrCh)
 
+	// teardown pubsub on shutdown
+	defer m.teardownPubsub(m.Manifest.Manifest())
+
 	var err error
 	select {
 	case <-ctx.Done():
@@ -261,16 +277,11 @@ loop:
 			m.log.Errorf("invalid msgValidatorData: %+v", msg.ValidatorData)
 			continue
 		}
-
 		select {
 		case queue <- gmsg:
 		case <-ctx.Done():
 			break loop
 		}
-	}
-
-	if err := m.teardownPubsub(m.Manifest.Manifest()); err != nil {
-		m.log.Errorf("tearing down message pubsub returned an error: %+v", err)
 	}
 }
 
@@ -279,12 +290,21 @@ loop:
 // If there is no rebootstrap it only starts a new pubsub topic with a new network name that
 // depends on the manifest version so there is no overlap between different configuration instances
 func ManifestChangeCallback(m *F3) manifest.OnManifestChange {
+	manifestUpdate := make(chan struct{}, 3)
+	m.client.manifestUpdate = manifestUpdate
 	return func(ctx context.Context, prevManifest manifest.Manifest, errCh chan error) {
+		m.client.psLock.Lock()
+		// Tear down pubsub.
+		if err := m.teardownPubsub(prevManifest); err != nil {
+			// for now we just log the error and continue.
+			// This is not critical, but alternative approaches welcome.
+			m.log.Errorf("error stopping gpbft runner: %+v", err)
+		}
 		// empty message queue from outstanding messages
 		m.emptyMessageQueue()
-		// Update the client network name to the new one.
-		// if not signatures will fail
-		m.client.nn = m.Manifest.Manifest().NetworkName
+		// Update the mmanifest in the client to update power table
+		// and network name (without this signatures will fail)
+		m.client.manifest = m.Manifest
 
 		if m.Manifest.Manifest().ReBootstrap {
 			// kill runner and teardown pubsub. This will also
@@ -297,15 +317,10 @@ func ManifestChangeCallback(m *F3) manifest.OnManifestChange {
 			// when we rebootstrap we need to start from instance 0, because
 			// we may not have anything in the certstore to fetch the
 			// right chain through host.GetProposalForInstance
+
+			m.client.psLock.Unlock()
 			m.setupGpbftRunner(ctx, 0, errCh)
 		} else {
-			// Tear down pubsub.
-			if err := m.teardownPubsub(prevManifest); err != nil {
-				// for now we just log the error and continue.
-				// This is not critical, but alternative approaches welcome.
-				m.log.Errorf("error stopping gpbft runner: %+v", err)
-			}
-
 			if err := m.setupPubsub(m.runner); err != nil {
 				errCh <- xerrors.Errorf("setting up pubsub: %w", err)
 				return
@@ -320,6 +335,9 @@ func ManifestChangeCallback(m *F3) manifest.OnManifestChange {
 
 			messageQueue := make(chan gpbft.ValidatedMessage, 20)
 			m.client.messageQueue = messageQueue
+			// notify update to host to pick up the new message queue
+			manifestUpdate <- struct{}{}
+			m.client.psLock.Unlock()
 			m.handleIncomingMessages(ctx, messageQueue)
 		}
 	}
@@ -336,10 +354,6 @@ func (m *F3) emptyMessageQueue() {
 	}
 }
 
-func (m *F3) CurrentGpbftInstace() uint64 {
-	return m.runner.participant.UnsafeCurrentInstance()
-}
-
 type Logger interface {
 	Debug(args ...interface{})
 	Debugf(format string, args ...interface{})
@@ -349,4 +363,17 @@ type Logger interface {
 	Infof(format string, args ...interface{})
 	Warn(args ...interface{})
 	Warnf(format string, args ...interface{})
+}
+
+// Methods exposed for testing purposes
+func (m *F3) CurrentGpbftInstace() uint64 {
+	return m.runner.participant.UnsafeCurrentInstance()
+}
+
+func (m *F3) IsRunning() bool {
+	return m.runner != nil
+}
+
+func (m *F3) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.PowerEntries, error) {
+	return m.client.GetPowerTable(ctx, ts)
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-libp2p v0.35.0
 	github.com/libp2p/go-libp2p-pubsub v0.11.0
+	github.com/multiformats/go-multiaddr v0.12.4
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2
 	github.com/whyrusleeping/cbor-gen v0.1.1
@@ -71,7 +72,6 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
-	github.com/multiformats/go-multiaddr v0.12.4 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -125,6 +125,13 @@ func (p *Participant) CurrentInstance() uint64 {
 	return p.currentInstance
 }
 
+// UnsafeCurrentInstance returns the current instance identifier without locking.
+// This should only be used for testing purposes in order to get a sense
+// if the participant is making progress or not.
+func (p *Participant) UnsafeCurrentInstance() uint64 {
+	return p.currentInstance
+}
+
 // Validates a message
 func (p *Participant) ValidateMessage(msg *GMessage) (valid ValidatedMessage, err error) {
 	// This method is not protected by the API mutex, it is intended for concurrent use.

--- a/host.go
+++ b/host.go
@@ -65,24 +65,9 @@ func (h *gpbftRunner) Run(instance uint64, ctx context.Context) error {
 		return xerrors.Errorf("starting a participant: %w", err)
 	}
 
-	manifestUpdates := h.manifest.ManifestQueue()
+	messageQueue := h.client.IncomingMessages()
 loop:
 	for {
-		// we need to retrieve the queue again in every
-		// iteration in case there has been a manifest change
-		// and we are subscribed to a new topic
-		messageQueue := h.client.IncomingMessages()
-
-		// if there is a manifest update handle it immediately
-		select {
-		case <-manifestUpdates:
-			// TODO: Perform configuration changes to the runner host
-			// - Power table updates
-			// - MaxLookBack and ECStabilizationDelay
-			// i.e. anything that doesn't require a re-bootstrap.
-			continue
-		default:
-		}
 
 		// prioritise alarm delivery
 		// although there is no guarantee that alarm won't fire between

--- a/host.go
+++ b/host.go
@@ -68,7 +68,6 @@ func (h *gpbftRunner) Run(instance uint64, ctx context.Context) error {
 	messageQueue := h.client.IncomingMessages()
 loop:
 	for {
-		// Inner loop with the initial or updated messageQueue
 		for {
 			// prioritise alarm delivery
 			select {
@@ -141,7 +140,7 @@ func (h *gpbftRunner) Stop() {
 // - the EC chain to propose.
 // These will be used as input to a subsequent instance of the protocol.
 // The chain should be a suffix of the last chain notified to the host via
-// ReceiveDecision (or known to be final via som99999e other channel).
+// ReceiveDecision (or known to be final via some other channel).
 func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
 	var baseTsk gpbft.TipSetKey
 	if instance == 0 {

--- a/host.go
+++ b/host.go
@@ -68,33 +68,43 @@ func (h *gpbftRunner) Run(instance uint64, ctx context.Context) error {
 	messageQueue := h.client.IncomingMessages()
 loop:
 	for {
-
-		// prioritise alarm delivery
-		// although there is no guarantee that alarm won't fire between
-		// the two select statements
-		select {
-		case <-h.alertTimer.C:
-			err = h.participant.ReceiveAlarm()
-		default:
-		}
-		if err != nil {
-			break loop
-		}
-
-		select {
-		case <-h.alertTimer.C:
-			err = h.participant.ReceiveAlarm()
-		case msg, ok := <-messageQueue:
-			if !ok {
-				err = xerrors.Errorf("incoming messsage queue closed")
+		// Inner loop with the initial or updated messageQueue
+		for {
+			// prioritise alarm delivery
+			select {
+			case <-h.alertTimer.C:
+				err = h.participant.ReceiveAlarm()
+			default:
+			}
+			if err != nil {
 				break loop
 			}
-			err = h.participant.ReceiveMessage(msg)
-		case <-ctx.Done():
-			return nil
-		}
-		if err != nil {
-			break loop
+
+			// Handle messages and alarms
+			select {
+			case <-h.alertTimer.C:
+				err = h.participant.ReceiveAlarm()
+			case msg, ok := <-messageQueue:
+				if !ok {
+					err = xerrors.Errorf("incoming message queue closed")
+					break loop
+				}
+				err = h.participant.ReceiveMessage(msg)
+			case <-ctx.Done():
+				return nil
+			}
+			if err != nil {
+				break loop
+			}
+
+			// Check for manifest update in the inner loop to exit and update the messageQueue
+			select {
+			case <-h.client.manifestUpdate:
+				h.log.Debugf("Manifest update detected, refreshing message queue")
+				messageQueue = h.client.IncomingMessages()
+				continue loop
+			default:
+			}
 		}
 	}
 	h.log.Errorf("gpbfthost exiting: %+v", err)
@@ -131,7 +141,7 @@ func (h *gpbftRunner) Stop() {
 // - the EC chain to propose.
 // These will be used as input to a subsequent instance of the protocol.
 // The chain should be a suffix of the last chain notified to the host via
-// ReceiveDecision (or known to be final via some other channel).
+// ReceiveDecision (or known to be final via som99999e other channel).
 func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
 	var baseTsk gpbft.TipSetKey
 	if instance == 0 {
@@ -167,7 +177,7 @@ func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.Supplemental
 		Epoch: baseTs.Epoch(),
 		Key:   baseTs.Key(),
 	}
-	pte, err := h.client.ec.GetPowerTable(h.runningCtx, baseTs.Key())
+	pte, err := h.client.GetPowerTable(h.runningCtx, baseTs.Key())
 	if err != nil {
 		return nil, nil, xerrors.Errorf("getting power table for base: %w", err)
 	}
@@ -181,7 +191,7 @@ func (h *gpbftHost) GetProposalForInstance(instance uint64) (*gpbft.Supplemental
 		suffix[i].Key = collectedChain[i].Key()
 		suffix[i].Epoch = collectedChain[i].Epoch()
 
-		pte, err = h.client.ec.GetPowerTable(h.runningCtx, suffix[i].Key)
+		pte, err = h.client.GetPowerTable(h.runningCtx, suffix[i].Key)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("getting power table for suffix %d: %w", i, err)
 		}
@@ -221,7 +231,7 @@ func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable,
 			return nil, nil, xerrors.Errorf("getting tipset for boostrap epoch with lookback: %w", err)
 		}
 		powerTsk = ts.Key()
-		powerEntries, err = h.client.ec.GetPowerTable(h.runningCtx, powerTsk)
+		powerEntries, err = h.client.GetPowerTable(h.runningCtx, powerTsk)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("getting power table: %w", err)
 		}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-type OnManifestChange func(ctx context.Context, initialInstance uint64, rebootstrap bool, errCh chan error)
+type OnManifestChange func(ctx context.Context, prevManifest Manifest, errCh chan error)
 
 type ManifestProvider interface {
 	// Run starts any background tasks required for the operation
@@ -46,10 +46,6 @@ type ManifestProvider interface {
 	Run(context.Context, chan error)
 	// Returns the list of gpbft options to be used for gpbft configuration
 	GpbftOptions() []gpbft.Option
-	// manifest queue used by the runner to get notifications about when a
-	// new manifest has been accepted.
-	// Only the gpbft runner is expected to subscribe to this queue.
-	ManifestQueue() <-chan struct{}
 	// Set callback to trigger to apply new manifests from F3.
 	SetManifestChangeCallback(OnManifestChange)
 	// Manifest accessor
@@ -100,7 +96,7 @@ type Manifest struct {
 	*EcConfig
 }
 
-func LocalDevnettManifest() Manifest {
+func LocalDevnetManifest() Manifest {
 	rng := make([]byte, 4)
 	_, _ = rand.Read(rng)
 	m := Manifest{

--- a/manifest/static.go
+++ b/manifest/static.go
@@ -47,10 +47,6 @@ func (m *StaticManifestProvider) InitialPowerTable() []gpbft.PowerEntry {
 	return m.manifest.InitialPowerTable
 }
 
-func (m *StaticManifestProvider) ManifestQueue() <-chan struct{} {
-	return nil
-}
-
 func (m *StaticManifestProvider) Run(ctx context.Context, errCh chan error) {}
 
 func (m *StaticManifestProvider) SetManifestChangeCallback(mc OnManifestChange) {}

--- a/passive/dynamic_manifest.go
+++ b/passive/dynamic_manifest.go
@@ -99,8 +99,7 @@ func (m *DynamicManifestProvider) handleApplyManifest(ctx context.Context, errCh
 					nn := m.networkNameOnChange()
 					m.manifest.NetworkName = nn
 					m.nextManifest = nil
-					// stop existing pubsub and subscribe to the new one
-					// if the re-bootstrap flag is enabled, it will setup a new runner with the new config.
+					// trigger manifest change callback.
 					go m.onManifestChange(ctx, prevManifest, errCh)
 					continue
 				}
@@ -175,6 +174,7 @@ func (m *DynamicManifestProvider) teardownManifestPubsub() error {
 func (m *DynamicManifestProvider) acceptNextManifest(manifest *manifest.Manifest) bool {
 	// if the manifest is older, skip it
 	if manifest.Sequence <= m.manifest.Sequence ||
+		// NOTE: Do we want to accept a manifest with a bootstrap epoch that is in the past?
 		manifest.BootstrapEpoch < m.manifest.BootstrapEpoch {
 		return false
 	}

--- a/passive/dynamic_manifest.go
+++ b/passive/dynamic_manifest.go
@@ -1,6 +1,7 @@
 package passive
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/filecoin-project/go-f3/ec"
@@ -10,6 +11,8 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/multierr"
+	"golang.org/x/xerrors"
 )
 
 var log = logging.Logger("f3-dynamic-manifest")
@@ -30,9 +33,9 @@ type DynamicManifest struct {
 
 	// these are populate in runtime
 	onManifestChange manifest.OnManifestChange
-	// nextManifest     *manifest.Manifest
-	manifestUpdates <-chan struct{}
-	// manifestTopic    *pubsub.Topic
+	nextManifest     *manifest.Manifest
+	manifestUpdates  <-chan struct{}
+	manifestTopic    *pubsub.Topic
 }
 
 func NewDynamicManifest(manifest *manifest.Manifest, pubsub *pubsub.PubSub, ec ec.ECBackend, manifestServerID peer.ID) manifest.ManifestProvider {
@@ -84,7 +87,154 @@ func (m *DynamicManifest) MsgPubSubTopic() string {
 	return m.manifest.PubSubTopic() + string(v)
 }
 
-func (m *DynamicManifest) Run(context.Context, chan error) {
-	log.Debug("running dynamic manifest")
-	// TODO: Implementation coming in the next PR.
+func (m *DynamicManifest) Run(ctx context.Context, errCh chan error) {
+	if m.onManifestChange == nil {
+		errCh <- xerrors.New("onManifestChange is nil. Callback for manifest change required")
+	}
+	manifestQueue := make(chan struct{}, 5)
+	m.manifestUpdates = manifestQueue
+	m.handleIncomingManifests(ctx, manifestQueue, errCh)
+}
+
+func (m *DynamicManifest) handleIncomingManifests(ctx context.Context, manifestQueue chan struct{}, errCh chan error) {
+	if err := m.setupManifestPubsub(); err != nil {
+		errCh <- xerrors.Errorf("setting up pubsub: %w", err)
+		return
+	}
+
+	manifestSub, err := m.manifestTopic.Subscribe()
+	if err != nil {
+		errCh <- xerrors.Errorf("subscribing to topic: %w", err)
+		return
+	}
+
+	// FIXME; This is a stub and should be replaced with whatever
+	// function allow us to subscribe to new epochs coming from EC.
+	// ecSub, err := m.ec.ChainHead(ctx)
+	// if err != nil {
+	// 	errCh <- xerrors.Errorf("subscribing to chain events: %w", err)
+	// 	return
+	// }
+	ecSub := make(chan ec.TipSet)
+
+loop:
+	for {
+		select {
+		// Check first if there is a new configuration manifest that needs to be applied.
+		case ts := <-ecSub:
+			if m.nextManifest != nil {
+				// if the upgrade epoch is reached or already passed.
+				if ts.Epoch() >= m.nextManifest.BootstrapEpoch {
+					// update the current manifest
+					m.manifest = m.nextManifest
+					m.nextManifest = nil
+					// stop existing pubsub and subscribe to the new one
+					// if the re-bootstrap flag is enabled, it will setup a new runner with the new config.
+					go m.onManifestChange(ctx, uint64(m.manifest.BootstrapEpoch), m.nextManifest.ReBootstrap, errCh)
+					if !m.nextManifest.ReBootstrap {
+						// TODO: If the manifest doesn't have the re-bootstrap flagged
+						// enabled, no new runner is setup, we reuse the existing one.
+						// We need to pass the manifest to the runner to notify
+						// that there is a new configuration to be applied without
+						// restarting the runner.
+						// Some of the configurations that we expect to run in this way are
+						// - Updates to the power table
+						// - ECStabilisationDelay
+						// - more?
+						manifestQueue <- struct{}{}
+					}
+					continue
+				}
+			}
+		case <-ctx.Done():
+			break loop
+
+		default:
+			var msg *pubsub.Message
+			msg, err = manifestSub.Next(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					break
+				}
+				log.Errorf("manifestPubsub subscription.Next() returned an error: %+v", err)
+				break
+			}
+			manifest, ok := msg.ValidatorData.(*manifest.Manifest)
+			if !ok {
+				log.Errorf("invalid manifestValidatorData: %+v", msg.ValidatorData)
+				continue
+			}
+
+			if !m.acceptNextManifest(manifest) {
+				continue
+			}
+
+			m.nextManifest = manifest
+		}
+	}
+
+	manifestSub.Cancel()
+	if err := m.teardownManifestPubsub(); err != nil {
+		errCh <- xerrors.Errorf("shutting down manifest pubsub: %w", err)
+	}
+}
+
+func (m *DynamicManifest) teardownPubsub(topic *pubsub.Topic, topicName string) error {
+	return multierr.Combine(
+		m.pubsub.UnregisterTopicValidator(topicName),
+		topic.Close(),
+	)
+}
+
+func (m *DynamicManifest) teardownManifestPubsub() error {
+	return m.teardownPubsub(m.manifestTopic, ManifestPubSubTopicName)
+}
+
+// Checks if we should accept the manifest that we received through pubsub
+func (m *DynamicManifest) acceptNextManifest(manifest *manifest.Manifest) bool {
+	// if the manifest is older, skip it
+	if manifest.Sequence <= m.manifest.Sequence ||
+		manifest.BootstrapEpoch < m.manifest.BootstrapEpoch {
+		return false
+	}
+
+	return true
+}
+
+func (m *DynamicManifest) setupManifestPubsub() (err error) {
+	topicName := ManifestPubSubTopicName
+	// using the same validator approach used for the message pubsub
+	// to be homogeneous.
+	var validator pubsub.ValidatorEx = func(ctx context.Context, pID peer.ID,
+		msg *pubsub.Message) pubsub.ValidationResult {
+		var manifest manifest.Manifest
+		err := manifest.Unmarshal(bytes.NewReader(msg.Data))
+		if err != nil {
+			return pubsub.ValidationReject
+		}
+
+		// manifest should come from the expected diagnostics server
+		if pID != m.manifestServerID {
+			return pubsub.ValidationReject
+		}
+
+		// TODO: Any additional validation?
+		// Expect a sequence number that is over our current sequence number.
+		// Expect an BootstrapEpoch over the BootstrapEpoch of the current manifests?
+		// These should probably not be ValidationRejects to avoid banning in gossipsub
+		// the centralized server in case of misconfigurations or bugs.
+		msg.ValidatorData = &manifest
+		return pubsub.ValidationAccept
+	}
+
+	err = m.pubsub.RegisterTopicValidator(topicName, validator)
+	if err != nil {
+		return xerrors.Errorf("registering topic validator: %w", err)
+	}
+
+	m.manifestTopic, err = m.pubsub.Join(topicName)
+	if err != nil {
+		return xerrors.Errorf("could not join on pubsub topic: %s: %w", topicName, err)
+	}
+	return
 }

--- a/passive/manifest_sender.go
+++ b/passive/manifest_sender.go
@@ -1,0 +1,97 @@
+package passive
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/filecoin-project/go-f3/manifest"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"golang.org/x/xerrors"
+)
+
+// ManifestSender is responsible for periodically broadcasting
+// the current manifest for the network through the corresponding pubsub
+type ManifestSender struct {
+	h             host.Host
+	pubsub        *pubsub.PubSub
+	manifestTopic *pubsub.Topic
+
+	lk       sync.RWMutex
+	manifest *manifest.Manifest
+	period   time.Duration
+
+	// Used to stop publishing manifests
+	cancel func()
+}
+
+func NewManifestSender(h host.Host, pubsub *pubsub.PubSub, firstManifest *manifest.Manifest, publicationPeriod time.Duration) (*ManifestSender, error) {
+	topicName := ManifestPubSubTopicName
+	m := &ManifestSender{
+		manifest: firstManifest,
+		h:        h,
+		pubsub:   pubsub,
+		period:   publicationPeriod,
+	}
+
+	var err error
+	m.manifestTopic, err = m.pubsub.Join(topicName)
+	if err != nil {
+		return nil, xerrors.Errorf("could not join on pubsub topic: %s: %w", topicName, err)
+	}
+
+	return m, nil
+}
+
+func (m *ManifestSender) SenderID() peer.ID {
+	return m.h.ID()
+}
+
+func (m *ManifestSender) Addrs() []multiaddr.Multiaddr {
+	return m.h.Addrs()
+}
+
+func (m *ManifestSender) Start(ctx context.Context) {
+	if m.cancel != nil {
+		log.Warn("manifest sender already running")
+		return
+	}
+	ctx, m.cancel = context.WithCancel(ctx)
+
+	ticker := time.NewTicker(m.period)
+	for {
+		select {
+		case <-ticker.C:
+			m.lk.RLock()
+			err := m.publishManifest(ctx)
+			if err != nil {
+				log.Error("error publishing manifest: %w", err)
+			}
+			m.lk.RUnlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (m *ManifestSender) publishManifest(ctx context.Context) error {
+	b, err := m.manifest.Marshal()
+	if err != nil {
+		return err
+	}
+	return m.manifestTopic.Publish(ctx, b)
+}
+
+func (m *ManifestSender) UpdateManifest(manifest *manifest.Manifest) {
+	m.lk.Lock()
+	m.manifest = manifest
+	m.lk.Unlock()
+}
+
+func (m *ManifestSender) Stop() {
+	m.cancel()
+	m.cancel = nil
+}

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -1,0 +1,312 @@
+//go:build !race
+
+// Note: We don't run these tests with race because UnsafeCurrentInstance
+// would trigger the race detector.
+package test
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-f3"
+	"github.com/filecoin-project/go-f3/ec"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/manifest"
+	"github.com/filecoin-project/go-f3/passive"
+	"github.com/filecoin-project/go-f3/sim/signing"
+	leveldb "github.com/ipfs/go-ds-leveldb"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+)
+
+const (
+	ManifestSenderTimeout = 1 * time.Second
+)
+
+var log = logging.Logger("f3-testing")
+
+func TestSimpleF3(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnvironment(t, 2, false)
+
+	initialInstance := uint64(0)
+
+	// For some reason, peers do not discover each other through MDNS
+	// so I decided to connect them manually to ensure that they are connected
+	// for the test.
+	env.Connect(ctx)
+	env.Run(ctx, initialInstance)
+	// Small wait for nodes to initialize. In the future we can probably
+	// make this asynchronously by adding a done channel to run.
+	time.Sleep(1 * time.Second)
+
+	env.waitForInstanceNumber(ctx, 5, 60*time.Second)
+}
+
+func TestDynamicManifestWithoutChanges(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnvironment(t, 2, true)
+
+	initialInstance := uint64(0)
+
+	env.Connect(ctx)
+	env.Run(ctx, initialInstance)
+	time.Sleep(1 * time.Second)
+
+	env.waitForInstanceNumber(ctx, 5, 60*time.Second)
+}
+
+func TestDynamicManifestWithRebootstrap(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnvironment(t, 2, true)
+
+	initialInstance := uint64(0)
+
+	env.Connect(ctx)
+	env.Run(ctx, initialInstance)
+	time.Sleep(1 * time.Second)
+
+	env.manifest.BootstrapEpoch = 5
+	env.manifest.Sequence = 1
+	env.manifestSender.UpdateManifest(&env.manifest)
+	// FIXME:
+	// env.ec.genTipset(5)
+
+	env.waitForInstanceNumber(ctx, 10, 60*time.Second)
+
+	time.Sleep(10 * ManifestSenderTimeout)
+	env.waitForInstanceNumber(ctx, 3, 60*time.Second)
+	require.True(t, env.nodes[0].f3.CurrentGpbftInstace() < 10)
+
+	// TODO: Check that the network name has changed.
+	// TODO: Currently WIP
+
+	// I need to trigger changes in the current epoch to trigger the manifest change
+	// Check that the instance number is restarted and the pubsub topic is refreshed to
+	// the right name.
+}
+
+const DiscoveryTag = "f3-standalone-testing"
+
+var baseManifest manifest.Manifest = manifest.Manifest{
+	Sequence:       0,
+	BootstrapEpoch: 0,
+	ReBootstrap:    true,
+	NetworkName:    gpbft.NetworkName("test"),
+	GpbftConfig: &manifest.GpbftConfig{
+		Delta:                3,
+		DeltaBackOffExponent: 2.0,
+		MaxLookaheadRounds:   10,
+	},
+	EcConfig: &manifest.EcConfig{
+		ECFinality:       900,
+		CommiteeLookback: 5,
+		ECDelay:          30 * time.Second,
+
+		ECPeriod: 30 * time.Second,
+	},
+}
+
+type testNode struct {
+	h  host.Host
+	f3 *f3.F3
+}
+
+type testEnv struct {
+	t              *testing.T
+	manifest       manifest.Manifest
+	signingBackend *signing.FakeBackend
+	nodes          []*testNode
+	ec             *ec.FakeEC
+
+	manifestSender *passive.ManifestSender
+}
+
+func (t *testEnv) waitForInstanceNumber(ctx context.Context, instanceNumber uint64, timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			t.t.Error("instance number not reached before timeout")
+		default:
+			reached := 0
+			for i := 0; i < len(t.nodes); i++ {
+				if t.nodes[i].f3.CurrentGpbftInstace() >= instanceNumber {
+					reached++
+				}
+				if reached == len(t.nodes) {
+					return
+				}
+			}
+			time.Sleep(time.Second)
+		}
+	}
+}
+
+func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) testEnv {
+	env := testEnv{t: t}
+
+	// populate manifest
+	m := baseManifest
+
+	env.ec = ec.NewFakeEC(1, m)
+	env.signingBackend = signing.NewFakeBackend()
+	for i := 0; i < n; i++ {
+		pubkey, _ := env.signingBackend.GenerateKey()
+
+		m.InitialPowerTable = append(m.InitialPowerTable, gpbft.PowerEntry{
+			ID:     gpbft.ActorID(i),
+			PubKey: pubkey,
+			Power:  big.NewInt(1),
+		})
+	}
+	env.manifest = m
+
+	manifestServer := peer.ID("")
+	if dynamicManifest {
+		env.newManifestSender(context.Background())
+		manifestServer = env.manifestSender.SenderID()
+	}
+
+	// initialize nodes
+	for i := 0; i < n; i++ {
+		n, err := env.newF3Instance(context.Background(), i, manifestServer)
+		require.NoError(t, err)
+		env.nodes = append(env.nodes, n)
+	}
+	return env
+}
+
+func (e *testEnv) Run(ctx context.Context, initialInstance uint64) {
+	// Start the nodes
+	for _, n := range e.nodes {
+		go func(n *testNode) {
+			// TODO: Handle error from Run
+			_ = n.f3.Run(initialInstance, ctx)
+		}(n)
+	}
+
+	// If it exists, start the manifest sender
+	if e.manifestSender != nil {
+		go func() {
+			e.manifestSender.Start(ctx)
+		}()
+	}
+}
+
+func (e *testEnv) Connect(ctx context.Context) {
+	for i, n := range e.nodes {
+		for j := i + 1; j < len(e.nodes); j++ {
+			addr := e.nodes[j].h.Addrs()[0]
+			pi, err := peer.AddrInfoFromString(fmt.Sprintf("%s/p2p/%s", addr.String(), e.nodes[j].h.ID()))
+			require.NoError(e.t, err)
+			err = n.h.Connect(ctx, *pi)
+			require.NoError(e.t, err)
+		}
+	}
+
+	// connect to the manifest server if it exists
+	if e.manifestSender != nil {
+		for _, n := range e.nodes {
+			addr := e.manifestSender.Addrs()[0]
+			pi, err := peer.AddrInfoFromString(fmt.Sprintf("%s/p2p/%s", addr.String(), e.manifestSender.SenderID()))
+			require.NoError(e.t, err)
+			err = n.h.Connect(ctx, *pi)
+			require.NoError(e.t, err)
+		}
+
+	}
+}
+
+func (e *testEnv) newManifestSender(ctx context.Context) {
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/udp/0/quic-v1"))
+	require.NoError(e.t, err)
+
+	ps, err := pubsub.NewGossipSub(ctx, h)
+	require.NoError(e.t, err)
+
+	closer, err := setupDiscovery(h)
+	require.NoError(e.t, err)
+	defer closer()
+
+	e.manifestSender, err = passive.NewManifestSender(h, ps, &e.manifest, ManifestSenderTimeout)
+	require.NoError(e.t, err)
+}
+
+func (e *testEnv) newF3Instance(ctx context.Context, id int, manifestServer peer.ID) (*testNode, error) {
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/udp/0/quic-v1"))
+	if err != nil {
+		return nil, xerrors.Errorf("creating libp2p host: %w", err)
+	}
+
+	ps, err := pubsub.NewGossipSub(ctx, h)
+	if err != nil {
+		return nil, xerrors.Errorf("creating gossipsub: %w", err)
+	}
+
+	closer, err := setupDiscovery(h)
+	if err != nil {
+		return nil, xerrors.Errorf("setting up discovery: %w", err)
+	}
+	defer closer()
+
+	tmpdir, err := os.MkdirTemp("", "f3-*")
+	if err != nil {
+		return nil, xerrors.Errorf("creating temp dir: %w", err)
+	}
+
+	err = logging.SetLogLevel("f3-testing", "debug")
+	if err != nil {
+		return nil, xerrors.Errorf("setting log level: %w", err)
+	}
+
+	ds, err := leveldb.NewDatastore(tmpdir, nil)
+	if err != nil {
+		return nil, xerrors.Errorf("creating a datastore: %w", err)
+	}
+
+	var mprovider manifest.ManifestProvider
+	if manifestServer != peer.ID("") {
+		mprovider = passive.NewDynamicManifest(&e.manifest, ps, e.ec, manifestServer)
+	} else {
+		mprovider = manifest.NewStaticManifest(&e.manifest)
+	}
+
+	e.signingBackend.Allow(int(id))
+	module, err := f3.New(ctx, gpbft.ActorID(id), mprovider, ds, h, manifestServer, ps, e.signingBackend, e.signingBackend, e.ec, log)
+	if err != nil {
+		return nil, xerrors.Errorf("creating module: %w", err)
+	}
+
+	mprovider.SetManifestChangeCb(f3.ManifestChangeCallback(module))
+	return &testNode{h, module}, nil
+}
+
+type discoveryNotifee struct {
+	h host.Host
+}
+
+func (n *discoveryNotifee) HandlePeerFound(pi peer.AddrInfo) {
+	fmt.Printf("discovered new peer %s\n", pi.ID)
+	err := n.h.Connect(context.Background(), pi)
+	if err != nil {
+		fmt.Printf("error connecting to peer %s: %s\n", pi.ID, err)
+	}
+}
+
+func setupDiscovery(h host.Host) (closer func(), err error) {
+	// setup mDNS discovery to find local peers
+	s := mdns.NewMdnsService(h, DiscoveryTag, &discoveryNotifee{h: h})
+	return func() { s.Close() }, s.Start()
+}

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -47,7 +47,7 @@ func TestSimpleF3(t *testing.T) {
 	env.Connect(ctx)
 	env.Run(ctx, initialInstance)
 	// Small wait for nodes to initialize. In the future we can probably
-	// make this asynchronously by adding a done channel to run.
+	// make this asynchronously
 	time.Sleep(1 * time.Second)
 
 	env.waitForInstanceNumber(ctx, 5, 60*time.Second)
@@ -100,7 +100,7 @@ const DiscoveryTag = "f3-standalone-testing"
 
 var baseManifest manifest.Manifest = manifest.Manifest{
 	Sequence:       0,
-	BootstrapEpoch: 0,
+	BootstrapEpoch: 1000,
 	ReBootstrap:    true,
 	NetworkName:    gpbft.NetworkName("test"),
 	GpbftConfig: &manifest.GpbftConfig{
@@ -159,6 +159,7 @@ func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) testEnv {
 
 	// populate manifest
 	m := baseManifest
+	m.ECBoostrapTimestamp = time.Now().Add(-time.Duration(m.BootstrapEpoch) * m.ECPeriod)
 
 	env.ec = ec.NewFakeEC(1, m)
 	env.signingBackend = signing.NewFakeBackend()
@@ -168,7 +169,7 @@ func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) testEnv {
 		m.InitialPowerTable = append(m.InitialPowerTable, gpbft.PowerEntry{
 			ID:     gpbft.ActorID(i),
 			PubKey: pubkey,
-			Power:  big.NewInt(1),
+			Power:  big.NewInt(1000),
 		})
 	}
 	env.manifest = m

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-f3"
+	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"
@@ -47,7 +48,7 @@ func TestSimpleF3(t *testing.T) {
 	env.waitForInstanceNumber(ctx, 5, 10*time.Second)
 }
 
-func TestDynamicManifestWithoutChanges(t *testing.T) {
+func TestDynamicManifest_WithoutChanges(t *testing.T) {
 	ctx := context.Background()
 	env := newTestEnvironment(t, 2, true)
 
@@ -64,7 +65,7 @@ func TestDynamicManifestWithoutChanges(t *testing.T) {
 	env.requireEqualManifests()
 }
 
-func TestDynamicManifestWithRebootstrap(t *testing.T) {
+func TestDynamicManifest_WithRebootstrap(t *testing.T) {
 	ctx := context.Background()
 	env := newTestEnvironment(t, 2, true)
 
@@ -94,6 +95,44 @@ func TestDynamicManifestWithRebootstrap(t *testing.T) {
 	env.waitForInstanceNumber(ctx, 3, 15*time.Second)
 	require.NotEqual(t, prev, env.nodes[0].f3.Manifest.Manifest())
 	env.requireEqualManifests()
+}
+
+func TestDynamicManifest_WithoutRebootstrap(t *testing.T) {
+	ctx := context.Background()
+	env := newTestEnvironment(t, 2, true)
+
+	initialInstance := uint64(0)
+
+	env.Connect(ctx)
+	env.Run(ctx, initialInstance)
+	time.Sleep(1 * time.Second)
+
+	prev := env.nodes[0].f3.Manifest.Manifest()
+
+	env.waitForInstanceNumber(ctx, 3, 15*time.Second)
+	prevInstance := env.nodes[0].f3.CurrentGpbftInstace()
+
+	env.manifest.BootstrapEpoch = 953
+	env.manifest.Sequence = 1
+	env.manifest.ReBootstrap = false
+	// Adding a power of 1 so we can reach consensus without having to run
+	// the new nodes
+	env.addPowerDeltaForParticipants(ctx, &env.manifest, []gpbft.ActorID{2, 3}, big.NewInt(1), false)
+	env.manifestSender.UpdateManifest(&env.manifest)
+
+	env.waitForManifestChange(ctx, prev, 1599999*time.Second)
+
+	// check that the runner continued wthout rebootstrap
+	require.True(t, env.nodes[0].f3.CurrentGpbftInstace() >= prevInstance)
+	env.waitForInstanceNumber(ctx, prevInstance+10, 150000*time.Second)
+	require.NotEqual(t, prev, env.nodes[0].f3.Manifest.Manifest())
+	env.requireEqualManifests()
+	// check that the power table is updated with the new entries
+	ts, err := env.ec.GetTipsetByEpoch(ctx, int64(env.nodes[0].f3.CurrentGpbftInstace()))
+	require.NoError(t, err)
+	pt, err := env.nodes[0].f3.GetPowerTable(ctx, ts.Key())
+	require.NoError(t, err)
+	require.Equal(t, len(pt), 4)
 }
 
 const DiscoveryTag = "f3-standalone-testing"
@@ -129,20 +168,57 @@ type testEnv struct {
 	manifestSender *passive.ManifestSender
 }
 
-func (t *testEnv) waitForInstanceNumber(ctx context.Context, instanceNumber uint64, timeout time.Duration) {
+func (e *testEnv) addPowerDeltaForParticipants(ctx context.Context, m *manifest.Manifest, participants []gpbft.ActorID, power *big.Int, runNodes bool) {
+	for _, n := range participants {
+		nodeLen := len(e.nodes)
+		newNode := false
+		// nodes are initialized sequentially. If the participantID is over the
+		// number of nodes, it means that it hasn't been initialized and is a new node
+		// that we need to add
+		// NOTE: We do not respect the original ID when adding a new one, we use the subsequent one.
+		if n >= gpbft.ActorID(nodeLen) {
+			e.initNode(int(nodeLen), e.manifestSender.SenderID())
+			newNode = true
+		}
+		pubkey, _ := e.signingBackend.GenerateKey()
+		m.PowerUpdate = append(m.PowerUpdate, certs.PowerTableDelta{
+			ParticipantID: gpbft.ActorID(nodeLen),
+			SigningKey:    pubkey,
+			PowerDelta:    power,
+		})
+		if runNodes && newNode {
+			// connect node
+			for j := 0; j < nodeLen-1; j++ {
+				e.connectNodes(ctx, e.nodes[nodeLen-1], e.nodes[j])
+			}
+			// run
+			e.nodes[nodeLen-1].f3.Run(e.nodes[nodeLen-1].f3.CurrentGpbftInstace(), context.Background())
+		}
+	}
+}
+
+// waits for all _running_ nodes to reach a specific instance number.
+func (e *testEnv) waitForInstanceNumber(ctx context.Context, instanceNumber uint64, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	for {
 		select {
 		case <-ctx.Done():
-			t.t.Fatal("instance number not reached before timeout")
+			e.t.Fatal("instance number not reached before timeout")
 		default:
 			reached := 0
-			for i := 0; i < len(t.nodes); i++ {
-				if t.nodes[i].f3.CurrentGpbftInstace() >= instanceNumber {
+			for i := 0; i < len(e.nodes); i++ {
+				// nodes that are not running are not required to reach the instance
+				// (it will actually panic if we try to fetch it because there is no
+				// runner initialized)
+				if !e.nodes[i].f3.IsRunning() {
+					reached++
+					continue
+				}
+				if e.nodes[i].f3.CurrentGpbftInstace() >= instanceNumber && e.nodes[i].f3.IsRunning() {
 					reached++
 				}
-				if reached == len(t.nodes) {
+				if reached == len(e.nodes) {
 					return
 				}
 			}
@@ -151,22 +227,22 @@ func (t *testEnv) waitForInstanceNumber(ctx context.Context, instanceNumber uint
 	}
 }
 
-func (t *testEnv) waitForManifestChange(ctx context.Context, prev manifest.Manifest, timeout time.Duration) {
+func (e *testEnv) waitForManifestChange(ctx context.Context, prev manifest.Manifest, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	for {
 		select {
 		case <-ctx.Done():
-			t.t.Fatal("manifest change not reached before timeout")
+			e.t.Fatal("manifest change not reached before timeout")
 		default:
 			reached := 0
-			for i := 0; i < len(t.nodes); i++ {
-				v1, _ := t.nodes[i].f3.Manifest.Manifest().Version()
+			for i := 0; i < len(e.nodes); i++ {
+				v1, _ := e.nodes[i].f3.Manifest.Manifest().Version()
 				v2, _ := prev.Version()
 				if v1 != v2 {
 					reached++
 				}
-				if reached == len(t.nodes) {
+				if reached == len(e.nodes) {
 					return
 				}
 			}
@@ -203,11 +279,15 @@ func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) testEnv {
 
 	// initialize nodes
 	for i := 0; i < n; i++ {
-		n, err := env.newF3Instance(context.Background(), i, manifestServer)
-		require.NoError(t, err)
-		env.nodes = append(env.nodes, n)
+		env.initNode(i, manifestServer)
 	}
 	return env
+}
+
+func (e *testEnv) initNode(i int, manifestServer peer.ID) {
+	n, err := e.newF3Instance(context.Background(), i, manifestServer)
+	require.NoError(e.t, err)
+	e.nodes = append(e.nodes, n)
 }
 
 func (e *testEnv) requireEqualManifests() {
@@ -234,14 +314,18 @@ func (e *testEnv) Run(ctx context.Context, initialInstance uint64) {
 	}
 }
 
+func (e *testEnv) connectNodes(ctx context.Context, n1, n2 *testNode) {
+	addr := n2.h.Addrs()[0]
+	pi, err := peer.AddrInfoFromString(fmt.Sprintf("%s/p2p/%s", addr.String(), n2.h.ID()))
+	require.NoError(e.t, err)
+	err = n1.h.Connect(ctx, *pi)
+	require.NoError(e.t, err)
+}
+
 func (e *testEnv) Connect(ctx context.Context) {
 	for i, n := range e.nodes {
 		for j := i + 1; j < len(e.nodes); j++ {
-			addr := e.nodes[j].h.Addrs()[0]
-			pi, err := peer.AddrInfoFromString(fmt.Sprintf("%s/p2p/%s", addr.String(), e.nodes[j].h.ID()))
-			require.NoError(e.t, err)
-			err = n.h.Connect(ctx, *pi)
-			require.NoError(e.t, err)
+			e.connectNodes(ctx, n, e.nodes[j])
 		}
 	}
 


### PR DESCRIPTION
Depends on https://github.com/filecoin-project/go-f3/pull/348

This PR:

Implements all the logic to handle the reception of new manifests, and to trigger a rebootstrap when the change is received. The implementation of configuration changes without rebootstraps (mainly EC config and power table changes), will come in the next PR.
Implements a simple manifest sender that periodically broadcast the current manifest used by the network.
Includes a really simple testing harness for F3 over real libp2p hosts to test all the pubsub integration and the distribution of manifests.
Implementation of the logic when a manifest change doesn't trigger a rebootstrap and power table updates.