### PR TITLE
Maybe fix spurious error in tests

### DIFF
--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -417,6 +417,9 @@ func (e *testEnv) monitorNodesError(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case err := <-n.errCh:
+				if ctx.Err() != nil {
+					return
+				}
 				require.NoError(e.t, err)
 			}
 		}(n)


### PR DESCRIPTION
Race tests will sometimes fail here, there exists ordering of goroutine
execution where ctx.Done() fires first within Runner and propagates through the errCh and select picks it over the context.