### PR TITLE
Ignore errors when failing to set stream deadlines

### DIFF
--- a/certexchange/client.go
+++ b/certexchange/client.go
@@ -63,9 +63,8 @@ func (c *Client) Request(ctx context.Context, p peer.ID, req *Request) (_rh *Res
 	context.AfterFunc(ctx, func() { _ = stream.Reset() })
 
 	if deadline, ok := ctx.Deadline(); ok {
-		if err := stream.SetDeadline(deadline); err != nil {
-			return nil, nil, err
-		}
+		// Not all transports support deadlines.
+		_ = stream.SetDeadline(deadline)
 	}
 
 	br := &io.LimitedReader{R: bufio.NewReader(stream), N: 100}

--- a/certexchange/server.go
+++ b/certexchange/server.go
@@ -51,9 +51,8 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 	}()
 
 	if deadline, ok := ctx.Deadline(); ok {
-		if err := stream.SetDeadline(deadline); err != nil {
-			return err
-		}
+		// Not all transports support deadlines.
+		_ = stream.SetDeadline(deadline)
 	}
 
 	br := bufio.NewReader(stream)


### PR DESCRIPTION
1. We set the deadline on the context as well, so the stream deadline isn't actually critical.
2. The mock libp2p implementation doesn't support them.