### PR TITLE
Remove MessageBuilder locks

### DIFF
--- a/emulator/driver.go
+++ b/emulator/driver.go
@@ -71,8 +71,8 @@ func (d *Driver) prepareMessage(partialMessage *gpbft.GMessage) *gpbft.GMessage 
 	d.require.NotNil(instance)
 
 	mb := instance.NewMessageBuilder(partialMessage.Vote, partialMessage.Justification, withValidTicket)
-	mb.SetNetworkName(d.host.NetworkName())
-	mb.SetSigningMarshaler(d.host.adhocSigning)
+	mb.NetworkName = d.host.NetworkName()
+	mb.SigningMarshaller = d.host.adhocSigning
 	msg, err := mb.Build(context.Background(), d.host.adhocSigning, partialMessage.Sender)
 	d.require.NoError(err)
 	d.require.NotNil(msg)

--- a/emulator/host.go
+++ b/emulator/host.go
@@ -42,8 +42,6 @@ func (h *driverHost) maybeReceiveAlarm() bool {
 }
 
 func (h *driverHost) RequestBroadcast(mb *gpbft.MessageBuilder) error {
-	mb.SetNetworkName(h.NetworkName())
-	mb.SetSigningMarshaler(h)
 	msg, err := mb.Build(context.Background(), h, h.id)
 	if err != nil {
 		return err

--- a/emulator/instance.go
+++ b/emulator/instance.go
@@ -100,18 +100,17 @@ func (i *Instance) NewPayload(round uint64, step gpbft.Phase, value gpbft.ECChai
 }
 
 func (i *Instance) NewMessageBuilder(payload gpbft.Payload, justification *gpbft.Justification, withTicket bool) *gpbft.MessageBuilder {
-
 	payload.SupplementalData = i.supplementalData
 	payload.Instance = i.id
-	builder := gpbft.NewMessageBuilder(i.powerTable)
-	builder.SetPayload(payload)
-	if justification != nil {
-		builder.SetJustification(justification)
+	mb := &gpbft.MessageBuilder{
+		PowerTable:    i.powerTable,
+		Payload:       payload,
+		Justification: justification,
 	}
 	if withTicket {
-		builder.SetBeaconForTicket(i.beacon)
+		mb.BeaconForTicket = i.beacon
 	}
-	return builder
+	return mb
 }
 
 func (i *Instance) NewJustification(round uint64, step gpbft.Phase, vote gpbft.ECChain, from ...gpbft.ActorID) *gpbft.Justification {

--- a/gpbft/message_builder_test.go
+++ b/gpbft/message_builder_test.go
@@ -37,10 +37,12 @@ func TestMessageBuilder(t *testing.T) {
 	}
 	nn := NetworkName("test")
 
-	mt := NewMessageBuilder(pt)
-	mt.SetPayload(payload)
-	mt.SetNetworkName(nn)
-	mt.SetSigningMarshaler(signingMarshaler)
+	mt := &MessageBuilder{
+		NetworkName:       nn,
+		PowerTable:        pt,
+		Payload:           payload,
+		SigningMarshaller: signingMarshaler,
+	}
 
 	_, err = mt.PrepareSigningInputs(2)
 	require.Error(t, err, "unknown ID should return an error")
@@ -85,11 +87,13 @@ func TestMessageBuilderWithVRF(t *testing.T) {
 	}
 
 	nn := NetworkName("test")
-	mt := NewMessageBuilder(pt)
-	mt.SetPayload(payload)
-	mt.SetNetworkName(nn)
-	mt.SetSigningMarshaler(signingMarshaler)
-	mt.SetBeaconForTicket([]byte{0xbe, 0xac, 0x04})
+	mt := &MessageBuilder{
+		NetworkName:       nn,
+		PowerTable:        pt,
+		Payload:           payload,
+		SigningMarshaller: signingMarshaler,
+		BeaconForTicket:   []byte{0xbe, 0xac, 0x04},
+	}
 
 	st, err := mt.PrepareSigningInputs(0)
 	require.NoError(t, err)

--- a/host.go
+++ b/host.go
@@ -534,10 +534,7 @@ func (h *gpbftHost) NetworkName() gpbft.NetworkName {
 }
 
 // Sends a message to all other participants.
-// The message's sender must be one that the network interface can sign on behalf of.
 func (h *gpbftHost) RequestBroadcast(mb *gpbft.MessageBuilder) error {
-	mb.SetNetworkName(h.manifest.NetworkName)
-	mb.SetSigningMarshaler(h)
 	(h.broadcastCb)(mb)
 	return nil
 }

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -47,15 +47,6 @@ func (i *ImmediateDecide) StartInstanceAt(instance uint64, _when time.Time) erro
 	if err != nil {
 		panic(err)
 	}
-	// Immediately send a DECIDE message
-	mb := gpbft.NewMessageBuilder(powertable)
-	mb.SetPayload(gpbft.Payload{
-		Instance:         instance,
-		Round:            0,
-		Step:             gpbft.DECIDE_PHASE,
-		Value:            i.value,
-		SupplementalData: *supplementalData,
-	})
 	justificationPayload := gpbft.Payload{
 		Instance:         instance,
 		Round:            0,
@@ -76,11 +67,25 @@ func (i *ImmediateDecide) StartInstanceAt(instance uint64, _when time.Time) erro
 	if err != nil {
 		panic(err)
 	}
-	mb.SetJustification(&gpbft.Justification{
-		Vote:      justificationPayload,
-		Signers:   signers,
-		Signature: aggregatedSig,
-	})
+
+	// Immediately send a DECIDE message
+	mb := &gpbft.MessageBuilder{
+		NetworkName:       i.host.NetworkName(),
+		PowerTable:        powertable,
+		SigningMarshaller: i.host,
+		Payload: gpbft.Payload{
+			Instance:         instance,
+			Round:            0,
+			Step:             gpbft.DECIDE_PHASE,
+			Value:            i.value,
+			SupplementalData: *supplementalData,
+		},
+		Justification: &gpbft.Justification{
+			Vote:      justificationPayload,
+			Signers:   signers,
+			Signature: aggregatedSig,
+		},
+	}
 
 	if err := i.host.RequestSynchronousBroadcast(mb); err != nil {
 		panic(err)

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -94,11 +94,15 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 		SupplementalData: *supplementalData,
 		Value:            msg.Vote.Value,
 	}
-	mt := gpbft.NewMessageBuilderWithPowerTable(power)
-	mt.SetPayload(p)
-	mt.SetJustification(msg.Justification)
-	if len(msg.Ticket) != 0 {
-		mt.SetBeaconForTicket(beacon)
+	mt := &gpbft.MessageBuilder{
+		NetworkName:       r.host.NetworkName(),
+		PowerTable:        power,
+		Payload:           p,
+		Justification:     msg.Justification,
+		SigningMarshaller: r.host,
+	}
+	if len(msg.Ticket) > 0 {
+		mt.BeaconForTicket = beacon
 	}
 	for i := 0; i < echoCount; i++ {
 		if msg.Sender != r.ID() {

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -78,8 +78,12 @@ func (s *Spam) spamAtInstance(instance uint64) {
 			SupplementalData: *supplementalData,
 			Step:             gpbft.COMMIT_PHASE,
 		}
-		mt := gpbft.NewMessageBuilderWithPowerTable(power)
-		mt.SetPayload(p)
+		mt := &gpbft.MessageBuilder{
+			NetworkName:       s.host.NetworkName(),
+			PowerTable:        power,
+			Payload:           p,
+			SigningMarshaller: s.host,
+		}
 		if err := s.host.RequestBroadcast(mt); err != nil {
 			panic(err)
 		}

--- a/sim/adversary/withhold.go
+++ b/sim/adversary/withhold.go
@@ -176,9 +176,13 @@ func (w *WithholdCommit) sign(pubkey gpbft.PubKey, msg []byte) []byte {
 
 func (w *WithholdCommit) synchronousBroadcastRequester(powertable *gpbft.PowerTable) func(gpbft.Payload, *gpbft.Justification) {
 	return func(payload gpbft.Payload, justification *gpbft.Justification) {
-		mb := gpbft.NewMessageBuilder(powertable)
-		mb.SetPayload(payload)
-		mb.SetJustification(justification)
+		mb := &gpbft.MessageBuilder{
+			NetworkName:       w.host.NetworkName(),
+			PowerTable:        powertable,
+			Payload:           payload,
+			Justification:     justification,
+			SigningMarshaller: w.host,
+		}
 		if err := w.host.RequestSynchronousBroadcast(mb); err != nil {
 			panic(err)
 		}

--- a/sim/network.go
+++ b/sim/network.go
@@ -92,8 +92,6 @@ func (nf *networkFor) RequestSynchronousBroadcast(mb *gpbft.MessageBuilder) erro
 }
 
 func (nf *networkFor) requestBroadcast(mb *gpbft.MessageBuilder, sync bool) error {
-	mb.SetNetworkName(nf.networkName)
-	mb.SetSigningMarshaler(nf.Signer)
 	msg, err := mb.Build(context.Background(), nf.Signer, nf.ParticipantID)
 	if err != nil {
 		nf.Log("building message for: %d: %+v", nf.ParticipantID, err)


### PR DESCRIPTION
And, importantly, avoid mutating it after creating it. Especially given that we now store/rebroadcast these message builders, I'll feel a lot more comfortable if they're immutable.