### PR TITLE
Make it possible to disable some/all participants via the manifest

### DIFF
--- a/ec/powerdelta.go
+++ b/ec/powerdelta.go
@@ -3,21 +3,52 @@ package ec
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"sort"
 
-	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/gpbft"
 )
 
-func WithModifiedPower(backend Backend, delta []certs.PowerTableDelta) Backend {
-	return &withModifiedPower{
-		Backend: backend,
-		delta:   delta,
+func WithModifiedPower(backend Backend, explicitPower gpbft.PowerEntries, ignoreEcPower bool) Backend {
+	if len(explicitPower) == 0 && !ignoreEcPower {
+		return backend
 	}
+
+	explicitPower = slices.Clone(explicitPower)
+	sort.Sort(explicitPower)
+
+	if ignoreEcPower {
+		return &withReplacedPower{
+			Backend: backend,
+			power:   trimPowerTable(explicitPower),
+		}
+	}
+
+	index := make(map[gpbft.ActorID]int, len(explicitPower))
+	for i, entry := range explicitPower {
+		index[entry.ID] = i
+	}
+	return &withModifiedPower{
+		Backend:       backend,
+		explicit:      explicitPower,
+		explicitIndex: index,
+	}
+}
+
+type withReplacedPower struct {
+	Backend
+	power gpbft.PowerEntries
+}
+
+func (b *withReplacedPower) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.PowerEntries, error) {
+	return b.power, nil
 }
 
 type withModifiedPower struct {
 	Backend
-	delta []certs.PowerTableDelta
+	explicit      gpbft.PowerEntries
+	explicitIndex map[gpbft.ActorID]int
 }
 
 func (b *withModifiedPower) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.PowerEntries, error) {
@@ -25,5 +56,26 @@ func (b *withModifiedPower) GetPowerTable(ctx context.Context, ts gpbft.TipSetKe
 	if err != nil {
 		return nil, fmt.Errorf("getting power table: %w", err)
 	}
-	return certs.ApplyPowerTableDiffs(pt, b.delta)
+	pt = slices.Clone(pt)
+	index := maps.Clone(b.explicitIndex)
+	for i := range pt {
+		e := &pt[i]
+		if idx, ok := index[e.ID]; ok {
+			*e = b.explicit[idx]
+			delete(index, e.ID)
+		}
+	}
+	for _, idx := range index {
+		pt = append(pt, b.explicit[idx])
+	}
+	sort.Sort(pt)
+	return trimPowerTable(pt), nil
+}
+
+func trimPowerTable(pt gpbft.PowerEntries) gpbft.PowerEntries {
+	newLen := len(pt)
+	for newLen > 0 && pt[newLen-1].Power.Sign() == 0 {
+		newLen--
+	}
+	return pt[:newLen]
 }

--- a/ec/powerdelta_test.go
+++ b/ec/powerdelta_test.go
@@ -1,0 +1,60 @@
+package ec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-f3/ec"
+	"github.com/filecoin-project/go-f3/gpbft"
+
+	"github.com/stretchr/testify/require"
+)
+
+var powerTableA = gpbft.PowerEntries{
+	{ID: 1, Power: gpbft.NewStoragePower(50)},
+	{ID: 2, Power: gpbft.NewStoragePower(30)},
+	{ID: 3, Power: gpbft.NewStoragePower(29)},
+}
+
+var powerTableB = gpbft.PowerEntries{
+	{ID: 3, Power: gpbft.NewStoragePower(10)},
+	{ID: 4, Power: gpbft.NewStoragePower(4)},
+	{ID: 2, Power: gpbft.NewStoragePower(0)},
+}
+
+var powerTableC = gpbft.PowerEntries{
+	{ID: 1, Power: gpbft.NewStoragePower(50)},
+	{ID: 3, Power: gpbft.NewStoragePower(10)},
+	{ID: 4, Power: gpbft.NewStoragePower(4)},
+}
+
+func TestReplacePowerTable(t *testing.T) {
+	backend := ec.NewFakeEC(0, 0, 0, powerTableA, false)
+	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, true)
+
+	head, err := modifiedBackend.GetHead(context.Background())
+	require.NoError(t, err)
+
+	// Replaces the power table, but doesn't return the "0" entries.
+	pt, err := modifiedBackend.GetPowerTable(context.Background(), head.Key())
+	require.NoError(t, err)
+	require.EqualValues(t, powerTableB[:2], pt)
+}
+
+func TestModifyPowerTable(t *testing.T) {
+	backend := ec.NewFakeEC(0, 0, 0, powerTableA, false)
+	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, false)
+
+	head, err := modifiedBackend.GetHead(context.Background())
+	require.NoError(t, err)
+
+	pt, err := modifiedBackend.GetPowerTable(context.Background(), head.Key())
+	require.NoError(t, err)
+	require.EqualValues(t, powerTableC, pt)
+}
+
+func TestBypassModifiedPowerTable(t *testing.T) {
+	backend := ec.NewFakeEC(0, 0, 0, powerTableA, false)
+	modifiedBackend := ec.WithModifiedPower(backend, nil, false)
+	require.Equal(t, backend, modifiedBackend)
+}

--- a/f3.go
+++ b/f3.go
@@ -292,10 +292,7 @@ func (m *F3) stopInternal(ctx context.Context) error {
 }
 
 func (m *F3) resumeInternal(ctx context.Context) error {
-	runnerEc := m.ec
-	if len(m.manifest.PowerUpdate) > 0 {
-		runnerEc = ec.WithModifiedPower(m.ec, m.manifest.PowerUpdate)
-	}
+	runnerEc := ec.WithModifiedPower(m.ec, m.manifest.ExplicitPower, m.manifest.IgnoreECPower)
 
 	// We don't reset this field if we only pause/resume.
 	if m.cs == nil {
@@ -374,6 +371,6 @@ func (m *F3) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.Power
 	if manifest == nil {
 		return nil, fmt.Errorf("no known network manifest")
 	}
-
-	return ec.WithModifiedPower(m.ec, manifest.PowerUpdate).GetPowerTable(ctx, ts)
+	return ec.WithModifiedPower(m.ec, m.manifest.ExplicitPower, m.manifest.IgnoreECPower).
+		GetPowerTable(ctx, ts)
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/ipfs/go-datastore"
 )
@@ -90,9 +89,11 @@ type Manifest struct {
 	BootstrapEpoch int64
 	// Network name to apply for this manifest.
 	NetworkName gpbft.NetworkName
-	// Updates to perform over the power table retrieved by the host
-	// starting from BootstrapEpoch.
-	PowerUpdate []certs.PowerTableDelta
+	// Updates to perform over the power table from EC (by replacement). Any entries with 0
+	// power will disable the participant.
+	ExplicitPower gpbft.PowerEntries
+	// Ignore the power table from EC.
+	IgnoreECPower bool
 	// Config parameters for gpbft
 	*GpbftConfig
 	// EC-specific parameters

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/stretchr/testify/require"
@@ -17,16 +16,16 @@ import (
 var base manifest.Manifest = manifest.Manifest{
 	BootstrapEpoch: 10,
 	NetworkName:    gpbft.NetworkName("test"),
-	PowerUpdate: []certs.PowerTableDelta{
+	ExplicitPower: gpbft.PowerEntries{
 		{
-			ParticipantID: 2,
-			PowerDelta:    big.NewInt(1),
-			SigningKey:    gpbft.PubKey{0},
+			ID:     2,
+			Power:  big.NewInt(1),
+			PubKey: gpbft.PubKey{0},
 		},
 		{
-			ParticipantID: 3,
-			PowerDelta:    big.NewInt(1),
-			SigningKey:    gpbft.PubKey{1},
+			ID:     3,
+			Power:  big.NewInt(1),
+			PubKey: gpbft.PubKey{1},
 		},
 	},
 	GpbftConfig: &manifest.GpbftConfig{

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-f3"
-	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"
@@ -147,7 +146,7 @@ func TestDynamicManifest_WithRebootstrap(t *testing.T) {
 	prevInstance := env.nodes[0].currentGpbftInstance()
 
 	env.manifest.BootstrapEpoch = 1253
-	env.addPowerDeltaForParticipants(&env.manifest, []gpbft.ActorID{2, 3}, big.NewInt(1), false)
+	env.addParticipants(&env.manifest, []gpbft.ActorID{2, 3}, big.NewInt(1), false)
 	env.updateManifest()
 
 	env.waitForManifestChange(prev, 35*time.Second)
@@ -289,7 +288,7 @@ func (e *testEnv) newHeadEveryPeriod(period time.Duration) {
 	})
 }
 
-func (e *testEnv) addPowerDeltaForParticipants(m *manifest.Manifest, participants []gpbft.ActorID, power *big.Int, runNodes bool) {
+func (e *testEnv) addParticipants(m *manifest.Manifest, participants []gpbft.ActorID, power *big.Int, runNodes bool) {
 	for _, n := range participants {
 		nodeLen := len(e.nodes)
 		newNode := false
@@ -303,10 +302,10 @@ func (e *testEnv) addPowerDeltaForParticipants(m *manifest.Manifest, participant
 			newNode = true
 		}
 		pubkey, _ := e.signingBackend.GenerateKey()
-		m.PowerUpdate = append(m.PowerUpdate, certs.PowerTableDelta{
-			ParticipantID: gpbft.ActorID(nodeLen),
-			SigningKey:    pubkey,
-			PowerDelta:    power,
+		m.ExplicitPower = append(m.ExplicitPower, gpbft.PowerEntry{
+			ID:     gpbft.ActorID(nodeLen),
+			PubKey: pubkey,
+			Power:  power,
 		})
 		if runNodes && newNode {
 			// connect node


### PR DESCRIPTION
This switches from deltas to:

1. Explicit power entries that extend/replace power entries in the EC power table.
2. A flag that ignores the EC power table entirely.

That way, we can test this out with a limited set of SPs and/or disable problematic SPs.

Fixes #463