### PR TITLE
Set default Certificate exchange config in local devnet manifest

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -139,6 +139,7 @@ func LocalDevnetManifest() *Manifest {
 		BootstrapEpoch: 1000,
 		EcConfig:       DefaultEcConfig,
 		GpbftConfig:    DefaultGpbftConfig,
+		CxConfig:       DefaultCxConfig,
 	}
 	return m
 }


### PR DESCRIPTION
Set the default cert exchange configuration in the local devnet manifest, since nil cert exchange config causes panic.

Relates to: https://github.com/filecoin-project/lotus/pull/12236