### PR TITLE
Test rebroadcast and fix rebroadcast reset issue

### DIFF
--- a/gpbft/gpbft_test.go
+++ b/gpbft/gpbft_test.go
@@ -16,6 +16,7 @@ var (
 )
 
 func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
+	t.Parallel()
 	newInstanceAndDriver := func(t *testing.T) (*emulator.Instance, *emulator.Driver) {
 		driver := emulator.NewDriver(t)
 		instance := emulator.NewInstance(t,
@@ -254,6 +255,141 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 		driver.RequireQuality()
 		driver.RequirePrepare(futureInstance.Proposal())
 		driver.RequireCommit(0, futureInstance.Proposal(), instance.NewJustification(0, gpbft.PREPARE_PHASE, futureInstance.Proposal(), 0, 1))
+	})
+
+	t.Run("Rebroadcasts selected messages on timeout", func(t *testing.T) {
+		instance, driver := newInstanceAndDriver(t)
+		driver.StartInstance(instance.ID())
+		driver.RequireQuality()
+		driver.RequireNoBroadcast()
+		driver.RequireDeliverAlarm()
+
+		baseChain := instance.Proposal().BaseChain()
+		driver.RequirePrepare(baseChain)
+		driver.RequireNoBroadcast()
+		// Trigger alarm to necessitate the need for scheduling rebroadcast.
+		driver.RequireDeliverAlarm()
+		// Expect no messages until the rebroadcast timeout has expired.
+		driver.RequireNoBroadcast()
+		// Trigger rebroadcast alarm.
+		driver.RequireDeliverAlarm()
+		// Expect rebroadcast of PREPARE only; no QUALITY message should be rebroadcasted.
+		driver.RequirePrepare(baseChain)
+		driver.RequireNoBroadcast()
+		// Trigger alarm and expect immediate rebroadcast of PREMARE.
+		driver.RequireDeliverAlarm()
+		// Expect rebroadcast of PREPARE only; no QUALITY message should be rebroadcasted.
+		driver.RequirePrepare(baseChain)
+		driver.RequireNoBroadcast()
+
+		// Deliver PREPARE for bottom to facilitate progress to COMMIT.
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewPrepare(0, baseChain),
+		})
+
+		// Expect progress to COMMIT with strong evidence of PREPARE.
+		evidenceOfPrepare := instance.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0, 1)
+		driver.RequireCommit(0, baseChain, evidenceOfPrepare)
+
+		// Expect no messages until the rebroadcast timeout has expired.
+		driver.RequireNoBroadcast()
+		// Trigger alarm to necessitate the need for scheduling rebroadcast, since
+		// rebroadcast timeout must have been reset Due to progress to COMMIT.
+		driver.RequireDeliverAlarm()
+		// Expect no messages until the rebroadcast timeout has expired.
+		driver.RequireNoBroadcast()
+		// Trigger rebroadcast alarm.
+		driver.RequireDeliverAlarm()
+
+		// Expect rebroadcast of PREPARE and COMMIT.
+		driver.RequirePrepare(baseChain)
+		driver.RequireCommit(0, baseChain, evidenceOfPrepare)
+		driver.RequireNoBroadcast()
+
+		// Deliver COMMIT for bottom to facilitate progress to CONVERGE.
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender: 1,
+			Vote:   instance.NewCommit(0, gpbft.ECChain{}),
+		})
+
+		// Expect Converge with evidence of COMMIT for bottom.
+		evidenceOfPrepareForBase := instance.NewJustification(0, gpbft.PREPARE_PHASE, baseChain, 0, 1)
+		driver.RequireConverge(1, baseChain, evidenceOfPrepareForBase)
+		driver.RequireNoBroadcast()
+
+		// Trigger alarm to facilitate PREPARE at round 1.
+		driver.RequireDeliverAlarm()
+		driver.RequirePrepareAtRound(1, baseChain, evidenceOfPrepareForBase)
+		driver.RequireNoBroadcast()
+
+		// Trigger alarm to necessitate the need for scheduling rebroadcast, since
+		// rebroadcast timeout must have been reset now that progress is made.
+		driver.RequireDeliverAlarm()
+		// Expect no messages until the rebroadcast timeout has expired.
+		driver.RequireNoBroadcast()
+		// Trigger rebroadcast alarm.
+		driver.RequireDeliverAlarm()
+
+		// Expect rebroadcast of all messages from previous and current round (except QUALITY)
+		driver.RequirePrepare(baseChain)
+		driver.RequireCommit(0, baseChain, evidenceOfPrepare)
+		driver.RequireConverge(1, baseChain, evidenceOfPrepareForBase)
+		driver.RequirePrepareAtRound(1, baseChain, evidenceOfPrepareForBase)
+
+		// Deliver PREPARE for base to facilitate progress to COMMIT.
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewPrepare(1, baseChain),
+			Justification: evidenceOfPrepareForBase,
+		})
+
+		// Expect Progress to COMMIT at round 1.
+		evidenceOfPrepareAtRound1 := instance.NewJustification(1, gpbft.PREPARE_PHASE, baseChain, 0, 1)
+		driver.RequireCommit(1, baseChain, evidenceOfPrepareAtRound1)
+		driver.RequireNoBroadcast()
+
+		// Trigger alarm to necessitate the need for scheduling rebroadcast, since
+		// rebroadcast timeout must have been reset now that progress is made.
+		driver.RequireDeliverAlarm()
+		// Expect no messages until the rebroadcast timeout has expired.
+		driver.RequireNoBroadcast()
+		// Trigger rebroadcast alarm.
+		driver.RequireDeliverAlarm()
+
+		// Expect rebroadcast of all messages from previous and current round, except
+		// QUALITY.
+		driver.RequirePrepare(baseChain)
+		driver.RequireCommit(0, baseChain, evidenceOfPrepare)
+		driver.RequireConverge(1, baseChain, evidenceOfPrepareForBase)
+		driver.RequirePrepareAtRound(1, baseChain, evidenceOfPrepareForBase)
+		driver.RequireCommit(1, baseChain, evidenceOfPrepareAtRound1)
+
+		// Deliver COMMIT at round 1 to facilitate progress to DECIDE.
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewCommit(1, baseChain),
+			Justification: evidenceOfPrepareAtRound1,
+		})
+
+		// Expect DECIDE with strong evidence of COMMIT.
+		evidenceOfCommit := instance.NewJustification(1, gpbft.COMMIT_PHASE, baseChain, 0, 1)
+		driver.RequireDecide(baseChain, evidenceOfCommit)
+
+		// Trigger alarm and expect immediate rebroadcast, because DECIDE phase has no
+		// phase timeout.
+		driver.RequireDeliverAlarm()
+
+		// Expect rebroadcast of only the DECIDE message.
+		driver.RequireDecide(baseChain, evidenceOfCommit)
+
+		// Deliver DECIDE to facilitate progress to decision.
+		driver.RequireDeliverMessage(&gpbft.GMessage{
+			Sender:        1,
+			Vote:          instance.NewDecide(0, baseChain),
+			Justification: evidenceOfCommit,
+		})
+		driver.RequireDecision(instance.ID(), baseChain)
 	})
 }
 

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -102,8 +102,9 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 	}
 	for i := 0; i < echoCount; i++ {
 		if msg.Sender != r.ID() {
-			_ = r.host.RequestBroadcast(mt)
-
+			if err := r.host.RequestBroadcast(mt); err != nil {
+				panic(err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Fix a bug where rebroadcast parameters are never reset within a round, because of the way by which "progress" was determined: The previous implementation stored last seen round/phase on broadcast and compared it to the current round to infer whether progress has been made. This approach would always result in no progress since on phase/round change
the broadcast state would update the references based on the last broadcast. Therefore the current round/phase always matched the last seen round/phase in broadcast state.

The changes here resolve the issue by explicitly resetting the rebroadcast params upon progress by explicitly resetting rebroadcast params on phase change. Based on a few retries this makes up the most readable code IMHO.

The changes also add a test that assert the right set of messages are broadcasted relative to phase and at only once enough alarms are triggered.

Part of #9 
