### PR TITLE
Limit size of signatures to 96 bytes

### DIFF
--- a/gpbft/gen.go
+++ b/gpbft/gen.go
@@ -227,7 +227,7 @@ func (t *GMessage) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Signature ([]uint8) (slice)
-	if len(t.Signature) > 2097152 {
+	if len(t.Signature) > 96 {
 		return xerrors.Errorf("Byte array in field t.Signature was too long")
 	}
 
@@ -240,7 +240,7 @@ func (t *GMessage) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Ticket (gpbft.Ticket) (slice)
-	if len(t.Ticket) > 2097152 {
+	if len(t.Ticket) > 96 {
 		return xerrors.Errorf("Byte array in field t.Ticket was too long")
 	}
 
@@ -312,7 +312,7 @@ func (t *GMessage) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 96 {
 		return fmt.Errorf("t.Signature: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {
@@ -334,7 +334,7 @@ func (t *GMessage) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 96 {
 		return fmt.Errorf("t.Ticket: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {
@@ -675,7 +675,7 @@ func (t *Justification) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Signature ([]uint8) (slice)
-	if len(t.Signature) > 2097152 {
+	if len(t.Signature) > 96 {
 		return xerrors.Errorf("Byte array in field t.Signature was too long")
 	}
 
@@ -738,7 +738,7 @@ func (t *Justification) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 96 {
 		return fmt.Errorf("t.Signature: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -64,9 +64,9 @@ type GMessage struct {
 	// Vote is the payload that is signed by the signature
 	Vote Payload
 	// Signature by the sender's public key over Instance || Round || Step || Value.
-	Signature []byte
+	Signature []byte `cborgen:"maxlen=96"`
 	// VRF ticket for CONVERGE messages (otherwise empty byte array).
-	Ticket Ticket
+	Ticket Ticket `cborgen:"maxlen=96"`
 	// Justification for this message (some messages must be justified by a strong quorum of messages from some previous step).
 	Justification *Justification
 }
@@ -77,7 +77,7 @@ type Justification struct {
 	// Indexes in the base power table of the signers (bitset)
 	Signers bitfield.BitField
 	// BLS aggregate signature of signers
-	Signature []byte
+	Signature []byte `cborgen:"maxlen=96"`
 }
 
 type SupplementalData struct {


### PR DESCRIPTION
96 is the size of the compressed representation of BLS-381 G2 point, which is the scheme we use for signatures. It is the larger of two possibilities, with signatures on G1 being 48 bytes.