### PR TITLE
Transition from xerrors to errors and fmt

### DIFF
--- a/blssig/aggregation.go
+++ b/blssig/aggregation.go
@@ -7,23 +7,22 @@ import (
 
 	"github.com/drand/kyber"
 	"github.com/drand/kyber/sign"
-	"golang.org/x/xerrors"
 )
 
 func (v Verifier) Aggregate(pubkeys []gpbft.PubKey, signatures [][]byte) ([]byte, error) {
 	if len(pubkeys) != len(signatures) {
-		return nil, xerrors.Errorf("lengths of pubkeys and sigs does not match %d != %d",
+		return nil, fmt.Errorf("lengths of pubkeys and sigs does not match %d != %d",
 			len(pubkeys), len(signatures))
 	}
 
 	mask, err := v.pubkeysToMask(pubkeys)
 	if err != nil {
-		return nil, xerrors.Errorf("converting public keys to mask: %w", err)
+		return nil, fmt.Errorf("converting public keys to mask: %w", err)
 	}
 
 	aggSigPoint, err := v.scheme.AggregateSignatures(signatures, mask)
 	if err != nil {
-		return nil, xerrors.Errorf("computing aggregate signature: %w", err)
+		return nil, fmt.Errorf("computing aggregate signature: %w", err)
 	}
 	aggSig, err := aggSigPoint.MarshalBinary()
 	if err != nil {
@@ -36,12 +35,12 @@ func (v Verifier) Aggregate(pubkeys []gpbft.PubKey, signatures [][]byte) ([]byte
 func (v Verifier) VerifyAggregate(msg []byte, signature []byte, pubkeys []gpbft.PubKey) error {
 	mask, err := v.pubkeysToMask(pubkeys)
 	if err != nil {
-		return xerrors.Errorf("converting public keys to mask: %w", err)
+		return fmt.Errorf("converting public keys to mask: %w", err)
 	}
 
 	aggPubKey, err := v.scheme.AggregatePublicKeys(mask)
 	if err != nil {
-		return xerrors.Errorf("aggregating public keys: %w", err)
+		return fmt.Errorf("aggregating public keys: %w", err)
 	}
 
 	return v.scheme.Verify(aggPubKey, msg, signature)
@@ -53,10 +52,10 @@ func (v Verifier) pubkeysToMask(pubkeys []gpbft.PubKey) (*sign.Mask, error) {
 		point := v.keyGroup.Point()
 		err := point.UnmarshalBinary(p)
 		if err != nil {
-			return nil, xerrors.Errorf("unarshalling pubkey at index %d: %w", i, err)
+			return nil, fmt.Errorf("unarshalling pubkey at index %d: %w", i, err)
 		}
 		if point.Equal(v.keyGroup.Point().Null()) {
-			return nil, xerrors.Errorf("the public key at %d is a null point", i)
+			return nil, fmt.Errorf("the public key at %d is a null point", i)
 		}
 
 		kPubkeys = append(kPubkeys, point)
@@ -64,12 +63,12 @@ func (v Verifier) pubkeysToMask(pubkeys []gpbft.PubKey) (*sign.Mask, error) {
 
 	mask, err := sign.NewMask(v.suite, kPubkeys, nil)
 	if err != nil {
-		return nil, xerrors.Errorf("creating key mask: %w", err)
+		return nil, fmt.Errorf("creating key mask: %w", err)
 	}
 	for i := range kPubkeys {
 		err := mask.SetBit(i, true)
 		if err != nil {
-			return nil, xerrors.Errorf("setting mask bit %d: %w", i, err)
+			return nil, fmt.Errorf("setting mask bit %d: %w", i, err)
 		}
 	}
 	return mask, nil

--- a/blssig/verifier.go
+++ b/blssig/verifier.go
@@ -1,12 +1,13 @@
 package blssig
 
 import (
+	"fmt"
+
 	"github.com/drand/kyber"
 	bls12381 "github.com/drand/kyber-bls12381"
 	"github.com/drand/kyber/pairing"
 	"github.com/drand/kyber/sign/bdn"
 	"github.com/filecoin-project/go-f3/gpbft"
-	"golang.org/x/xerrors"
 )
 
 type Verifier struct {
@@ -28,10 +29,10 @@ func (v Verifier) Verify(pubKey gpbft.PubKey, msg, sig []byte) error {
 	pubKeyPoint := v.keyGroup.Point()
 	err := pubKeyPoint.UnmarshalBinary(pubKey)
 	if err != nil {
-		return xerrors.Errorf("unarshalling public key: %w", err)
+		return fmt.Errorf("unarshalling public key: %w", err)
 	}
 	if pubKeyPoint.Equal(v.keyGroup.Point().Null()) {
-		return xerrors.Errorf("the public key is a null point")
+		return fmt.Errorf("the public key is a null point")
 	}
 
 	return v.scheme.Verify(pubKeyPoint, msg, sig)

--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	"github.com/ipfs/go-datastore/query"
-	"golang.org/x/xerrors"
 )
 
 var ErrCertNotFound = errors.New("certificate not found")
@@ -48,19 +47,19 @@ func open(ctx context.Context, ds datastore.Datastore) (*Store, error) {
 	}
 	err := maybeContinueDelete(ctx, ds)
 	if err != nil {
-		return nil, xerrors.Errorf("continuing deletion: %w", err)
+		return nil, fmt.Errorf("continuing deletion: %w", err)
 	}
 
 	latestInstance, err := cs.readInstanceNumber(ctx, certStoreLatestKey)
 	if errors.Is(err, datastore.ErrNotFound) {
 		return cs, nil
 	} else if err != nil {
-		return nil, xerrors.Errorf("determining latest cert: %w", err)
+		return nil, fmt.Errorf("determining latest cert: %w", err)
 	}
 
 	latestCert, err := cs.Get(ctx, latestInstance)
 	if err != nil {
-		return nil, xerrors.Errorf("loading latest cert: %w", err)
+		return nil, fmt.Errorf("loading latest cert: %w", err)
 	}
 
 	cs.busCerts.Publish(latestCert)
@@ -75,7 +74,7 @@ func open(ctx context.Context, ds datastore.Datastore) (*Store, error) {
 // The passed Datastore has to be thread safe.
 func OpenOrCreateStore(ctx context.Context, ds datastore.Datastore, firstInstance uint64, initialPowerTable gpbft.PowerEntries) (*Store, error) {
 	if len(initialPowerTable) == 0 {
-		return nil, xerrors.New("cannot construct certificate store with an empty initial power table")
+		return nil, errors.New("cannot construct certificate store with an empty initial power table")
 	}
 	cs, err := open(ctx, ds)
 	if err != nil {
@@ -84,34 +83,34 @@ func OpenOrCreateStore(ctx context.Context, ds datastore.Datastore, firstInstanc
 	dbFirstInstance, err := cs.readInstanceNumber(ctx, certStoreFirstKey)
 	if err == nil {
 		if firstInstance != dbFirstInstance {
-			return nil, xerrors.Errorf("certificate store re-initialized with a different initial instance %d != %d", dbFirstInstance, firstInstance)
+			return nil, fmt.Errorf("certificate store re-initialized with a different initial instance %d != %d", dbFirstInstance, firstInstance)
 		}
 		var buf bytes.Buffer
 		if err := initialPowerTable.MarshalCBOR(&buf); err != nil {
-			return nil, xerrors.Errorf("failed to martial initial power table: %w", err)
+			return nil, fmt.Errorf("failed to martial initial power table: %w", err)
 		}
 		pb, err := cs.ds.Get(ctx, cs.keyForPowerTable(firstInstance))
 		if err != nil {
-			return nil, xerrors.Errorf("failed to load initial power table: %w", err)
+			return nil, fmt.Errorf("failed to load initial power table: %w", err)
 		}
 		if !bytes.Equal(buf.Bytes(), pb) {
 			return nil, errors.New("certificate store re-initialized with the wrong power table")
 		}
 	} else if errors.Is(err, datastore.ErrNotFound) {
 		if err := cs.putPowerTable(ctx, firstInstance, initialPowerTable); err != nil {
-			return nil, xerrors.Errorf("while storing the initial power table: %w", err)
+			return nil, fmt.Errorf("while storing the initial power table: %w", err)
 		}
 		if err := cs.writeInstanceNumber(ctx, certStoreFirstKey, firstInstance); err != nil {
-			return nil, xerrors.Errorf("while recording the first instance: %w", err)
+			return nil, fmt.Errorf("while recording the first instance: %w", err)
 		}
 	} else {
-		return nil, xerrors.Errorf("failed to read initial instance number: %w", err)
+		return nil, fmt.Errorf("failed to read initial instance number: %w", err)
 	}
 	cs.firstInstance = firstInstance
 	if latest := cs.Latest(); latest != nil {
 		cs.latestPowerTable, err = cs.GetPowerTable(ctx, latest.GPBFTInstance+1)
 		if err != nil {
-			return nil, xerrors.Errorf("failed to load latest power table: %w", err)
+			return nil, fmt.Errorf("failed to load latest power table: %w", err)
 		}
 	} else {
 		cs.latestPowerTable = initialPowerTable
@@ -124,7 +123,7 @@ func OpenOrCreateStore(ctx context.Context, ds datastore.Datastore, firstInstanc
 // The passed Datastore has to be thread safe.
 func CreateStore(ctx context.Context, ds datastore.Datastore, firstInstance uint64, initialPowerTable gpbft.PowerEntries) (*Store, error) {
 	if len(initialPowerTable) == 0 {
-		return nil, xerrors.New("cannot construct certificate store with an empty initial power table")
+		return nil, errors.New("cannot construct certificate store with an empty initial power table")
 	}
 	cs, err := open(ctx, ds)
 	if err != nil {
@@ -134,10 +133,10 @@ func CreateStore(ctx context.Context, ds datastore.Datastore, firstInstance uint
 		return nil, errors.New("certificate store already initialized")
 	}
 	if err := cs.putPowerTable(ctx, firstInstance, initialPowerTable); err != nil {
-		return nil, xerrors.Errorf("while storing the initial power table: %w", err)
+		return nil, fmt.Errorf("while storing the initial power table: %w", err)
 	}
 	if err := cs.writeInstanceNumber(ctx, certStoreFirstKey, firstInstance); err != nil {
-		return nil, xerrors.Errorf("while recording the first instance: %w", err)
+		return nil, fmt.Errorf("while recording the first instance: %w", err)
 	}
 	cs.firstInstance = firstInstance
 	cs.latestPowerTable = initialPowerTable
@@ -158,7 +157,7 @@ func OpenStore(ctx context.Context, ds datastore.Datastore) (*Store, error) {
 		return nil, ErrNotInitialized
 	}
 	if err != nil {
-		return nil, xerrors.Errorf("getting first instance: %w", err)
+		return nil, fmt.Errorf("getting first instance: %w", err)
 	}
 	latestPowerTable := cs.firstInstance
 	if latest := cs.Latest(); latest != nil {
@@ -166,7 +165,7 @@ func OpenStore(ctx context.Context, ds datastore.Datastore) (*Store, error) {
 	}
 	cs.latestPowerTable, err = cs.GetPowerTable(ctx, latestPowerTable)
 	if err != nil {
-		return nil, xerrors.Errorf("getting latest power table: %w", err)
+		return nil, fmt.Errorf("getting latest power table: %w", err)
 	}
 	return cs, nil
 }
@@ -175,10 +174,10 @@ func OpenStore(ctx context.Context, ds datastore.Datastore) (*Store, error) {
 func (cs *Store) readInstanceNumber(ctx context.Context, key datastore.Key) (uint64, error) {
 	b, err := cs.ds.Get(ctx, key)
 	if err != nil {
-		return 0, xerrors.Errorf("failed to read instance number at %q: %w", key, err)
+		return 0, fmt.Errorf("failed to read instance number at %q: %w", key, err)
 	}
 	if len(b) != 8 {
-		return 0, xerrors.Errorf("unexpected instance number len %d != 8 at %q", len(b), key)
+		return 0, fmt.Errorf("unexpected instance number len %d != 8 at %q", len(b), key)
 	}
 	return binary.BigEndian.Uint64(b), nil
 }
@@ -187,7 +186,7 @@ func (cs *Store) readInstanceNumber(ctx context.Context, key datastore.Key) (uin
 func (cs *Store) writeInstanceNumber(ctx context.Context, key datastore.Key, value uint64) error {
 	err := cs.ds.Put(ctx, key, binary.BigEndian.AppendUint64(nil, value))
 	if err != nil {
-		return xerrors.Errorf("failed to write instance number at %q: %w", key, err)
+		return fmt.Errorf("failed to write instance number at %q: %w", key, err)
 	}
 	return nil
 }
@@ -203,15 +202,15 @@ func (cs *Store) Get(ctx context.Context, instance uint64) (*certs.FinalityCerti
 	b, err := cs.ds.Get(ctx, cs.keyForCert(instance))
 
 	if errors.Is(err, datastore.ErrNotFound) {
-		return nil, xerrors.Errorf("cert at %d: %w", instance, ErrCertNotFound)
+		return nil, fmt.Errorf("cert at %d: %w", instance, ErrCertNotFound)
 	}
 	if err != nil {
-		return nil, xerrors.Errorf("accessing cert in datastore: %w", err)
+		return nil, fmt.Errorf("accessing cert in datastore: %w", err)
 	}
 
 	var c certs.FinalityCertificate
 	if err := c.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
-		return nil, xerrors.Errorf("unmarshalling cert: %w", err)
+		return nil, fmt.Errorf("unmarshalling cert: %w", err)
 	}
 	return &c, err
 }
@@ -222,10 +221,10 @@ func (cs *Store) Get(ctx context.Context, instance uint64) (*certs.FinalityCerti
 // If it encounters missing cert, it returns a wrapped ErrCertNotFound and the available certs.
 func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]certs.FinalityCertificate, error) {
 	if start > end {
-		return nil, xerrors.Errorf("start is larger than end: %d > %d", start, end)
+		return nil, fmt.Errorf("start is larger than end: %d > %d", start, end)
 	}
 	if end-start >= math.MaxInt {
-		return nil, xerrors.Errorf("range %d to %d is too large", start, end)
+		return nil, fmt.Errorf("range %d to %d is too large", start, end)
 	}
 
 	bCerts := make([][]byte, 0, end-start+1)
@@ -236,7 +235,7 @@ func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]cert
 			break
 		}
 		if err != nil {
-			return nil, xerrors.Errorf("accessing cert at %d for range request: %w", i, err)
+			return nil, fmt.Errorf("accessing cert at %d for range request: %w", i, err)
 		}
 
 		bCerts = append(bCerts, b)
@@ -246,12 +245,12 @@ func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]cert
 	for j, bCert := range bCerts {
 		err := certs[j].UnmarshalCBOR(bytes.NewReader(bCert))
 		if err != nil {
-			return nil, xerrors.Errorf("unmarshalling a cert at j=%d, instance %d: %w", j, start+uint64(j), err)
+			return nil, fmt.Errorf("unmarshalling a cert at j=%d, instance %d: %w", j, start+uint64(j), err)
 		}
 	}
 
 	if len(certs) < cap(bCerts) {
-		return certs, xerrors.Errorf("cert at %d: %w", start+uint64(len(bCerts)), ErrCertNotFound)
+		return certs, fmt.Errorf("cert at %d: %w", start+uint64(len(bCerts)), ErrCertNotFound)
 	}
 	return certs, nil
 }
@@ -259,9 +258,9 @@ func (cs *Store) GetRange(ctx context.Context, start uint64, end uint64) ([]cert
 func (cs *Store) readPowerTable(ctx context.Context, instance uint64) (gpbft.PowerEntries, error) {
 	var powerTable gpbft.PowerEntries
 	if b, err := cs.ds.Get(ctx, cs.keyForPowerTable(instance)); err != nil {
-		return nil, xerrors.Errorf("failed to load power table at instance %d: %w", instance, err)
+		return nil, fmt.Errorf("failed to load power table at instance %d: %w", instance, err)
 	} else if err := powerTable.UnmarshalCBOR(bytes.NewReader(b)); err != nil {
-		return nil, xerrors.Errorf("failed to unmarshal power table at instance %d: %w", instance, err)
+		return nil, fmt.Errorf("failed to unmarshal power table at instance %d: %w", instance, err)
 	}
 	return powerTable, nil
 }
@@ -270,10 +269,10 @@ func (cs *Store) readPowerTable(ctx context.Context, instance uint64) (gpbft.Pow
 func (cs *Store) putPowerTable(ctx context.Context, instance uint64, powerTable gpbft.PowerEntries) error {
 	var buf bytes.Buffer
 	if err := powerTable.MarshalCBOR(&buf); err != nil {
-		return xerrors.Errorf("marshalling power table instance %d: %w", instance, err)
+		return fmt.Errorf("marshalling power table instance %d: %w", instance, err)
 	}
 	if err := cs.ds.Put(ctx, cs.keyForPowerTable(instance), buf.Bytes()); err != nil {
-		return xerrors.Errorf("putting power table instance %d: %w", instance, err)
+		return fmt.Errorf("putting power table instance %d: %w", instance, err)
 	}
 	return nil
 }
@@ -298,7 +297,7 @@ func (cs *Store) GetPowerTable(ctx context.Context, instance uint64) (gpbft.Powe
 
 	powerTable, err := cs.readPowerTable(ctx, startInstance)
 	if err != nil {
-		return nil, xerrors.Errorf("failed fo find expected power table for instance %d: %w", startInstance, err)
+		return nil, fmt.Errorf("failed fo find expected power table for instance %d: %w", startInstance, err)
 	}
 	if startInstance == instance {
 		return powerTable, nil
@@ -316,7 +315,7 @@ func (cs *Store) GetPowerTable(ctx context.Context, instance uint64) (gpbft.Powe
 	}
 	powerTable, err = certs.ApplyPowerTableDiffs(powerTable, deltas...)
 	if err != nil {
-		return nil, xerrors.Errorf("applying power deltas: %w", err)
+		return nil, fmt.Errorf("applying power deltas: %w", err)
 	}
 	return powerTable, err
 }
@@ -336,7 +335,7 @@ func (*Store) keyForPowerTable(i uint64) datastore.Key {
 // 2. More than one instance after the last certificate stored.
 func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error {
 	if cert.GPBFTInstance < cs.firstInstance {
-		return xerrors.Errorf("certificate store only stores certificates on or after instance %d", cs.firstInstance)
+		return fmt.Errorf("certificate store only stores certificates on or after instance %d", cs.firstInstance)
 	}
 
 	// Take a lock to ensure ordering.
@@ -348,7 +347,7 @@ func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error
 		nextCert = latestCert.GPBFTInstance + 1
 	}
 	if cert.GPBFTInstance > nextCert {
-		return xerrors.Errorf("attempted to add cert at %d, expected %d", cert.GPBFTInstance, nextCert)
+		return fmt.Errorf("attempted to add cert at %d, expected %d", cert.GPBFTInstance, nextCert)
 	}
 	if cert.GPBFTInstance < nextCert {
 		return nil
@@ -362,7 +361,7 @@ func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error
 		var err error
 		newPowerTable, err = certs.ApplyPowerTableDiffs(cs.latestPowerTable, cert.PowerTableDelta)
 		if err != nil {
-			return xerrors.Errorf("failed to apply power table delta for instance %d: %w", cert.GPBFTInstance, err)
+			return fmt.Errorf("failed to apply power table delta for instance %d: %w", cert.GPBFTInstance, err)
 		}
 	}
 
@@ -372,22 +371,22 @@ func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error
 	if ptCid, err := certs.MakePowerTableCID(newPowerTable); err != nil {
 		return err
 	} else if !bytes.Equal(ptCid, cert.SupplementalData.PowerTable) {
-		return xerrors.Errorf("new power table differs from expected power table")
+		return fmt.Errorf("new power table differs from expected power table")
 	}
 
 	// Double check that we're not killing the network.
 	if len(newPowerTable) == 0 {
-		return xerrors.Errorf("finality certificate for instance %d would empty the power table", cert.GPBFTInstance)
+		return fmt.Errorf("finality certificate for instance %d would empty the power table", cert.GPBFTInstance)
 	}
 
 	// Write the cert/power table.
 	var buf bytes.Buffer
 	if err := cert.MarshalCBOR(&buf); err != nil {
-		return xerrors.Errorf("marshalling cert instance %d: %w", cert.GPBFTInstance, err)
+		return fmt.Errorf("marshalling cert instance %d: %w", cert.GPBFTInstance, err)
 	}
 
 	if err := cs.ds.Put(ctx, cs.keyForCert(cert.GPBFTInstance), buf.Bytes()); err != nil {
-		return xerrors.Errorf("putting the cert: %w", err)
+		return fmt.Errorf("putting the cert: %w", err)
 	}
 
 	if cert.GPBFTInstance%cs.powerTableFrequency == 0 {
@@ -398,7 +397,7 @@ func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error
 
 	// Finally, advance the latest instance pointer (always do this last) and publish.
 	if err := cs.writeInstanceNumber(ctx, certStoreLatestKey, cert.GPBFTInstance); err != nil {
-		return xerrors.Errorf("putting recording the latest GPBFT instance: %w", err)
+		return fmt.Errorf("putting recording the latest GPBFT instance: %w", err)
 	}
 
 	cs.latestPowerTable = newPowerTable
@@ -421,7 +420,7 @@ var tombstoneKey = datastore.NewKey("/tombstone")
 func maybeContinueDelete(ctx context.Context, ds datastore.Datastore) error {
 	ok, err := ds.Has(ctx, tombstoneKey)
 	if err != nil {
-		return xerrors.Errorf("checking tombstoneKey: %w", err)
+		return fmt.Errorf("checking tombstoneKey: %w", err)
 	}
 	if !ok {
 		// no tombstone, exit
@@ -430,7 +429,7 @@ func maybeContinueDelete(ctx context.Context, ds datastore.Datastore) error {
 
 	qr, err := ds.Query(ctx, query.Query{KeysOnly: true})
 	if err != nil {
-		return xerrors.Errorf("starting a query for certs: %w", err)
+		return fmt.Errorf("starting a query for certs: %w", err)
 	}
 	for r := range qr.Next() {
 		key := datastore.NewKey(r.Key)
@@ -439,12 +438,12 @@ func maybeContinueDelete(ctx context.Context, ds datastore.Datastore) error {
 		}
 		err := ds.Delete(ctx, key)
 		if err != nil {
-			return xerrors.Errorf("error while deleting: %w", err)
+			return fmt.Errorf("error while deleting: %w", err)
 		}
 	}
 	err = ds.Delete(ctx, tombstoneKey)
 	if err != nil {
-		return xerrors.Errorf("error while deleting tombstone: %w", err)
+		return fmt.Errorf("error while deleting tombstone: %w", err)
 	}
 	return nil
 }
@@ -454,7 +453,7 @@ func maybeContinueDelete(ctx context.Context, ds datastore.Datastore) error {
 func (cs *Store) DeleteAll(ctx context.Context) error {
 	err := cs.ds.Put(ctx, tombstoneKey, []byte("tombstone"))
 	if err != nil {
-		return xerrors.Errorf("creating a tombstone: %w", err)
+		return fmt.Errorf("creating a tombstone: %w", err)
 	}
 
 	return maybeContinueDelete(ctx, cs.ds)

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -19,7 +19,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/xerrors"
 )
 
 var log = logging.Logger("f3/cli")
@@ -48,38 +47,38 @@ var runCmd = cli.Command{
 		ctx := c.Context
 		h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/udp/0/quic-v1"))
 		if err != nil {
-			return xerrors.Errorf("creating libp2p host: %w", err)
+			return fmt.Errorf("creating libp2p host: %w", err)
 		}
 
 		ps, err := pubsub.NewGossipSub(ctx, h)
 		if err != nil {
-			return xerrors.Errorf("creating gossipsub: %w", err)
+			return fmt.Errorf("creating gossipsub: %w", err)
 		}
 
 		closer, err := setupDiscovery(h)
 		if err != nil {
-			return xerrors.Errorf("setting up discovery: %w", err)
+			return fmt.Errorf("setting up discovery: %w", err)
 		}
 		defer closer()
 
 		tmpdir, err := os.MkdirTemp("", "f3-*")
 		if err != nil {
-			return xerrors.Errorf("creating temp dir: %w", err)
+			return fmt.Errorf("creating temp dir: %w", err)
 		}
 
 		ds, err := leveldb.NewDatastore(tmpdir, nil)
 		if err != nil {
-			return xerrors.Errorf("creating a datastore: %w", err)
+			return fmt.Errorf("creating a datastore: %w", err)
 		}
 
 		m, err := getManifest(c)
 		if err != nil {
-			return xerrors.Errorf("loading manifest: %w", err)
+			return fmt.Errorf("loading manifest: %w", err)
 		}
 
 		err = logging.SetLogLevel("f3", "debug")
 		if err != nil {
-			return xerrors.Errorf("setting log level: %w", err)
+			return fmt.Errorf("setting log level: %w", err)
 		}
 
 		// setup initial power table for number of participants
@@ -103,7 +102,7 @@ var runCmd = cli.Command{
 		if mFlag != "" {
 			manifestServer, err = peer.Decode(mFlag)
 			if err != nil {
-				return xerrors.Errorf("parsing manifest server ID: %w", err)
+				return fmt.Errorf("parsing manifest server ID: %w", err)
 			}
 			mprovider = manifest.NewDynamicManifestProvider(m, ps, nil, manifestServer)
 		} else {
@@ -118,7 +117,7 @@ var runCmd = cli.Command{
 
 		module, err := f3.New(ctx, mprovider, ds, h, ps, signingBackend, ec)
 		if err != nil {
-			return xerrors.Errorf("creating module: %w", err)
+			return fmt.Errorf("creating module: %w", err)
 		}
 
 		errCh := make(chan error, 1)

--- a/ec/fake_ec.go
+++ b/ec/fake_ec.go
@@ -3,11 +3,11 @@ package ec
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"sync"
 	"time"
 
 	"golang.org/x/crypto/blake2b"
-	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-f3/gpbft"
 )
@@ -108,7 +108,7 @@ func (ec *FakeEC) currentEpoch() int64 {
 // GetTipsetByHeight should return a tipset or nil/empty byte array if it does not exists
 func (ec *FakeEC) GetTipsetByEpoch(ctx context.Context, epoch int64) (TipSet, error) {
 	if ec.useTime && ec.currentEpoch() < epoch {
-		return nil, xerrors.Errorf("does not yet exist")
+		return nil, fmt.Errorf("does not yet exist")
 	}
 	ts := ec.genTipset(epoch)
 	for ts == nil {
@@ -123,13 +123,13 @@ func (ec *FakeEC) GetParent(ctx context.Context, ts TipSet) (TipSet, error) {
 	for epoch := ts.Epoch() - 1; epoch > 0; epoch-- {
 		ts, err := ec.GetTipsetByEpoch(ctx, epoch)
 		if err != nil {
-			return nil, xerrors.Errorf("walking back tipsets: %w", err)
+			return nil, fmt.Errorf("walking back tipsets: %w", err)
 		}
 		if ts != nil {
 			return ts, nil
 		}
 	}
-	return nil, xerrors.Errorf("parent not found")
+	return nil, fmt.Errorf("parent not found")
 }
 
 // SetCurrentHead sets the current head epoch.

--- a/f3.go
+++ b/f3.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ipfs/go-datastore"
 	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/xerrors"
 )
 
 type F3 struct {
@@ -105,7 +104,7 @@ func (m *F3) GetLatestCert(ctx context.Context) (*certs.FinalityCertificate, err
 	m.mu.Unlock()
 
 	if cs == nil {
-		return nil, xerrors.Errorf("F3 is not running")
+		return nil, fmt.Errorf("F3 is not running")
 	}
 	return cs.Latest(), nil
 }
@@ -116,7 +115,7 @@ func (m *F3) GetCert(ctx context.Context, instance uint64) (*certs.FinalityCerti
 	m.mu.Unlock()
 
 	if cs == nil {
-		return nil, xerrors.Errorf("F3 is not running")
+		return nil, fmt.Errorf("F3 is not running")
 	}
 	return cs.Get(ctx, instance)
 }
@@ -130,7 +129,7 @@ func (m *F3) computeBootstrapDelay(manifest *manifest.Manifest) (time.Duration, 
 
 	ts, err := m.ec.GetHead(m.runningCtx)
 	if err != nil {
-		err := xerrors.Errorf("failed to get the EC chain head: %w", err)
+		err := fmt.Errorf("failed to get the EC chain head: %w", err)
 		return 0, err
 	}
 
@@ -175,7 +174,7 @@ func (m *F3) Start(startCtx context.Context) (_err error) {
 	// bootstrap. That way, we'll be fully started when we return from Start.
 	if initialDelay == 0 {
 		if err := m.reconfigure(startCtx, pendingManifest); err != nil {
-			return xerrors.Errorf("failed to start GPBFT: %w", err)
+			return fmt.Errorf("failed to start GPBFT: %w", err)
 		}
 		pendingManifest = nil
 	}
@@ -213,7 +212,7 @@ func (m *F3) Start(startCtx context.Context) (_err error) {
 				manifestChangeTimer.Reset(delay)
 			} else {
 				if err := m.reconfigure(m.runningCtx, pendingManifest); err != nil {
-					return xerrors.Errorf("failed to reconfigure F3: %w", err)
+					return fmt.Errorf("failed to reconfigure F3: %w", err)
 				}
 				pendingManifest = nil
 			}
@@ -303,7 +302,7 @@ func (m *F3) resumeInternal(ctx context.Context) error {
 	if m.cs == nil {
 		cs, err := openCertstore(m.runningCtx, runnerEc, m.ds, m.manifest)
 		if err != nil {
-			return xerrors.Errorf("failed to open certstore: %w", err)
+			return fmt.Errorf("failed to open certstore: %w", err)
 		}
 
 		m.cs = cs
@@ -374,7 +373,7 @@ func (m *F3) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.Power
 	m.mu.Unlock()
 
 	if manifest == nil {
-		return nil, xerrors.Errorf("no known network manifest")
+		return nil, fmt.Errorf("no known network manifest")
 	}
 
 	return ec.WithModifiedPower(m.ec, manifest.PowerUpdate).GetPowerTable(ctx, ts)

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -17,7 +17,6 @@ import (
 	"github.com/filecoin-project/go-f3/merkle"
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/crypto/blake2b"
-	"golang.org/x/xerrors"
 )
 
 type Phase uint8
@@ -472,50 +471,50 @@ func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMes
 	// Check sender is eligible.
 	senderPower, senderPubKey := powerTable.Get(msg.Sender)
 	if senderPower == 0 {
-		return xerrors.Errorf("sender %d with zero power or not in power table", msg.Sender)
+		return fmt.Errorf("sender %d with zero power or not in power table", msg.Sender)
 	}
 
 	// Check that message value is a valid chain.
 	if err := msg.Vote.Value.Validate(); err != nil {
-		return xerrors.Errorf("invalid message vote value chain: %w", err)
+		return fmt.Errorf("invalid message vote value chain: %w", err)
 	}
 
 	// Check phase-specific constraints.
 	switch msg.Vote.Step {
 	case QUALITY_PHASE:
 		if msg.Vote.Round != 0 {
-			return xerrors.Errorf("unexpected round %d for quality phase", msg.Vote.Round)
+			return fmt.Errorf("unexpected round %d for quality phase", msg.Vote.Round)
 		}
 		if msg.Vote.Value.IsZero() {
-			return xerrors.Errorf("unexpected zero value for quality phase")
+			return fmt.Errorf("unexpected zero value for quality phase")
 		}
 	case CONVERGE_PHASE:
 		if msg.Vote.Round == 0 {
-			return xerrors.Errorf("unexpected round 0 for converge phase")
+			return fmt.Errorf("unexpected round 0 for converge phase")
 		}
 		if msg.Vote.Value.IsZero() {
-			return xerrors.Errorf("unexpected zero value for converge phase")
+			return fmt.Errorf("unexpected zero value for converge phase")
 		}
 		if !VerifyTicket(host.NetworkName(), beacon, msg.Vote.Instance, msg.Vote.Round, senderPubKey, host, msg.Ticket) {
-			return xerrors.Errorf("failed to verify ticket from %v", msg.Sender)
+			return fmt.Errorf("failed to verify ticket from %v", msg.Sender)
 		}
 	case DECIDE_PHASE:
 		if msg.Vote.Round != 0 {
-			return xerrors.Errorf("unexpected non-zero round %d for decide phase", msg.Vote.Round)
+			return fmt.Errorf("unexpected non-zero round %d for decide phase", msg.Vote.Round)
 		}
 		if msg.Vote.Value.IsZero() {
-			return xerrors.Errorf("unexpected zero value for decide phase")
+			return fmt.Errorf("unexpected zero value for decide phase")
 		}
 	case PREPARE_PHASE, COMMIT_PHASE:
 		// No additional checks for PREPARE and COMMIT.
 	default:
-		return xerrors.Errorf("invalid vote step: %d", msg.Vote.Step)
+		return fmt.Errorf("invalid vote step: %d", msg.Vote.Step)
 	}
 
 	// Check vote signature.
 	sigPayload := host.MarshalPayloadForSigning(host.NetworkName(), &msg.Vote)
 	if err := host.Verify(senderPubKey, sigPayload, msg.Signature); err != nil {
-		return xerrors.Errorf("invalid signature on %v, %v", msg, err)
+		return fmt.Errorf("invalid signature on %v, %v", msg, err)
 	}
 
 	// Check justification
@@ -532,7 +531,7 @@ func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMes
 		}
 		// Check that justification vote value is a valid chain.
 		if err := msg.Justification.Vote.Value.Validate(); err != nil {
-			return xerrors.Errorf("invalid justification vote value chain: %w", err)
+			return fmt.Errorf("invalid justification vote value chain: %w", err)
 		}
 
 		// Check every remaining field of the justification, according to the phase requirements.
@@ -589,7 +588,7 @@ func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMes
 			}
 			power := powerTable.ScaledPower[bit]
 			if power == 0 {
-				return xerrors.Errorf("signer with ID %d has no power", powerTable.Entries[bit].ID)
+				return fmt.Errorf("signer with ID %d has no power", powerTable.Entries[bit].ID)
 			}
 			justificationPower += power
 			signers = append(signers, powerTable.Entries[bit].PubKey)
@@ -604,7 +603,7 @@ func ValidateMessage(powerTable *PowerTable, beacon []byte, host Host, msg *GMes
 
 		payload := host.MarshalPayloadForSigning(host.NetworkName(), &msg.Justification.Vote)
 		if err := host.VerifyAggregate(payload, msg.Justification.Signature, signers); err != nil {
-			return xerrors.Errorf("verification of the aggregate failed: %+v: %w", msg.Justification, err)
+			return fmt.Errorf("verification of the aggregate failed: %+v: %w", msg.Justification, err)
 		}
 	} else if msg.Justification != nil {
 		return fmt.Errorf("message %v has unexpected justification", msg)
@@ -1079,7 +1078,7 @@ func (i *instance) alarmAfterSynchrony() time.Time {
 func (i *instance) buildJustification(quorum QuorumResult, round uint64, phase Phase, value ECChain) *Justification {
 	aggSignature, err := quorum.Aggregate(i.participant.host)
 	if err != nil {
-		panic(xerrors.Errorf("aggregating for phase %v: %v", phase, err))
+		panic(fmt.Errorf("aggregating for phase %v: %v", phase, err))
 	}
 	return &Justification{
 		Vote: Payload{

--- a/gpbft/message_builder.go
+++ b/gpbft/message_builder.go
@@ -3,8 +3,7 @@ package gpbft
 import (
 	"context"
 	"errors"
-
-	xerrors "golang.org/x/xerrors"
+	"fmt"
 )
 
 // ErrNoPower is returned by the MessageBuilder if the specified participant has no power.
@@ -33,12 +32,12 @@ type SignerWithMarshaler interface {
 func (mt *MessageBuilder) Build(ctx context.Context, signer Signer, id ActorID) (*GMessage, error) {
 	st, err := mt.PrepareSigningInputs(id)
 	if err != nil {
-		return nil, xerrors.Errorf("preparing signing inputs: %w", err)
+		return nil, fmt.Errorf("preparing signing inputs: %w", err)
 	}
 
 	payloadSig, vrf, err := st.Sign(ctx, signer)
 	if err != nil {
-		return nil, xerrors.Errorf("signing message builder: %w", err)
+		return nil, fmt.Errorf("signing message builder: %w", err)
 	}
 
 	return st.Build(payloadSig, vrf), nil
@@ -59,7 +58,7 @@ type SignatureBuilder struct {
 func (mb *MessageBuilder) PrepareSigningInputs(id ActorID) (*SignatureBuilder, error) {
 	effectivePower, pubKey := mb.PowerTable.Get(id)
 	if pubKey == nil || effectivePower == 0 {
-		return nil, xerrors.Errorf("could not find pubkey for actor %d: %w", id, ErrNoPower)
+		return nil, fmt.Errorf("could not find pubkey for actor %d: %w", id, ErrNoPower)
 	}
 	sb := SignatureBuilder{
 		ParticipantID: id,
@@ -82,13 +81,13 @@ func (mb *MessageBuilder) PrepareSigningInputs(id ActorID) (*SignatureBuilder, e
 func (st *SignatureBuilder) Sign(ctx context.Context, signer Signer) ([]byte, []byte, error) {
 	payloadSignature, err := signer.Sign(ctx, st.PubKey, st.PayloadToSign)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("signing payload: %w", err)
+		return nil, nil, fmt.Errorf("signing payload: %w", err)
 	}
 	var vrf []byte
 	if st.VRFToSign != nil {
 		vrf, err = signer.Sign(ctx, st.PubKey, st.VRFToSign)
 		if err != nil {
-			return nil, nil, xerrors.Errorf("signing vrf: %w", err)
+			return nil, nil, fmt.Errorf("signing vrf: %w", err)
 		}
 	}
 	return payloadSignature, vrf, nil

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"sync"
 	"time"
-
-	xerrors "golang.org/x/xerrors"
 )
 
 // An F3 participant runs repeated instances of Granite to finalise longer chains.
@@ -140,7 +138,7 @@ func (p *Participant) ValidateMessage(msg *GMessage) (valid ValidatedMessage, er
 
 	// Validate the message.
 	if err = ValidateMessage(comt.power, comt.beacon, p.host, msg); err != nil {
-		return nil, xerrors.Errorf("%v: %w", err, ErrValidationInvalid)
+		return nil, fmt.Errorf("%v: %w", err, ErrValidationInvalid)
 	}
 	return &validatedMessage{msg: msg}, nil
 }

--- a/gpbft/powertable.go
+++ b/gpbft/powertable.go
@@ -7,8 +7,6 @@ import (
 	"math/big"
 	"slices"
 	"sort"
-
-	xerrors "golang.org/x/xerrors"
 )
 
 var _ sort.Interface = (*PowerTable)(nil)
@@ -237,7 +235,7 @@ func (p *PowerTable) Validate() error {
 func scalePower(power, total *StoragePower) (uint16, error) {
 	const maxPower = 0xffff
 	if power.Cmp(total) > 0 {
-		return 0, xerrors.Errorf("total power %d is less than the power of a single participant %d", total, power)
+		return 0, fmt.Errorf("total power %d is less than the power of a single participant %d", total, power)
 	}
 	scaled := big.NewInt(maxPower)
 	scaled = scaled.Mul(scaled, (*big.Int)(power))

--- a/manifest/dynamic_manifest.go
+++ b/manifest/dynamic_manifest.go
@@ -16,7 +16,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/xerrors"
 )
 
 var log = logging.Logger("f3-dynamic-manifest")
@@ -68,7 +67,7 @@ func (mu ManifestUpdateMessage) toManifest() *Manifest {
 func (m ManifestUpdateMessage) Marshal() ([]byte, error) {
 	b, err := json.Marshal(m)
 	if err != nil {
-		return nil, xerrors.Errorf("marshaling JSON: %w", err)
+		return nil, fmt.Errorf("marshaling JSON: %w", err)
 	}
 	return b, nil
 }
@@ -76,7 +75,7 @@ func (m ManifestUpdateMessage) Marshal() ([]byte, error) {
 func (m *ManifestUpdateMessage) Unmarshal(r io.Reader) error {
 	err := json.NewDecoder(r).Decode(&m)
 	if err != nil {
-		return xerrors.Errorf("decoding JSON: %w", err)
+		return fmt.Errorf("decoding JSON: %w", err)
 	}
 	return nil
 }
@@ -113,12 +112,12 @@ func (m *DynamicManifestProvider) Start(startCtx context.Context) (_err error) {
 
 	manifestTopic, err := m.pubsub.Join(ManifestPubSubTopicName)
 	if err != nil {
-		return xerrors.Errorf("could not join manifest pubsub topic: %w", err)
+		return fmt.Errorf("could not join manifest pubsub topic: %w", err)
 	}
 
 	manifestSub, err := manifestTopic.Subscribe()
 	if err != nil {
-		return xerrors.Errorf("subscribing to manifest pubsub topic: %w", err)
+		return fmt.Errorf("subscribing to manifest pubsub topic: %w", err)
 	}
 
 	// XXX: load the initial manifest from disk!
@@ -152,7 +151,7 @@ func (m *DynamicManifestProvider) Start(startCtx context.Context) (_err error) {
 			msg, err := manifestSub.Next(m.runningCtx)
 			if err != nil {
 				if m.runningCtx.Err() == nil {
-					return xerrors.Errorf("error from manifest subscription: %w", err)
+					return fmt.Errorf("error from manifest subscription: %w", err)
 				}
 				return nil
 			}
@@ -207,7 +206,7 @@ func (m *DynamicManifestProvider) registerTopicValidator() error {
 
 	err := m.pubsub.RegisterTopicValidator(ManifestPubSubTopicName, validator)
 	if err != nil {
-		return xerrors.Errorf("registering topic validator: %w", err)
+		return fmt.Errorf("registering topic validator: %w", err)
 	}
 	return nil
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -12,7 +12,6 @@ import (
 	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/ipfs/go-datastore"
-	"golang.org/x/xerrors"
 )
 
 var (
@@ -117,7 +116,7 @@ func LocalDevnetManifest() *Manifest {
 func (m *Manifest) Version() (Version, error) {
 	b, err := json.Marshal(m)
 	if err != nil {
-		return "", xerrors.Errorf("computing manifest version: %w", err)
+		return "", fmt.Errorf("computing manifest version: %w", err)
 	}
 	return Version(hex.EncodeToString(gpbft.MakeCid(b))), nil
 }
@@ -128,7 +127,7 @@ func (m *Manifest) Version() (Version, error) {
 func (m *Manifest) Marshal() ([]byte, error) {
 	b, err := json.Marshal(m)
 	if err != nil {
-		return nil, xerrors.Errorf("marshaling JSON: %w", err)
+		return nil, fmt.Errorf("marshaling JSON: %w", err)
 	}
 	return b, nil
 }
@@ -136,7 +135,7 @@ func (m *Manifest) Marshal() ([]byte, error) {
 func (m *Manifest) Unmarshal(r io.Reader) error {
 	err := json.NewDecoder(r).Decode(&m)
 	if err != nil {
-		return xerrors.Errorf("decoding JSON: %w", err)
+		return fmt.Errorf("decoding JSON: %w", err)
 	}
 	return nil
 }

--- a/manifest/manifest_sender.go
+++ b/manifest/manifest_sender.go
@@ -2,13 +2,13 @@ package manifest
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"golang.org/x/xerrors"
 )
 
 // ManifestSender is responsible for periodically broadcasting
@@ -39,7 +39,7 @@ func NewManifestSender(h host.Host, pubsub *pubsub.PubSub, firstManifest *Manife
 	var err error
 	m.manifestTopic, err = m.pubsub.Join(topicName)
 	if err != nil {
-		return nil, xerrors.Errorf("could not join on pubsub topic: %s: %w", topicName, err)
+		return nil, fmt.Errorf("could not join on pubsub topic: %s: %w", topicName, err)
 	}
 
 	return m, nil
@@ -63,7 +63,7 @@ func (m *ManifestSender) Run(ctx context.Context) error {
 				if ctx.Err() != nil {
 					return nil
 				}
-				return xerrors.Errorf("error publishing manifest: %w", err)
+				return fmt.Errorf("error publishing manifest: %w", err)
 			}
 		case <-ctx.Done():
 			return nil

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/filecoin-project/go-f3/gpbft"
-	"golang.org/x/xerrors"
 )
 
 var _ Backend = (*FakeBackend)(nil)
@@ -48,7 +47,7 @@ func (s *FakeBackend) Sign(_ context.Context, signer gpbft.PubKey, msg []byte) (
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if _, ok := s.allowed[string(signer)]; !ok {
-		return nil, xerrors.Errorf("cannot sign: unknown sender")
+		return nil, fmt.Errorf("cannot sign: unknown sender")
 	}
 	return s.generateSignature(signer, msg)
 }

--- a/store.go
+++ b/store.go
@@ -2,6 +2,7 @@ package f3
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/ec"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
-	"golang.org/x/xerrors"
 )
 
 // openCertstore opens the certificate store for the specific manifest (namespaced by the network
@@ -20,12 +20,12 @@ func openCertstore(ctx context.Context, ec ec.Backend, ds datastore.Datastore, m
 
 	ts, err := ec.GetTipsetByEpoch(ctx, m.BootstrapEpoch-m.ECFinality)
 	if err != nil {
-		return nil, xerrors.Errorf("getting initial power tipset: %w", err)
+		return nil, fmt.Errorf("getting initial power tipset: %w", err)
 	}
 
 	initialPowerTable, err := ec.GetPowerTable(ctx, ts.Key())
 	if err != nil {
-		return nil, xerrors.Errorf("getting initial power table: %w", err)
+		return nil, fmt.Errorf("getting initial power table: %w", err)
 	}
 
 	return certstore.OpenOrCreateStore(ctx, ds, m.InitialInstance, initialPowerTable)

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -24,7 +24,6 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -98,7 +97,7 @@ func TestFailRecover(t *testing.T) {
 			switch op {
 			case "put", "batch-put":
 				failDsWrite.Store(false)
-				return xerrors.Errorf("FAILURE!")
+				return fmt.Errorf("FAILURE!")
 			}
 		}
 		return nil
@@ -530,14 +529,14 @@ func (e *testEnv) newManifestSender() {
 func (e *testEnv) newF3Instance(id int, manifestServer peer.ID) (*testNode, error) {
 	h, err := e.net.GenPeer()
 	if err != nil {
-		return nil, xerrors.Errorf("creating libp2p host: %w", err)
+		return nil, fmt.Errorf("creating libp2p host: %w", err)
 	}
 
 	n := &testNode{e: e, h: h}
 
 	ps, err := pubsub.NewGossipSub(e.testCtx, h)
 	if err != nil {
-		return nil, xerrors.Errorf("creating gossipsub: %w", err)
+		return nil, fmt.Errorf("creating gossipsub: %w", err)
 	}
 
 	ds := ds_sync.MutexWrap(failstore.NewFailstore(datastore.NewMapDatastore(), func(s string) error {
@@ -559,7 +558,7 @@ func (e *testEnv) newF3Instance(id int, manifestServer peer.ID) (*testNode, erro
 
 	n.f3, err = f3.New(e.testCtx, mprovider, ds, h, ps, e.signingBackend, e.ec)
 	if err != nil {
-		return nil, xerrors.Errorf("creating module: %w", err)
+		return nil, fmt.Errorf("creating module: %w", err)
 	}
 
 	e.errgrp.Go(func() error {


### PR DESCRIPTION
```
sed -i -e 's|xerrors\.Errorf|fmt.Errorf|g' -e 's|xerrors\.New|errors.New|g' **/*.go *.go
goimports -w **/*.go *.go
go generate ./...
```