### PR TITLE
Fail gracefully on manifest server bootstrap connection

### DIFF
--- a/cmd/f3/manifest.go
+++ b/cmd/f3/manifest.go
@@ -166,7 +166,7 @@ var manifestServeCmd = cli.Command{
 				return xerrors.Errorf("parsing bootstrap address %s: %w", bootstrapper, err)
 			}
 			if err := host.Connect(c.Context, *addr); err != nil {
-				return xerrors.Errorf("connecting to bootstrapper %s: %w", bootstrapper, err)
+				_, _ = fmt.Fprintf(c.App.ErrWriter, "Failed to connect to bootstrap address: %v\n", err)
 			}
 		}
 


### PR DESCRIPTION
Avoid failing fatally if connection to bootstrap servers fails. It is possible that some or all the bootstrap server addresses are down, in which case proceed with running the manifest server and simply output the connection failure.
