### PR TITLE
Bump version in prep for releasing `v0.0.4`

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -16,4 +16,7 @@ jobs:
   releaser:
     uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
     with:
-      UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+      # Use default GitHub actions secrets until a UCI-specific secret is created.
+      # See: https://github.com/filecoin-project/go-f3/issues/449
+      # UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+      UCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.0.3"
+  "version": "v0.0.4"
 }


### PR DESCRIPTION
Bump the version in prep for release of `v0.0.4`.

Use default GA secret to allow CI to make the tag until UCI specific secret is created.