### PR TITLE
Remove manifest versions

### DIFF
--- a/cmd/f3/manifest.go
+++ b/cmd/f3/manifest.go
@@ -173,20 +173,7 @@ var manifestServeCmd = cli.Command{
 		}
 
 		manifestPath := c.String("manifest")
-		loadManifestAndVersion := func() (*manifest.Manifest, manifest.Version, error) {
-
-			m, err := loadManifest(manifestPath)
-			if err != nil {
-				return nil, "", fmt.Errorf("loading manifest: %w", err)
-			}
-			version, err := m.Version()
-			if err != nil {
-				return nil, "", fmt.Errorf("versioning manifest: %w", err)
-			}
-			return m, version, nil
-		}
-
-		initManifest, manifestVersion, err := loadManifestAndVersion()
+		currentManifest, err := loadManifest(manifestPath)
 		if err != nil {
 			return fmt.Errorf("loading initial manifest: %w", err)
 		}
@@ -196,11 +183,11 @@ var manifestServeCmd = cli.Command{
 			return fmt.Errorf("initialzing pubsub: %w", err)
 		}
 
-		sender, err := manifest.NewManifestSender(host, pubSub, initManifest, c.Duration("publishInterval"))
+		sender, err := manifest.NewManifestSender(host, pubSub, currentManifest, c.Duration("publishInterval"))
 		if err != nil {
 			return fmt.Errorf("initialzing manifest sender: %w", err)
 		}
-		_, _ = fmt.Fprintf(c.App.Writer, "Started manifest sender with version: %s\n", manifestVersion)
+		_, _ = fmt.Fprintf(c.App.Writer, "Started manifest sender with network name: %s\n", currentManifest.NetworkName)
 
 		checkInterval := c.Duration("checkInterval")
 
@@ -215,12 +202,12 @@ var manifestServeCmd = cli.Command{
 				case <-ctx.Done():
 					return nil
 				case <-checkTicker.C:
-					if nextManifest, nextManifestVersion, err := loadManifestAndVersion(); err != nil {
+					if nextManifest, err := loadManifest(manifestPath); err != nil {
 						_, _ = fmt.Fprintf(c.App.ErrWriter, "Failed reload manifest: %v\n", err)
-					} else if manifestVersion != nextManifestVersion {
-						_, _ = fmt.Fprintf(c.App.Writer, "Loaded manifest with version: %s\n", nextManifestVersion)
+					} else if nextManifest.NetworkName != currentManifest.NetworkName {
+						_, _ = fmt.Fprintf(c.App.Writer, "Loaded manifest: %q\n", nextManifest.NetworkName)
 						sender.UpdateManifest(nextManifest)
-						manifestVersion = nextManifestVersion
+						currentManifest = nextManifest
 					}
 				}
 			}

--- a/cmd/f3/manifest.go
+++ b/cmd/f3/manifest.go
@@ -204,8 +204,8 @@ var manifestServeCmd = cli.Command{
 				case <-checkTicker.C:
 					if nextManifest, err := loadManifest(manifestPath); err != nil {
 						_, _ = fmt.Fprintf(c.App.ErrWriter, "Failed reload manifest: %v\n", err)
-					} else if nextManifest.NetworkName != currentManifest.NetworkName {
-						_, _ = fmt.Fprintf(c.App.Writer, "Loaded manifest: %q\n", nextManifest.NetworkName)
+					} else if !nextManifest.Equal(currentManifest) {
+						_, _ = fmt.Fprintf(c.App.Writer, "Loaded changed manifest with network name: %q\n", nextManifest.NetworkName)
 						sender.UpdateManifest(nextManifest)
 						currentManifest = nextManifest
 					}

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -104,7 +104,7 @@ var runCmd = cli.Command{
 			if err != nil {
 				return fmt.Errorf("parsing manifest server ID: %w", err)
 			}
-			mprovider = manifest.NewDynamicManifestProvider(m, ps, nil, manifestServer)
+			mprovider = manifest.NewDynamicManifestProvider(m, ps, manifestServer)
 		} else {
 			mprovider = manifest.NewStaticManifestProvider(m)
 		}

--- a/gpbft/powertable.go
+++ b/gpbft/powertable.go
@@ -1,6 +1,7 @@
 package gpbft
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"maps"
@@ -29,6 +30,22 @@ type PowerTable struct {
 	Lookup      map[ActorID]int // Maps ActorID to the index of the associated entry in Entries
 	Total       *StoragePower
 	ScaledTotal uint16
+}
+
+func (p *PowerEntry) Equal(o *PowerEntry) bool {
+	return p.ID == o.ID && p.Power.Cmp(o.Power) == 0 && bytes.Equal(p.PubKey, o.PubKey)
+}
+
+func (p PowerEntries) Equal(o PowerEntries) bool {
+	if len(p) != len(o) {
+		return false
+	}
+	for i := range p {
+		if !p[i].Equal(&o[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // Len returns the number of entries in this PowerTable.

--- a/gpbft/powertable_test.go
+++ b/gpbft/powertable_test.go
@@ -191,6 +191,7 @@ func TestPowerTable(t *testing.T) {
 				gotCopy := subject.Copy()
 				require.Equal(t, subject, gotCopy)
 				require.NotSame(t, subject, gotCopy)
+				require.True(t, subject.Entries.Equal(gotCopy.Entries))
 			})
 		}
 	})

--- a/manifest/dynamic_manifest_test.go
+++ b/manifest/dynamic_manifest_test.go
@@ -1,0 +1,90 @@
+package manifest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	mocknetwork "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicManifest(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Cleanup(cancel)
+
+	mocknet := mocknetwork.New()
+	initialManifest := LocalDevnetManifest()
+
+	var (
+		sender   *ManifestSender
+		provider *DynamicManifestProvider
+	)
+
+	{
+		host, err := mocknet.GenPeer()
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+		pubSub, err := pubsub.NewGossipSub(ctx, host, pubsub.WithPeerExchange(true))
+		require.NoError(t, err)
+		sender, err = NewManifestSender(host, pubSub, initialManifest, 10*time.Millisecond)
+		require.NoError(t, err)
+	}
+
+	{
+		host, err := mocknet.GenPeer()
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, host.Close()) })
+
+		pubSub, err := pubsub.NewGossipSub(ctx, host, pubsub.WithPeerExchange(true))
+		require.NoError(t, err)
+
+		provider = NewDynamicManifestProvider(initialManifest, pubSub, sender.SenderID())
+	}
+
+	mocknet.LinkAll()
+	mocknet.ConnectAllButSelf()
+
+	waitSender := make(chan error, 1)
+	senderCtx, cancelSender := context.WithCancel(ctx)
+	go func() { waitSender <- sender.Run(senderCtx) }()
+
+	require.NoError(t, provider.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, provider.Stop(context.Background())) })
+
+	// Should receive the initial manifest.
+	require.True(t, initialManifest.Equal(<-provider.ManifestUpdates()))
+
+	// Pausing should send nil.
+	sender.Pause()
+	require.Nil(t, <-provider.ManifestUpdates())
+
+	// Should get the initial manifest again.
+	sender.Resume()
+	require.True(t, initialManifest.Equal(<-provider.ManifestUpdates()))
+
+	cancelSender()
+	require.Nil(t, <-waitSender)
+
+	// Re-start the sender. The client shouldn't see an update.
+	senderCtx, cancelSender = context.WithCancel(ctx)
+	go func() { waitSender <- sender.Run(senderCtx) }()
+
+	select {
+	case <-provider.ManifestUpdates():
+		t.Fatal("did not expect a manifest update when restarting manifest sender")
+	case <-time.After(1 * time.Second):
+	}
+	newManifest := *initialManifest
+	newManifest.NetworkName = "updated-name"
+	sender.UpdateManifest(&newManifest)
+
+	require.True(t, newManifest.Equal(<-provider.ManifestUpdates()))
+
+	cancelSender()
+	require.NoError(t, <-waitSender)
+}

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -28,19 +28,19 @@ var base manifest.Manifest = manifest.Manifest{
 			PubKey: gpbft.PubKey{1},
 		},
 	},
-	GpbftConfig: &manifest.GpbftConfig{
+	GpbftConfig: manifest.GpbftConfig{
 		Delta:                10,
 		DeltaBackOffExponent: 0.2,
 		MaxLookaheadRounds:   10,
 	},
-	EcConfig: &manifest.EcConfig{
+	EcConfig: manifest.EcConfig{
 		ECFinality:               900,
 		CommitteeLookback:        5,
 		ECDelayMultiplier:        2.0,
 		ECPeriod:                 30 * time.Second,
 		BaseDecisionBackoffTable: []float64{1.3, 1.69, 2.2, 2.86, 3.71, 4.83, 6.27, 8.16, 10.6, 13.79, 15.},
 	},
-	CxConfig: &manifest.CxConfig{
+	CxConfig: manifest.CxConfig{
 		ClientRequestTimeout: 10 * time.Second,
 		ServerRequestTimeout: time.Minute,
 		MinimumPollInterval:  30 * time.Second,
@@ -58,22 +58,6 @@ func TestManifest_Serialization(t *testing.T) {
 	err = m2.Unmarshal(bytes.NewReader(b))
 	require.NoError(t, err)
 	require.Equal(t, base, m2)
-}
-
-func TestManifest_Version(t *testing.T) {
-	m := base
-	v1, err := m.Version()
-	require.NoError(t, err)
-	v2, err := base.Version()
-	require.NoError(t, err)
-	require.Equal(t, v1, v2)
-
-	m.Delta = 1
-	m.NetworkName = "test2"
-	v1, err = m.Version()
-	require.NoError(t, err)
-	require.NotEqual(t, v1, v2)
-
 }
 
 func TestManifest_NetworkName(t *testing.T) {


### PR DESCRIPTION
This also allows us to re-config without re-bootstrap (by restarting the local F3 instance). This is only safe for non-consensus parameters and will be horribly unsafe until we fix 392.

Also:

- Removes reliance on hashing json, relies on the network name and manual equality checks.
- Removes versions. We now expect the version to be explicitly specified in the network name.
- Starts message sequence numbers at the current time so we don't need to save them.
- Remove the EC from the dynamic manifest provider as it's unused.
- Tests.

fixes #468