### PR TITLE
ci: fix coverage ignore

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,6 @@ ignore:
   - "gen"
   - "test"
   - "sim"
+  - "cmd"
   - "**/*_test.go"
-  - "**/gen.go"
+  - "**/cbor_gen.go"


### PR DESCRIPTION
1. Ignore generated cbor-gen files.
2. Ignore the command itselt (not going to be covered by unit tests).