### PR TITLE
Import go-log directly (except in GPBFT) and remove Logging

### DIFF
--- a/certexchange/polling/common.go
+++ b/certexchange/polling/common.go
@@ -5,5 +5,5 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
-var log = logging.Logger("f3-certexchange")
+var log = logging.Logger("f3/certexchange")
 var clk clock.Clock = clock.New()

--- a/certexchange/polling/common.go
+++ b/certexchange/polling/common.go
@@ -2,6 +2,8 @@ package polling
 
 import (
 	"github.com/benbjohnson/clock"
+	logging "github.com/ipfs/go-log/v2"
 )
 
+var log = logging.Logger("f3-certexchange")
 var clk clock.Clock = clock.New()

--- a/certexchange/polling/common_test.go
+++ b/certexchange/polling/common_test.go
@@ -10,15 +10,11 @@ import (
 	"github.com/filecoin-project/go-f3/sim/signing"
 
 	"github.com/benbjohnson/clock"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/stretchr/testify/require"
 )
 
 // The network name used in tests.
 const TestNetworkName gpbft.NetworkName = "testnet"
-
-// The logger used in tests.
-var TestLog = logging.Logger("f3-testing")
 
 // The clock used in tests. Time doesn't pass in tests unless you add time to this clock.
 var MockClock = clock.NewMock()

--- a/certexchange/polling/poller_test.go
+++ b/certexchange/polling/poller_test.go
@@ -49,7 +49,6 @@ func TestPoller(t *testing.T) {
 		NetworkName: polling.TestNetworkName,
 		Host:        serverHost,
 		Store:       serverCs,
-		Log:         polling.TestLog,
 	}
 
 	require.NoError(t, server.Start())
@@ -62,7 +61,6 @@ func TestPoller(t *testing.T) {
 	client := certexchange.Client{
 		Host:        clientHost,
 		NetworkName: polling.TestNetworkName,
-		Log:         polling.TestLog,
 	}
 
 	poller, err := polling.NewPoller(ctx, &client, clientCs, backend)

--- a/certexchange/polling/subscriber.go
+++ b/certexchange/polling/subscriber.go
@@ -64,7 +64,7 @@ func (s *Subscriber) Start() error {
 		}()
 
 		if err := s.run(ctx); err != nil && ctx.Err() == nil {
-			s.Log.Errorf("polling certificate exchange subscriber exited early: %s", err)
+			log.Errorf("polling certificate exchange subscriber exited early: %s", err)
 		}
 	}()
 
@@ -115,7 +115,7 @@ func (s *Subscriber) run(ctx context.Context) error {
 			nextInterval := predictor.update(progress)
 			nextPollTime := pollTime.Add(nextInterval)
 			delay := max(clk.Until(nextPollTime), 0)
-			s.Log.Infof("predicted interval is %s (waiting %s)", nextInterval, delay)
+			log.Infof("predicted interval is %s (waiting %s)", nextInterval, delay)
 			timer.Reset(delay)
 		case <-ctx.Done():
 			return ctx.Err()
@@ -132,14 +132,14 @@ func (s *Subscriber) poll(ctx context.Context) (uint64, error) {
 
 	peers := s.peerTracker.suggestPeers()
 	start := s.poller.NextInstance
-	s.Log.Debugf("polling %d peers for instance %d", len(peers), s.poller.NextInstance)
+	log.Debugf("polling %d peers for instance %d", len(peers), s.poller.NextInstance)
 	for _, peer := range peers {
 		oldInstance := s.poller.NextInstance
 		res, err := s.poller.Poll(ctx, peer)
 		if err != nil {
 			return s.poller.NextInstance - start, err
 		}
-		s.Log.Debugf("polled %s for instance %d, got %+v", peer, s.poller.NextInstance, res)
+		log.Debugf("polled %s for instance %d, got %+v", peer, s.poller.NextInstance, res)
 		// If we manage to advance, all old "hits" are actually misses.
 		if oldInstance < s.poller.NextInstance {
 			misses = append(misses, hits...)

--- a/certexchange/polling/subscriber_test.go
+++ b/certexchange/polling/subscriber_test.go
@@ -45,7 +45,6 @@ func TestSubscriber(t *testing.T) {
 			NetworkName: polling.TestNetworkName,
 			Host:        h,
 			Store:       cs,
-			Log:         polling.TestLog,
 		}
 	}
 
@@ -63,7 +62,6 @@ func TestSubscriber(t *testing.T) {
 	client := certexchange.Client{
 		Host:        clientHost,
 		NetworkName: polling.TestNetworkName,
-		Log:         polling.TestLog,
 	}
 
 	subscriber := polling.Subscriber{

--- a/certexchange/protocol_test.go
+++ b/certexchange/protocol_test.go
@@ -11,14 +11,11 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	ds_sync "github.com/ipfs/go-datastore/sync"
-	logging "github.com/ipfs/go-log/v2"
 	mocknetwork "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 )
 
 const testNetworkName gpbft.NetworkName = "testnet"
-
-var log = logging.Logger("certexchange-test")
 
 func testPowerTable(entries int64) (gpbft.PowerEntries, gpbft.CID) {
 	powerTable := make(gpbft.PowerEntries, entries)
@@ -68,13 +65,11 @@ func TestClientServer(t *testing.T) {
 		NetworkName: testNetworkName,
 		Host:        h1,
 		Store:       cs,
-		Log:         log,
 	}
 
 	client := certexchange.Client{
 		Host:        h2,
 		NetworkName: testNetworkName,
-		Log:         log,
 	}
 
 	require.NoError(t, server.Start())

--- a/certexchange/server.go
+++ b/certexchange/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 )
 
-var log = logging.Logger("f3-certexchange")
+var log = logging.Logger("f3/certexchange")
 
 const maxResponseLen = 256
 

--- a/certexchange/server.go
+++ b/certexchange/server.go
@@ -8,12 +8,15 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/filecoin-project/go-f3"
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/gpbft"
+
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 )
+
+var log = logging.Logger("f3-certexchange")
 
 const maxResponseLen = 256
 
@@ -24,7 +27,6 @@ type Server struct {
 	NetworkName    gpbft.NetworkName
 	Host           host.Host
 	Store          *certstore.Store
-	Log            f3.Logger
 
 	cancel context.CancelFunc
 }
@@ -40,7 +42,7 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 	defer func() {
 		if perr := recover(); perr != nil {
 			_err = fmt.Errorf("panicked in server response: %v", perr)
-			s.Log.Errorf("%s\n%s", string(debug.Stack()))
+			log.Errorf("%s\n%s", string(debug.Stack()))
 		}
 	}()
 
@@ -56,7 +58,7 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 	// Request has no variable-length fields, so we don't need a limited reader.
 	var req Request
 	if err := req.UnmarshalCBOR(br); err != nil {
-		s.Log.Debugf("failed to read request from stream: %w", err)
+		log.Debugf("failed to read request from stream: %w", err)
 		return err
 	}
 
@@ -72,14 +74,14 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 	if resp.PendingInstance >= req.FirstInstance && req.IncludePowerTable {
 		pt, err := s.Store.GetPowerTable(ctx, req.FirstInstance)
 		if err != nil {
-			s.Log.Errorf("failed to load power table: %w", err)
+			log.Errorf("failed to load power table: %w", err)
 			return err
 		}
 		resp.PowerTable = pt
 	}
 
 	if err := resp.MarshalCBOR(bw); err != nil {
-		s.Log.Debugf("failed to write header to stream: %w", err)
+		log.Debugf("failed to write header to stream: %w", err)
 		return err
 	}
 
@@ -96,12 +98,12 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 		if err == nil || errors.Is(err, certstore.ErrCertNotFound) {
 			for i := range certs {
 				if err := certs[i].MarshalCBOR(bw); err != nil {
-					s.Log.Debugf("failed to write certificate to stream: %w", err)
+					log.Debugf("failed to write certificate to stream: %w", err)
 					return err
 				}
 			}
 		} else {
-			s.Log.Errorf("failed to load finality certificates: %w", err)
+			log.Errorf("failed to load finality certificates: %w", err)
 		}
 	}
 	return bw.Flush()

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -21,9 +21,9 @@ import (
 	"golang.org/x/xerrors"
 )
 
-const DiscoveryTag = "f3-standalone"
+var log = logging.Logger("f3-cli")
 
-var log = logging.Logger("f3")
+const DiscoveryTag = "f3-standalone"
 
 var runCmd = cli.Command{
 	Name:  "run",
@@ -115,8 +115,7 @@ var runCmd = cli.Command{
 
 		ec := ec.NewFakeEC(1, m.BootstrapEpoch, m.ECPeriod, initialPowerTable, true)
 
-		module, err := f3.New(ctx, mprovider, ds, h, ps,
-			signingBackend, ec, log, nil)
+		module, err := f3.New(ctx, mprovider, ds, h, ps, signingBackend, ec, nil)
 		if err != nil {
 			return xerrors.Errorf("creating module: %w", err)
 		}

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-var log = logging.Logger("f3-cli")
+var log = logging.Logger("f3/cli")
 
 const DiscoveryTag = "f3-standalone"
 

--- a/logging.go
+++ b/logging.go
@@ -6,7 +6,7 @@ import (
 )
 
 var log = logging.Logger("f3")
-var tracer gpbft.Tracer = (*gpbftTracer)(log)
+var tracer gpbft.Tracer = (*gpbftTracer)(logging.WithSkip(logging.Logger("gpbft"), 1))
 
 // Tracer used by GPBFT, backed by a Zap logger.
 type gpbftTracer logging.ZapEventLogger

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,17 @@
+package f3
+
+import (
+	"github.com/filecoin-project/go-f3/gpbft"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("f3")
+var tracer gpbft.Tracer = (*gpbftTracer)(log)
+
+// Tracer used by GPBFT, backed by a Zap logger.
+type gpbftTracer logging.ZapEventLogger
+
+// Log fulfills the gpbft.Tracer interface
+func (h *gpbftTracer) Log(fmt string, args ...any) {
+	(*logging.ZapEventLogger)(h).Debugf(fmt, args...)
+}

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -457,8 +457,7 @@ func (e *testEnv) newF3Instance(id int, manifestServer peer.ID) (*testNode, erro
 
 	e.signingBackend.Allow(int(id))
 
-	module, err := f3.New(e.testCtx, mprovider, ds, h, ps,
-		e.signingBackend, e.ec, log, nil)
+	module, err := f3.New(e.testCtx, mprovider, ds, h, ps, e.signingBackend, e.ec, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("creating module: %w", err)
 	}


### PR DESCRIPTION
It was causing circular import issues (which could have been fixed by moving it, I guess) but, more importantly, the abstraction really wasn't pulling its weight. We're keeping it out of GPBFT itself but our other packages already depend on things like go-datastore and go-libp2p, so depending on go-log doesn't really matter.