### PR TITLE
Test GPBFT queues and drains future instance messages

### DIFF
--- a/emulator/driver.go
+++ b/emulator/driver.go
@@ -10,14 +10,13 @@ import (
 // Driver drives the emulation of a GPBFT instance for one honest participant,
 // and allows frame-by-frame control over progress of a GPBFT instance.
 type Driver struct {
-	require         *require.Assertions
-	subject         *gpbft.Participant
-	host            *driverHost
-	currentInstance *Instance
+	require *require.Assertions
+	subject *gpbft.Participant
+	host    *driverHost
 }
 
 // NewDriver instantiates a new Driver with the given GPBFT options. See
-// Driver.Start.
+// Driver.StartInstance.
 func NewDriver(t *testing.T, o ...gpbft.Option) *Driver {
 	h := newHost(t)
 	participant, err := gpbft.NewParticipant(h, o...)
@@ -29,18 +28,20 @@ func NewDriver(t *testing.T, o ...gpbft.Option) *Driver {
 	}
 }
 
-// Start starts emulation for the given instance and signals the start of
-// instance to the emulated honest gpbft.Participant.
+// StartInstance sets the current instances and starts emulation for it by signalling the
+// start of instance to the emulated honest gpbft.Participant.
 //
 // See NewInstance.
-func (d *Driver) Start(instance *Instance) {
-	d.require.NoError(d.host.setInstance(instance))
-	d.require.NoError(d.subject.StartInstance(instance.id))
-	d.currentInstance = instance
-
+func (d *Driver) StartInstance(id uint64) {
+	d.require.NoError(d.subject.StartInstance(id))
 	// Trigger alarm once based on the implicit assumption that go-f3 uses alarm to
 	// kickstart an instance internally.
 	d.RequireDeliverAlarm()
+}
+
+// AddInstance adds an instance to the list of instances known by the driver.
+func (d *Driver) AddInstance(instance *Instance) {
+	d.require.NoError(d.host.addInstance(instance))
 }
 
 func (d *Driver) deliverAlarm() (bool, error) {

--- a/emulator/host.go
+++ b/emulator/host.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const networkName = "emulator-net"
+
 var _ gpbft.Host = (*driverHost)(nil)
 
 type driverHost struct {
@@ -82,12 +84,16 @@ func (h *driverHost) GetCommitteeForInstance(id uint64) (power *gpbft.PowerTable
 	return instance.powerTable, instance.beacon, nil
 }
 
-func (h *driverHost) setInstance(instance *Instance) error {
+func (h *driverHost) addInstance(instance *Instance) error {
 	if existing := h.chain[instance.id]; existing != nil {
 		return fmt.Errorf("instance ID %d is already set", instance.id)
 	}
 	h.chain[instance.id] = instance
 	return nil
+}
+
+func (h *driverHost) getInstance(id uint64) *Instance {
+	return h.chain[id]
 }
 
 func (h *driverHost) popReceivedBroadcast() *gpbft.GMessage {
@@ -101,6 +107,6 @@ func (h *driverHost) popReceivedBroadcast() *gpbft.GMessage {
 	}
 }
 
-func (h *driverHost) NetworkName() gpbft.NetworkName { return "emulator-net" }
+func (h *driverHost) NetworkName() gpbft.NetworkName { return networkName }
 func (h *driverHost) Time() time.Time                { return h.now }
 func (h *driverHost) SetAlarm(at time.Time)          { h.pendingAlarm = &at }

--- a/gpbft/gpbft_test.go
+++ b/gpbft/gpbft_test.go
@@ -11,6 +11,8 @@ var (
 	tipset0 = gpbft.TipSet{Epoch: 0, Key: []byte("bigbang")}
 	tipSet1 = gpbft.TipSet{Epoch: 1, Key: []byte("fish")}
 	tipSet2 = gpbft.TipSet{Epoch: 2, Key: []byte("lobster")}
+	tipSet3 = gpbft.TipSet{Epoch: 3, Key: []byte("fisherman")}
+	tipSet4 = gpbft.TipSet{Epoch: 4, Key: []byte("lobstermucher")}
 )
 
 func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
@@ -30,12 +32,14 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			},
 			tipset0, tipSet1, tipSet2,
 		)
-		driver.Start(instance)
+		driver.AddInstance(instance)
+		driver.RequireNoBroadcast()
 		return instance, driver
 	}
 
 	t.Run("Decides proposal on strong quorum", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
+		driver.StartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -49,7 +53,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Vote:   instance.NewPrepare(0, instance.Proposal()),
 		})
 
-		evidenceOfPrepare := driver.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0, 1)
+		evidenceOfPrepare := instance.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0, 1)
 		driver.RequireCommit(0, instance.Proposal(), evidenceOfPrepare)
 		driver.RequireDeliverMessage(&gpbft.GMessage{
 			Sender:        1,
@@ -57,7 +61,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Justification: evidenceOfPrepare,
 		})
 
-		evidenceOfCommit := driver.NewJustification(0, gpbft.COMMIT_PHASE, instance.Proposal(), 0, 1)
+		evidenceOfCommit := instance.NewJustification(0, gpbft.COMMIT_PHASE, instance.Proposal(), 0, 1)
 		driver.RequireDecide(instance.Proposal(), evidenceOfCommit)
 		driver.RequireDeliverMessage(&gpbft.GMessage{
 			Sender:        1,
@@ -65,11 +69,12 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Justification: evidenceOfCommit,
 		})
 
-		driver.RequireDecision(instance.Proposal())
+		driver.RequireDecision(instance.ID(), instance.Proposal())
 	})
 
 	t.Run("Decides base on lack of quorum", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
+		driver.StartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -86,7 +91,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Sender: 1,
 			Vote:   instance.NewPrepare(0, baseChain),
 		})
-		evidenceOfPrepare := driver.NewJustification(0, gpbft.PREPARE_PHASE, baseChain, 0, 1)
+		evidenceOfPrepare := instance.NewJustification(0, gpbft.PREPARE_PHASE, baseChain, 0, 1)
 
 		driver.RequireCommit(0, baseChain, evidenceOfPrepare)
 		driver.RequireDeliverMessage(&gpbft.GMessage{
@@ -95,18 +100,19 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Justification: evidenceOfPrepare,
 		})
 
-		evidenceOfCommit := driver.NewJustification(0, gpbft.COMMIT_PHASE, baseChain, 0, 1)
+		evidenceOfCommit := instance.NewJustification(0, gpbft.COMMIT_PHASE, baseChain, 0, 1)
 		driver.RequireDecide(baseChain, evidenceOfCommit)
 		driver.RequireDeliverMessage(&gpbft.GMessage{
 			Sender:        1,
 			Vote:          instance.NewDecide(0, baseChain),
 			Justification: evidenceOfCommit,
 		})
-		driver.RequireDecision(baseChain)
+		driver.RequireDecision(instance.ID(), baseChain)
 	})
 
 	t.Run("Converges on base when quorum not possible", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
+		driver.StartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -130,7 +136,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Vote:   instance.NewCommit(0, gpbft.ECChain{}),
 		})
 
-		evidenceOfCommitForBottom := driver.NewJustification(0, gpbft.COMMIT_PHASE, gpbft.ECChain{}, 0, 1)
+		evidenceOfCommitForBottom := instance.NewJustification(0, gpbft.COMMIT_PHASE, gpbft.ECChain{}, 0, 1)
 
 		driver.RequireConverge(1, baseChain, evidenceOfCommitForBottom)
 		driver.RequireDeliverMessage(&gpbft.GMessage{
@@ -148,7 +154,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Justification: evidenceOfCommitForBottom,
 		})
 
-		evidenceOfPrepare := driver.NewJustification(1, gpbft.PREPARE_PHASE, baseChain, 0, 1)
+		evidenceOfPrepare := instance.NewJustification(1, gpbft.PREPARE_PHASE, baseChain, 0, 1)
 
 		driver.RequireCommit(1, baseChain, evidenceOfPrepare)
 		driver.RequireDeliverMessage(&gpbft.GMessage{
@@ -157,16 +163,98 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Justification: evidenceOfPrepare,
 		})
 
-		evidenceOfCommit := driver.NewJustification(1, gpbft.COMMIT_PHASE, baseChain, 0, 1)
+		evidenceOfCommit := instance.NewJustification(1, gpbft.COMMIT_PHASE, baseChain, 0, 1)
 		driver.RequireDecide(baseChain, evidenceOfCommit)
 		driver.RequireDeliverMessage(&gpbft.GMessage{
 			Sender:        1,
 			Vote:          instance.NewDecide(0, baseChain),
 			Justification: evidenceOfCommit,
 		})
-		driver.RequireDecision(baseChain)
+		driver.RequireDecision(instance.ID(), baseChain)
 	})
 
+	t.Run("Dequeues received messages after start", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewQuality(instance.Proposal()),
+		})
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewPrepare(0, instance.Proposal()),
+		})
+
+		driver.StartInstance(instance.ID())
+		driver.RequireQuality()
+		driver.RequirePrepare(instance.Proposal())
+		evidenceOfPrepare := instance.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0, 1)
+		driver.RequireCommit(0, instance.Proposal(), evidenceOfPrepare)
+	})
+
+	t.Run("Queues future instance messages during current instance", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		futureInstance := emulator.NewInstance(t,
+			42,
+			gpbft.PowerEntries{
+				gpbft.PowerEntry{
+					ID:    0,
+					Power: gpbft.NewStoragePower(1),
+				},
+				gpbft.PowerEntry{
+					ID:    1,
+					Power: gpbft.NewStoragePower(1),
+				},
+			},
+			tipSet3, tipSet4,
+		)
+		driver.AddInstance(futureInstance)
+		driver.StartInstance(instance.ID())
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewQuality(instance.Proposal()),
+		})
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewPrepare(0, instance.Proposal()),
+		})
+
+		// Send messages from future instance which should be enough to progress the
+		// future instance to COMMIT with strong evidence of prepare without any further
+		// messages or timeout.
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   futureInstance.NewQuality(futureInstance.Proposal()),
+		})
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   futureInstance.NewPrepare(0, futureInstance.Proposal()),
+		})
+
+		driver.RequireQuality()
+		driver.RequirePrepare(instance.Proposal())
+		evidenceOfPrepare := instance.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0, 1)
+		driver.RequireCommit(0, instance.Proposal(), evidenceOfPrepare)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewCommit(0, instance.Proposal()),
+			Justification: evidenceOfPrepare,
+		})
+		evidenceOfCommit := instance.NewJustification(0, gpbft.COMMIT_PHASE, instance.Proposal(), 0, 1)
+		driver.RequireDecide(instance.Proposal(), evidenceOfCommit)
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewDecide(0, instance.Proposal()),
+			Justification: evidenceOfCommit,
+		})
+		driver.RequireDecision(instance.ID(), instance.Proposal())
+
+		// Start the future instance and expect progress to commit without any timeouts
+		// based on previously queued messages.
+		driver.StartInstance(futureInstance.ID())
+		driver.RequireQuality()
+		driver.RequirePrepare(futureInstance.Proposal())
+		driver.RequireCommit(0, futureInstance.Proposal(), instance.NewJustification(0, gpbft.PREPARE_PHASE, futureInstance.Proposal(), 0, 1))
+	})
 }
 
 func TestGPBFT_SoloParticipant(t *testing.T) {
@@ -182,41 +270,44 @@ func TestGPBFT_SoloParticipant(t *testing.T) {
 			},
 			tipset0, tipSet1, tipSet2,
 		)
-		driver.Start(instance)
+		driver.AddInstance(instance)
+		driver.RequireNoBroadcast()
 		return instance, driver
 	}
 
 	t.Run("Decides proposal with no timeout", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
+		driver.StartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequirePrepare(instance.Proposal())
 		driver.RequireCommit(
 			0,
 			instance.Proposal(),
-			driver.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0),
+			instance.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0),
 		)
 		driver.RequireDecide(
 			instance.Proposal(),
-			driver.NewJustification(0, gpbft.COMMIT_PHASE, instance.Proposal(), 0),
+			instance.NewJustification(0, gpbft.COMMIT_PHASE, instance.Proposal(), 0),
 		)
-		driver.RequireDecision(instance.Proposal())
+		driver.RequireDecision(instance.ID(), instance.Proposal())
 	})
 
 	t.Run("Decides base on QUALITY timeout", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
 		baseChain := instance.Proposal().BaseChain()
+		driver.StartInstance(instance.ID())
 		driver.RequireDeliverAlarm()
 		driver.RequireQuality()
 		driver.RequirePrepare(baseChain)
 		driver.RequireCommit(
 			0,
 			baseChain,
-			driver.NewJustification(0, gpbft.PREPARE_PHASE, baseChain, 0),
+			instance.NewJustification(0, gpbft.PREPARE_PHASE, baseChain, 0),
 		)
 		driver.RequireDecide(
 			baseChain,
-			driver.NewJustification(0, gpbft.COMMIT_PHASE, baseChain, 0),
+			instance.NewJustification(0, gpbft.COMMIT_PHASE, baseChain, 0),
 		)
-		driver.RequireDecision(baseChain)
+		driver.RequireDecision(instance.ID(), baseChain)
 	})
 }


### PR DESCRIPTION
Add two new tests that assert:
* messages arriving before instance is started are processed.
* messages arriving after instance is started that belong to future rounds are processed.

Part of #9