### PR TITLE
Explicitly set the `stringer` version in go-generate

### DIFF
--- a/certexchange/polling/poller.go
+++ b/certexchange/polling/poller.go
@@ -1,4 +1,4 @@
-//go:generate go run golang.org/x/tools/cmd/stringer -type=PollStatus
+//go:generate go run golang.org/x/tools/cmd/stringer@v0.22.0 -type=PollStatus
 package polling
 
 import (


### PR DESCRIPTION
Use explicit version for `stringer` generator to assure consistent output from `go generate ./...`.