### PR TITLE
Don't make the SigningMarshaler customizable in F3

### DIFF
--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -115,7 +115,7 @@ var runCmd = cli.Command{
 
 		ec := ec.NewFakeEC(1, m.BootstrapEpoch, m.ECPeriod, initialPowerTable, true)
 
-		module, err := f3.New(ctx, mprovider, ds, h, ps, signingBackend, ec, nil)
+		module, err := f3.New(ctx, mprovider, ds, h, ps, signingBackend, ec)
 		if err != nil {
 			return xerrors.Errorf("creating module: %w", err)
 		}

--- a/f3.go
+++ b/f3.go
@@ -22,9 +22,8 @@ import (
 )
 
 type F3 struct {
-	verifier          gpbft.Verifier
-	signingMarshaller gpbft.SigningMarshaler
-	manifestProvider  manifest.ManifestProvider
+	verifier         gpbft.Verifier
+	manifestProvider manifest.ManifestProvider
 
 	busBroadcast broadcast.Channel[*gpbft.MessageBuilder]
 
@@ -47,25 +46,20 @@ type F3 struct {
 // The context is used for initialization not runtime.
 // signingMarshaller can be nil for default SigningMarshaler
 func New(_ctx context.Context, manifest manifest.ManifestProvider, ds datastore.Datastore, h host.Host,
-	ps *pubsub.PubSub, verif gpbft.Verifier, ec ec.Backend, signingMarshaller gpbft.SigningMarshaler) (*F3, error) {
+	ps *pubsub.PubSub, verif gpbft.Verifier, ec ec.Backend) (*F3, error) {
 	runningCtx, cancel := context.WithCancel(context.Background())
 	errgrp, runningCtx := errgroup.WithContext(runningCtx)
 
-	if signingMarshaller == nil {
-		signingMarshaller = gpbft.DefaultSigningMarshaller
-	}
-
 	return &F3{
-		verifier:          verif,
-		signingMarshaller: signingMarshaller,
-		manifestProvider:  manifest,
-		host:              h,
-		ds:                ds,
-		ec:                ec,
-		pubsub:            ps,
-		runningCtx:        runningCtx,
-		cancelCtx:         cancel,
-		errgrp:            errgrp,
+		verifier:         verif,
+		manifestProvider: manifest,
+		host:             h,
+		ds:               ds,
+		ec:               ec,
+		pubsub:           ps,
+		runningCtx:       runningCtx,
+		cancelCtx:        cancel,
+		errgrp:           errgrp,
 	}, nil
 }
 
@@ -265,8 +259,7 @@ func (m *F3) reconfigure(ctx context.Context, manifest *manifest.Manifest) error
 	m.cs = cs
 	m.manifest = manifest
 	m.runner, err = newRunner(
-		ctx, m.cs, runnerEc, m.pubsub,
-		m.signingMarshaller, m.verifier,
+		ctx, m.cs, runnerEc, m.pubsub, m.verifier,
 		m.busBroadcast.Publish, m.manifest,
 	)
 	if err != nil {

--- a/gpbft/message_builder.go
+++ b/gpbft/message_builder.go
@@ -184,15 +184,3 @@ func (st *SignatureBuilder) Build(payloadSignature []byte, vrf []byte) *GMessage
 		Justification: st.Justification,
 	}
 }
-
-type defaultSigningMarshaller struct{}
-
-var DefaultSigningMarshaller SigningMarshaler = defaultSigningMarshaller{}
-
-// MarshalPayloadForSigning marshals the given payload into the bytes that should be signed.
-// This should usually call `Payload.MarshalForSigning(NetworkName)` except when testing as
-// that method is slow (computes a merkle tree that's necessary for testing).
-// Implementations must be safe for concurrent use.
-func (defaultSigningMarshaller) MarshalPayloadForSigning(nn NetworkName, p *Payload) []byte {
-	return p.MarshalForSigning(nn)
-}

--- a/gpbft/message_builder_test.go
+++ b/gpbft/message_builder_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testSigningMarshaler struct{}
+
+var signingMarshaler SigningMarshaler = testSigningMarshaler{}
+
+func (testSigningMarshaler) MarshalPayloadForSigning(nn NetworkName, p *Payload) []byte {
+	return p.MarshalForSigning(nn)
+}
+
 func TestMessageBuilder(t *testing.T) {
 	pt := NewPowerTable()
 	err := pt.Add([]PowerEntry{
@@ -32,7 +40,7 @@ func TestMessageBuilder(t *testing.T) {
 	mt := NewMessageBuilder(pt)
 	mt.SetPayload(payload)
 	mt.SetNetworkName(nn)
-	mt.SetSigningMarshaler(DefaultSigningMarshaller)
+	mt.SetSigningMarshaler(signingMarshaler)
 
 	_, err = mt.PrepareSigningInputs(2)
 	require.Error(t, err, "unknown ID should return an error")
@@ -80,7 +88,7 @@ func TestMessageBuilderWithVRF(t *testing.T) {
 	mt := NewMessageBuilder(pt)
 	mt.SetPayload(payload)
 	mt.SetNetworkName(nn)
-	mt.SetSigningMarshaler(DefaultSigningMarshaller)
+	mt.SetSigningMarshaler(signingMarshaler)
 	mt.SetBeaconForTicket([]byte{0xbe, 0xac, 0x04})
 
 	st, err := mt.PrepareSigningInputs(0)

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -457,7 +457,7 @@ func (e *testEnv) newF3Instance(id int, manifestServer peer.ID) (*testNode, erro
 
 	e.signingBackend.Allow(int(id))
 
-	module, err := f3.New(e.testCtx, mprovider, ds, h, ps, e.signingBackend, e.ec, nil)
+	module, err := f3.New(e.testCtx, mprovider, ds, h, ps, e.signingBackend, e.ec)
 	if err != nil {
 		return nil, xerrors.Errorf("creating module: %w", err)
 	}


### PR DESCRIPTION
We use this internally for simulation testing where performance is
critical. The user should never change this.