### PR TITLE
Correctly use ECPeriod & ECDelay

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -14,12 +14,14 @@ type Manifest struct {
 	InitialPowerTable gpbft.PowerEntries
 	BootstrapEpoch    int64
 
-	ECFinality       int64
-	ECDelay          time.Duration
+	ECFinality int64
+	// The delay after a tipset is produced before we attempt to finalize it.
+	ECDelay time.Duration
+	// The delay between tipsets.
+	ECPeriod         time.Duration
 	CommiteeLookback uint64
 
 	//Temporary
-	ECPeriod            time.Duration
 	ECBoostrapTimestamp time.Time
 }
 
@@ -31,7 +33,7 @@ func LocalnetManifest() Manifest {
 		BootstrapEpoch:   1000,
 		ECFinality:       900,
 		CommiteeLookback: 5,
-		ECDelay:          30 * time.Second,
+		ECDelay:          60 * time.Second,
 
 		ECPeriod: 30 * time.Second,
 	}


### PR DESCRIPTION
ECDelay is how long we wait before finalizing a tipset, but it isn't necessarily the time between instances (it's actually 2x right now in lotus). ECPeriod is the time between instances.

The new logic waits `ECDelay + ECPeriod * multiplier` where I've reduced each multiplier by 1 to account for the added delay.

Additionally:

1. We now use `now+ECPeriod` when we fail to get the tipset from lotus.
2. ECDelay defaults to 60s (same as lotus).

NOTE: I'm not sure if this new logic is correct, but the old logic definitely had some issues so I'm opening this PR for discussion.