### PR TITLE
Broadcast messages via a blocking channel

### DIFF
--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"os"
 
@@ -120,47 +121,46 @@ var runCmd = cli.Command{
 			return xerrors.Errorf("creating module: %w", err)
 		}
 
-		go runMessageSubscription(ctx, module, gpbft.ActorID(id), signingBackend)
+		errCh := make(chan error, 1)
+		go func() { errCh <- runMessageSubscription(ctx, module, gpbft.ActorID(id), signingBackend) }()
 
 		if err := module.Start(ctx); err != nil {
 			return nil
 		}
-		<-ctx.Done()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				log.Error(err)
+			}
+		case <-ctx.Done():
+		}
 		return module.Stop(context.Background())
 	},
 }
 
-func runMessageSubscription(ctx context.Context, module *f3.F3, actorID gpbft.ActorID, signer gpbft.Signer) {
+func runMessageSubscription(ctx context.Context, module *f3.F3, actorID gpbft.ActorID, signer gpbft.Signer) error {
 	for ctx.Err() == nil {
-
-		ch := make(chan *gpbft.MessageBuilder, 4)
-		module.SubscribeForMessagesToSign(ch)
-	inner:
-		for {
-			select {
-			case mb, ok := <-ch:
-				if !ok {
-					// the broadcast bus kicked us out
-					log.Infof("lost message bus subscription, retrying")
-					break inner
-				}
-				signatureBuilder, err := mb.PrepareSigningInputs(actorID)
-				if err != nil {
-					log.Errorf("preparing signing inputs: %+v", err)
-				}
-				// signatureBuilder can be sent over RPC
-				payloadSig, vrfSig, err := signatureBuilder.Sign(ctx, signer)
-				if err != nil {
-					log.Errorf("signing message: %+v", err)
-				}
-				// signatureBuilder and signatures can be returned back over RPC
-				module.Broadcast(ctx, signatureBuilder, payloadSig, vrfSig)
-			case <-ctx.Done():
-				return
+		select {
+		case mb, ok := <-module.MessagesToSign():
+			if !ok {
+				return nil
 			}
+			signatureBuilder, err := mb.PrepareSigningInputs(actorID)
+			if err != nil {
+				return fmt.Errorf("preparing signing inputs: %w", err)
+			}
+			// signatureBuilder can be sent over RPC
+			payloadSig, vrfSig, err := signatureBuilder.Sign(ctx, signer)
+			if err != nil {
+				return fmt.Errorf("signing message: %w", err)
+			}
+			// signatureBuilder and signatures can be returned back over RPC
+			module.Broadcast(ctx, signatureBuilder, payloadSig, vrfSig)
+		case <-ctx.Done():
+			return nil
 		}
-
 	}
+	return nil
 }
 
 type discoveryNotifee struct {

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"os"
 	"testing"
@@ -14,7 +15,6 @@ import (
 	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/filecoin-project/go-f3/sim/signing"
 	leveldb "github.com/ipfs/go-ds-leveldb"
-	logging "github.com/ipfs/go-log/v2"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -28,8 +28,6 @@ const (
 	ManifestSenderTimeout = 1 * time.Second
 	logLevel              = "info"
 )
-
-var log = logging.Logger("f3-testing")
 
 func TestSimpleF3(t *testing.T) {
 	env := newTestEnvironment(t, 2, false)
@@ -323,12 +321,17 @@ func (e *testEnv) waitForManifestChange(prev *manifest.Manifest, timeout time.Du
 	}, timeout, ManifestSenderTimeout)
 }
 
-func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) testEnv {
+func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) *testEnv {
 	ctx, cancel := context.WithCancel(context.Background())
 	grp, ctx := errgroup.WithContext(ctx)
-	env := testEnv{t: t, errgrp: grp, testCtx: ctx, net: mocknet.New()}
+	env := &testEnv{t: t, errgrp: grp, testCtx: ctx, net: mocknet.New()}
+
+	// Cleanup on exit.
 	env.t.Cleanup(func() {
 		cancel()
+		for _, n := range env.nodes {
+			require.NoError(env.t, n.f3.Stop(context.Background()))
+		}
 		require.NoError(env.t, env.errgrp.Wait())
 	})
 
@@ -360,6 +363,7 @@ func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) testEnv {
 	for i := 0; i < n; i++ {
 		env.initNode(i, manifestServer)
 	}
+
 	return env
 }
 
@@ -439,9 +443,6 @@ func (e *testEnv) resumeNode(i int) {
 func (e *testEnv) startNode(i int) {
 	n := e.nodes[i]
 	require.NoError(e.t, n.f3.Start(e.testCtx))
-	e.t.Cleanup(func() {
-		require.NoError(e.t, n.f3.Stop(context.Background()))
-	})
 }
 
 func (e *testEnv) connectAll() {
@@ -495,11 +496,6 @@ func (e *testEnv) newF3Instance(id int, manifestServer peer.ID) (*testNode, erro
 		return nil, xerrors.Errorf("creating temp dir: %w", err)
 	}
 
-	err = logging.SetLogLevel("f3-testing", logLevel)
-	if err != nil {
-		return nil, xerrors.Errorf("setting log level: %w", err)
-	}
-
 	ds, err := leveldb.NewDatastore(tmpdir, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("creating a datastore: %w", err)
@@ -530,26 +526,20 @@ func (e *testEnv) newF3Instance(id int, manifestServer peer.ID) (*testNode, erro
 // TODO: This code is copy-pasta from cmd/f3/run.go, consider taking it out into a shared testing lib.
 // We could do the same to the F3 test instantiation
 func runMessageSubscription(ctx context.Context, module *f3.F3, actorID gpbft.ActorID, signer gpbft.Signer) error {
-	ch := make(chan *gpbft.MessageBuilder, 4)
-	module.SubscribeForMessagesToSign(ch)
 	for ctx.Err() == nil {
 		select {
-		case mb, ok := <-ch:
+		case mb, ok := <-module.MessagesToSign():
 			if !ok {
-				// the broadcast bus kicked us out
-				log.Infof("lost message bus subscription, retrying")
-				ch = make(chan *gpbft.MessageBuilder, 4)
-				module.SubscribeForMessagesToSign(ch)
-				continue
+				return nil
 			}
 			signatureBuilder, err := mb.PrepareSigningInputs(actorID)
 			if err != nil {
-				return xerrors.Errorf("preparing signing inputs: %w", err)
+				return fmt.Errorf("preparing signing inputs: %w", err)
 			}
 			// signatureBuilder can be sent over RPC
 			payloadSig, vrfSig, err := signatureBuilder.Sign(ctx, signer)
 			if err != nil {
-				return xerrors.Errorf("signing message: %w", err)
+				return fmt.Errorf("signing message: %w", err)
 			}
 			// signatureBuilder and signatures can be returned back over RPC
 			module.Broadcast(ctx, signatureBuilder, payloadSig, vrfSig)


### PR DESCRIPTION
Otherwise rebroadcast will end up dropping the last and most important messages when the message bus blocks.

fixes #443