### PR TITLE
Fix typo in manifest EC config

### DIFF
--- a/host.go
+++ b/host.go
@@ -485,7 +485,7 @@ func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable,
 	var powerEntries gpbft.PowerEntries
 	var err error
 
-	if instance < h.manifest.InitialInstance+h.manifest.CommiteeLookback {
+	if instance < h.manifest.InitialInstance+h.manifest.CommitteeLookback {
 		//boostrap phase
 		ts, err := h.ec.GetTipsetByEpoch(h.runningCtx, h.manifest.BootstrapEpoch-h.manifest.ECFinality)
 		if err != nil {
@@ -497,7 +497,7 @@ func (h *gpbftHost) GetCommitteeForInstance(instance uint64) (*gpbft.PowerTable,
 			return nil, nil, fmt.Errorf("getting power table: %w", err)
 		}
 	} else {
-		cert, err := h.certStore.Get(h.runningCtx, instance-h.manifest.CommiteeLookback)
+		cert, err := h.certStore.Get(h.runningCtx, instance-h.manifest.CommitteeLookback)
 		if err != nil {
 			return nil, nil, fmt.Errorf("getting finality certificate: %w", err)
 		}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -18,7 +18,7 @@ var (
 	// Default configuration for the EC Backend
 	DefaultEcConfig = &EcConfig{
 		ECFinality:        900,
-		CommiteeLookback:  10,
+		CommitteeLookback: 10,
 		ECPeriod:          30 * time.Second,
 		ECDelayMultiplier: 2.,
 		// MaxBackoff is 15min given default params
@@ -72,14 +72,14 @@ type GpbftConfig struct {
 type EcConfig struct {
 	// The delay between tipsets.
 	ECPeriod time.Duration
-	// Number of epochs required to reach EC defined fianlity
+	// Number of epochs required to reach EC defined finality
 	ECFinality int64
 	// The multiplier on top of the ECPeriod of the time we will wait before starting a new instance,
-	// referencing the timestampt of the latest finalized tipset.
+	// referencing the timestamp of the latest finalized tipset.
 	ECDelayMultiplier float64
 	// Table of incremental multipliers to backoff in units of ECDelay in case of base decisions
 	BaseDecisionBackoffTable []float64
-	CommiteeLookback         uint64
+	CommitteeLookback        uint64
 }
 
 // Manifest identifies the specific configuration for the F3 instance currently running.

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -36,7 +36,7 @@ var base manifest.Manifest = manifest.Manifest{
 	},
 	EcConfig: &manifest.EcConfig{
 		ECFinality:               900,
-		CommiteeLookback:         5,
+		CommitteeLookback:        5,
 		ECDelayMultiplier:        2.0,
 		ECPeriod:                 30 * time.Second,
 		BaseDecisionBackoffTable: []float64{1.3, 1.69, 2.2, 2.86, 3.71, 4.83, 6.27, 8.16, 10.6, 13.79, 15.},

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -66,7 +66,7 @@ func TestPauseResumeCatchup(t *testing.T) {
 	env.waitForInstanceNumber(resumeInstance, 10*time.Second, false)
 
 	// Wait until we're far enough that pure GPBFT catchup should be impossible.
-	targetInstance := resumeInstance + env.manifest.CommiteeLookback
+	targetInstance := resumeInstance + env.manifest.CommitteeLookback
 	env.waitForInstanceNumber(targetInstance, 30*time.Second, false)
 
 	pausedInstance := env.nodes[2].currentGpbftInstance()
@@ -200,7 +200,7 @@ func TestDynamicManifest_WithPauseAndRebootstrap(t *testing.T) {
 	env.requireEqualManifests(false)
 }
 
-var base manifest.Manifest = manifest.Manifest{
+var base = manifest.Manifest{
 	BootstrapEpoch:  950,
 	InitialInstance: 0,
 	NetworkName:     gpbft.NetworkName("f3-test"),
@@ -212,8 +212,8 @@ var base manifest.Manifest = manifest.Manifest{
 	},
 	// EcConfig:        manifest.DefaultEcConfig,
 	EcConfig: &manifest.EcConfig{
-		ECFinality:       10,
-		CommiteeLookback: 5,
+		ECFinality:        10,
+		CommitteeLookback: 5,
 		// increased delay and period to accelerate test times.
 		ECPeriod:                 100 * time.Millisecond,
 		ECDelayMultiplier:        1.0,


### PR DESCRIPTION
Fix minor typo in spelling of "committee".