### PR TITLE
Publish container images for both arm and amd 64

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -36,11 +36,12 @@ jobs:
             type=ref,event=branch
             type=raw,value=${{ github.ref }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Include both linux arm64 and amd64 platforms when building and publishing container.

Update push action to latest.

Part of #396 