### PR TITLE
Improve test parallelism

### DIFF
--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -31,6 +31,8 @@ func testPowerTable(entries int64) (gpbft.PowerEntries, gpbft.CID) {
 }
 
 func TestNewCertStore(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -40,6 +42,8 @@ func TestNewCertStore(t *testing.T) {
 }
 
 func TestLatest(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -52,6 +56,8 @@ func TestLatest(t *testing.T) {
 }
 
 func TestPut(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -81,6 +87,8 @@ func TestPut(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -103,6 +111,8 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetRange(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -126,6 +136,8 @@ func TestGetRange(t *testing.T) {
 }
 
 func TestDeleteAll(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -165,6 +177,8 @@ func TestDeleteAll(t *testing.T) {
 }
 
 func TestSubscribeForNewCerts(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -191,6 +205,8 @@ func TestSubscribeForNewCerts(t *testing.T) {
 }
 
 func TestLatestAfterPut(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -217,6 +233,8 @@ func TestLatestAfterPut(t *testing.T) {
 }
 
 func TestPutSequential(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -237,6 +255,8 @@ func TestPutSequential(t *testing.T) {
 }
 
 func TestPersistency(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -264,6 +284,8 @@ func TestPersistency(t *testing.T) {
 }
 
 func TestClear(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -300,6 +322,8 @@ func TestClear(t *testing.T) {
 }
 
 func TestCreateOpen(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 
@@ -333,6 +357,7 @@ func TestCreateOpen(t *testing.T) {
 }
 
 func TestPowerNoData(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 	pt, _ := testPowerTable(20)
@@ -352,6 +377,7 @@ func TestPowerNoData(t *testing.T) {
 }
 
 func TestPowerEmptyPowerTable(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
 	pt, _ := testPowerTable(5)
@@ -380,10 +406,13 @@ func TestPowerEmptyPowerTable(t *testing.T) {
 }
 
 func TestPower(t *testing.T) {
+	t.Parallel()
 	t.Run("Offset", func(t *testing.T) {
+		t.Parallel()
 		testPowerInner(t, 2)
 	})
 	t.Run("NoOffset", func(t *testing.T) {
+		t.Parallel()
 		testPowerInner(t, 0)
 	})
 }

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -10,7 +10,10 @@ import (
 
 func TestHashTree(t *testing.T) {
 	for i := 1; i < 256; i++ {
+		i := i
 		t.Run(fmt.Sprintf("Length/%d", i), func(t *testing.T) {
+			t.Parallel()
+
 			test := make([][]byte, i)
 			for j := range test {
 				test[j] = []byte{byte(j)}

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -33,6 +33,8 @@ const (
 )
 
 func TestSimpleF3(t *testing.T) {
+	t.Parallel()
+
 	env := newTestEnvironment(t, 2, false)
 
 	env.connectAll()
@@ -41,6 +43,8 @@ func TestSimpleF3(t *testing.T) {
 }
 
 func TestPauseResumeCatchup(t *testing.T) {
+	t.Parallel()
+
 	env := newTestEnvironment(t, 3, false)
 
 	env.connectAll()
@@ -83,6 +87,8 @@ func TestPauseResumeCatchup(t *testing.T) {
 }
 
 func TestFailRecover(t *testing.T) {
+	t.Parallel()
+
 	env := newTestEnvironment(t, 2, false)
 
 	// Make it possible to fail a single write for node 0.
@@ -114,6 +120,8 @@ func TestFailRecover(t *testing.T) {
 }
 
 func TestDynamicManifest_WithoutChanges(t *testing.T) {
+	t.Parallel()
+
 	env := newTestEnvironment(t, 2, true)
 
 	env.connectAll()
@@ -127,6 +135,8 @@ func TestDynamicManifest_WithoutChanges(t *testing.T) {
 }
 
 func TestDynamicManifest_WithRebootstrap(t *testing.T) {
+	t.Parallel()
+
 	env := newTestEnvironment(t, 2, true)
 
 	env.connectAll()
@@ -157,6 +167,8 @@ func TestDynamicManifest_WithRebootstrap(t *testing.T) {
 }
 
 func TestDynamicManifest_WithPauseAndRebootstrap(t *testing.T) {
+	t.Parallel()
+
 	env := newTestEnvironment(t, 2, true)
 
 	env.connectAll()

--- a/test/signing_suite_test.go
+++ b/test/signing_suite_test.go
@@ -27,6 +27,7 @@ func TestBLSSigning(t *testing.T) {
 		blsSuit   = bls12381.NewBLS12381Suite()
 		blsSchema = bdn.NewSchemeOnG2(blsSuit)
 	)
+	t.Parallel()
 	suite.Run(t, NewSigningSuite(func(t *testing.T) (gpbft.PubKey, gpbft.Signer) {
 		privKey, pubKey := blsSchema.NewKeyPair(blsSuit.RandomStream())
 		pubKeyB, err := pubKey.MarshalBinary()
@@ -36,6 +37,7 @@ func TestBLSSigning(t *testing.T) {
 }
 
 func TestFakeSigning(t *testing.T) {
+	t.Parallel()
 	var fakeSigning = signing.NewFakeBackend()
 	suite.Run(t, NewSigningSuite(func(t *testing.T) (gpbft.PubKey, gpbft.Signer) {
 		pubKey, _ := fakeSigning.GenerateKey()

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestWitholdCommitAdversary(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		gst  time.Duration


### PR DESCRIPTION
The main slowdown is due to the main "F3" tests, but we might as well run tests in parallel wherever possible. I excluded the certificate exchange tests as parallelizing them actually slowed everything down a bit.
