### PR TITLE
Implement the "ohshitstore"

### DIFF
--- a/certs/cbor_gen.go
+++ b/certs/cbor_gen.go
@@ -169,6 +169,75 @@ func (t *PowerTableDelta) UnmarshalCBOR(r io.Reader) (err error) {
 	return nil
 }
 
+func (t *PowerTableDiff) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+
+	// (*t) (certs.PowerTableDiff) (slice)
+	if len((*t)) > 8192 {
+		return xerrors.Errorf("Slice value in field (*t) was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len((*t)))); err != nil {
+		return err
+	}
+	for _, v := range *t {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (t *PowerTableDiff) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = PowerTableDiff{}
+
+	cr := cbg.NewCborReader(r)
+	var maj byte
+	var extra uint64
+	_ = maj
+	_ = extra
+	// (*t) (certs.PowerTableDiff) (slice)
+
+	maj, extra, err = cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+
+	if extra > 8192 {
+		return fmt.Errorf("(*t): array too large (%d)", extra)
+	}
+
+	if maj != cbg.MajArray {
+		return fmt.Errorf("expected cbor array")
+	}
+
+	if extra > 0 {
+		(*t) = make([]PowerTableDelta, extra)
+	}
+
+	for i := 0; i < int(extra); i++ {
+		{
+			var maj byte
+			var extra uint64
+			var err error
+			_ = maj
+			_ = extra
+			_ = err
+
+			{
+
+				if err := (*t)[i].UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling (*t)[i]: %w", err)
+				}
+
+			}
+
+		}
+	}
+	return nil
+}
+
 var lengthBufFinalityCertificate = []byte{134}
 
 func (t *FinalityCertificate) MarshalCBOR(w io.Writer) error {
@@ -227,7 +296,7 @@ func (t *FinalityCertificate) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.PowerTableDelta ([]certs.PowerTableDelta) (slice)
+	// t.PowerTableDelta (certs.PowerTableDiff) (slice)
 	if len(t.PowerTableDelta) > 8192 {
 		return xerrors.Errorf("Slice value in field t.PowerTableDelta was too long")
 	}
@@ -359,7 +428,7 @@ func (t *FinalityCertificate) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	// t.PowerTableDelta ([]certs.PowerTableDelta) (slice)
+	// t.PowerTableDelta (certs.PowerTableDiff) (slice)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {

--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -309,7 +309,7 @@ func (cs *Store) GetPowerTable(ctx context.Context, instance uint64) (gpbft.Powe
 	}
 
 	// Apply the diffs and return the result.
-	deltas := make([][]certs.PowerTableDelta, len(certificates))
+	deltas := make([]certs.PowerTableDiff, len(certificates))
 	for i := range certificates {
 		deltas[i] = certificates[i].PowerTableDelta
 	}

--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -102,7 +102,7 @@ func TestPutWrongPowerDelta(t *testing.T) {
 	cert := &certs.FinalityCertificate{
 		GPBFTInstance:    0,
 		SupplementalData: supp,
-		PowerTableDelta: []certs.PowerTableDelta{{
+		PowerTableDelta: certs.PowerTableDiff{{
 			ParticipantID: 0,
 			PowerDelta:    gpbft.NewStoragePower(10),
 			SigningKey:    []byte("testkey"),

--- a/gen/main.go
+++ b/gen/main.go
@@ -29,6 +29,7 @@ func main() {
 
 	err = gen.WriteTupleEncodersToFile("../certs/cbor_gen.go", "certs",
 		certs.PowerTableDelta{},
+		certs.PowerTableDiff{},
 		certs.FinalityCertificate{},
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/metric v1.28.0
 	go.uber.org/multierr v1.11.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.24.0
 	golang.org/x/sync v0.7.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
@@ -124,7 +125,6 @@ require (
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/fx v1.21.1 // indirect
 	go.uber.org/mock v0.4.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect

--- a/internal/powerstore/powerstore.go
+++ b/internal/powerstore/powerstore.go
@@ -1,0 +1,351 @@
+package powerstore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/filecoin-project/go-f3/certs"
+	"github.com/filecoin-project/go-f3/certstore"
+	"github.com/filecoin-project/go-f3/ec"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/internal/clock"
+	"github.com/filecoin-project/go-f3/manifest"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-datastore/query"
+	logging "github.com/ipfs/go-log/v2"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+var log = logging.Logger("f3/ohshitstore")
+
+var _ ec.Backend = (*Store)(nil)
+
+type Store struct {
+	ec.Backend
+
+	ds       datastore.Datastore
+	cs       *certstore.Store
+	manifest *manifest.Manifest
+
+	clock      clock.Clock
+	runningCtx context.Context
+	cancel     context.CancelFunc
+	errgrp     *errgroup.Group
+
+	lastStoredPt    gpbft.PowerEntries
+	lastStoredEpoch int64
+}
+
+const diffPrefix = "/powerdiffs"
+
+func New(ctx context.Context, ec ec.Backend, ds datastore.Datastore, cs *certstore.Store, manifest *manifest.Manifest) (*Store, error) {
+	runningCtx, ctxCancel := context.WithCancel(context.WithoutCancel(ctx))
+	errgrp, runningCtx := errgroup.WithContext(runningCtx)
+	return &Store{
+		Backend: ec,
+
+		ds:         namespace.Wrap(ds, datastore.NewKey("/ohshitstore")),
+		cs:         cs,
+		manifest:   manifest,
+		clock:      clock.GetClock(ctx),
+		runningCtx: runningCtx,
+		cancel:     ctxCancel,
+		errgrp:     errgrp,
+	}, nil
+}
+
+func (ps *Store) Start(ctx context.Context) error {
+	ps.errgrp.Go(func() (_err error) {
+		defer func() {
+			if err := recover(); err != nil {
+				_err = fmt.Errorf("PANIC in power store: %+v", err)
+				log.Errorw("PANIC in power store", "error", _err)
+			} else if _err != nil && ps.runningCtx.Err() == nil {
+				log.Errorw("power store exited early", "error", _err)
+			}
+		}()
+		return ps.run(ps.runningCtx)
+	})
+	return nil
+}
+
+func (ps *Store) Stop(ctx context.Context) error {
+	ps.cancel()
+	return ps.errgrp.Wait()
+}
+
+func (ps *Store) GetPowerTable(ctx context.Context, tsk gpbft.TipSetKey) (gpbft.PowerEntries, error) {
+	pt, ptErr := ps.Backend.GetPowerTable(ctx, tsk)
+	if ptErr == nil {
+		return pt, nil
+	}
+
+	ts, err := ps.GetTipset(ctx, tsk)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load tipset with key %s: %w", tsk, err)
+	}
+
+	targetEpoch := ts.Epoch()
+	baseEpoch, basePt, err := ps.basePowerTable(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load base power table: %w", err)
+	}
+
+	// We might fail here if we receive a decision from the network while trying to participate
+	// in an instance. In practice, we should be robust against this method failing _anyways_
+	// (e.g., if we're really behind or something).
+	//
+	// TODO: Consider searching backwards for a better base?
+	if targetEpoch < baseEpoch {
+		return nil, fmt.Errorf("target epoch %d before the latest F3 finalized base %d, move on already", targetEpoch, baseEpoch)
+	} else if targetEpoch == baseEpoch {
+		return basePt, nil
+	}
+
+	diffs := make([]certs.PowerTableDiff, 0, targetEpoch-baseEpoch)
+	for baseEpoch < targetEpoch {
+		baseEpoch++
+		diff, err := ps.get(ctx, baseEpoch)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, diff)
+	}
+	return certs.ApplyPowerTableDiffs(basePt, diffs...)
+}
+
+func (ps *Store) basePowerTable(ctx context.Context) (int64, gpbft.PowerEntries, error) {
+	baseEpoch := ps.manifest.BootstrapEpoch - ps.manifest.ECFinality
+	baseInstance := ps.manifest.InitialInstance
+	if lastCert := ps.cs.Latest(); lastCert != nil {
+		baseInstance = lastCert.GPBFTInstance + 1
+		if lastCert.GPBFTInstance > ps.manifest.InitialInstance+ps.manifest.CommitteeLookback {
+			baseCert, err := ps.cs.Get(ctx, lastCert.GPBFTInstance-ps.manifest.CommitteeLookback)
+			if err != nil {
+				return 0, nil, err
+			}
+			baseEpoch = baseCert.ECChain.Head().Epoch
+		}
+	}
+
+	basePt, err := ps.cs.GetPowerTable(ctx, baseInstance)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to load base power table: %w", err)
+	}
+	return baseEpoch, basePt, nil
+}
+
+func (ps *Store) mostRecentPowerTable(ctx context.Context) (int64, gpbft.PowerEntries, error) {
+	baseEpoch, basePt, err := ps.basePowerTable(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var diffs []certs.PowerTableDiff
+	for {
+		diff, err := ps.get(ctx, baseEpoch+1)
+		if err != nil {
+			if !errors.Is(err, datastore.ErrNotFound) {
+				log.Errorw("failed to lookup power table delta", "epoch", baseEpoch+1, "error", err)
+			}
+			break
+		}
+		diffs = append(diffs, diff)
+		baseEpoch++
+	}
+	basePt, err = certs.ApplyPowerTableDiffs(basePt, diffs...)
+	if err != nil {
+		return 0, nil, err
+	}
+	return baseEpoch, basePt, nil
+}
+
+func (ps *Store) put(ctx context.Context, epoch int64, diff certs.PowerTableDiff) error {
+	var buf bytes.Buffer
+	if err := diff.MarshalCBOR(&buf); err != nil {
+		return err
+	}
+	if err := ps.ds.Put(ctx, ps.dsKeyForDiff(epoch), buf.Bytes()); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ps *Store) f3HeadEpoch() int64 {
+	latestCert := ps.cs.Latest()
+	if latestCert == nil {
+		return ps.manifest.BootstrapEpoch - ps.manifest.ECFinality
+	}
+	return latestCert.ECChain.Head().Epoch
+}
+
+func (ps *Store) deleteAll(ctx context.Context) {
+	res, err := ps.ds.Query(ctx, query.Query{Prefix: diffPrefix})
+	if err != nil {
+		log.Errorw("failed to query for power-table diffs to delete", "error", err)
+		return
+	}
+	defer res.Close()
+	for r, ok := res.NextSync(); ok; r, ok = res.NextSync() {
+		if r.Error != nil {
+			log.Errorw("failed to query for power-table diffs to delete", "error", r.Error)
+			continue
+		}
+
+		if err := ps.ds.Delete(ctx, datastore.NewKey(r.Key)); err != nil {
+			log.Errorw("failed to delete power-table diffs to delete", "error", err)
+			return
+		}
+	}
+}
+
+func (ps *Store) run(ctx context.Context) error {
+	ticker := ps.clock.Ticker(2 * ps.manifest.ECPeriod)
+	defer ticker.Stop()
+
+	startThreshold := max(ps.manifest.ECFinality*3/2, 1)
+	stopThreshold := max(ps.manifest.ECFinality/2, 1)
+
+	var initialized bool
+	for ctx.Err() == nil {
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return nil
+		}
+
+		f3Head := ps.f3HeadEpoch()
+		ecHeadTs, err := ps.GetHead(ctx)
+		if err != nil {
+			log.Errorw("failed to get EC head", "error", err)
+			continue
+		}
+		ecHead := ecHeadTs.Epoch()
+
+		log := log.With(zap.Int64("ecHead", ecHead), zap.Int64("f3Head", f3Head))
+
+		if !initialized && f3Head > ecHead-stopThreshold {
+			initialized = true
+			log.Debugw("Clearing the OhShitStore on initialization because we're caught-up.")
+			ps.deleteAll(ctx)
+			ps.lastStoredEpoch = -1
+			ps.lastStoredPt = nil
+			continue
+		}
+		initialized = true
+
+		if ps.lastStoredPt == nil {
+			if f3Head > ecHead-startThreshold {
+				log.Debugw("skipping catch-up because we're within the start threshold")
+				continue
+			}
+			log.Warnf("Uh-oh, F3 has fallen behind EC by more than %d epochs! Engaging the OhShitStore™.", startThreshold)
+			ps.lastStoredEpoch, ps.lastStoredPt, err = ps.mostRecentPowerTable(ctx)
+			if err != nil {
+				log.Errorw("failed to lookup most recent power table", "error", err)
+				continue
+			}
+		} else if f3Head > ecHead-stopThreshold {
+			log.Infow("Stopping the OhShitStore™ because we're caught-up")
+			ps.deleteAll(ctx)
+			ps.lastStoredEpoch = -1
+			ps.lastStoredPt = nil
+			continue
+		}
+		if err := ps.advance(ctx, ecHead); err != nil {
+			log.Errorw("failed to store power tables", "last-stored", ps.lastStoredEpoch, "error", err)
+		}
+	}
+	return nil
+}
+
+func (ps *Store) advance(ctx context.Context, head int64) error {
+	targetEpoch := head - ps.manifest.ECFinality
+	// Only store tipsets before finality.
+	if ps.lastStoredEpoch >= targetEpoch {
+		return nil
+	}
+
+	ts, err := ps.GetTipsetByEpoch(ctx, targetEpoch)
+	if err != nil {
+		return err
+	}
+
+	// Due to null epochs, we may get a tipset from before the target. If we do, record the null
+	// epochs and move on.
+	if ts.Epoch() <= ps.lastStoredEpoch {
+		return ps.fillNullEpochs(ctx, targetEpoch)
+	}
+
+	// Load the tipsets in reverse order, then reverse. GetParent is O(1),
+	// GetTipsetByEpoch is O(N) where N is how far back in history we are.
+	chain := make([]ec.TipSet, 0, ts.Epoch()-ps.lastStoredEpoch)
+	chain = append(chain, ts)
+	for ts.Epoch() > ps.lastStoredEpoch+1 {
+		ts, err = ps.GetParent(ctx, ts)
+		if err != nil {
+			return err
+		}
+		// We might have skipped an epoch due to null tipsets.
+		if ts.Epoch() <= ps.lastStoredEpoch {
+			break
+		}
+		chain = append(chain, ts)
+	}
+	slices.Reverse(chain)
+
+	for _, ts := range chain {
+		// Fill in null epochs.
+		if err := ps.fillNullEpochs(ctx, ts.Epoch()-1); err != nil {
+			return err
+		}
+
+		pt, err := ps.Backend.GetPowerTable(ctx, ts.Key())
+		if err != nil {
+			return err
+		}
+		diff := certs.MakePowerTableDiff(ps.lastStoredPt, pt)
+		if err := ps.put(ctx, ps.lastStoredEpoch+1, diff); err != nil {
+			return err
+		}
+		ps.lastStoredEpoch++
+		ps.lastStoredPt = pt
+	}
+
+	return ps.fillNullEpochs(ctx, targetEpoch)
+}
+
+func (ps *Store) fillNullEpochs(ctx context.Context, until int64) error {
+	for ; ps.lastStoredEpoch < until; ps.lastStoredEpoch++ {
+		if err := ps.put(ctx, ps.lastStoredEpoch+1, nil); err != nil {
+			return fmt.Errorf("failed to record power delta for null tipset at epoch %d", ps.lastStoredEpoch+1)
+		}
+	}
+	return nil
+}
+
+func (ps *Store) get(ctx context.Context, epoch int64) (certs.PowerTableDiff, error) {
+	if epoch < 0 {
+		return nil, fmt.Errorf("negative epoch (%d) cannot have a power table", epoch)
+	}
+	buf, err := ps.ds.Get(ctx, ps.dsKeyForDiff(epoch))
+	if err != nil {
+		return nil, err
+	}
+	var diff certs.PowerTableDiff
+	if err := diff.UnmarshalCBOR(bytes.NewReader(buf)); err != nil {
+		return nil, err
+	}
+
+	return diff, nil
+}
+
+func (ps *Store) dsKeyForDiff(epoch int64) datastore.Key {
+	return datastore.NewKey(fmt.Sprintf("%s/%016X", diffPrefix, epoch))
+}

--- a/internal/powerstore/powerstore_test.go
+++ b/internal/powerstore/powerstore_test.go
@@ -1,0 +1,157 @@
+package powerstore_test
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-f3/certstore"
+	"github.com/filecoin-project/go-f3/ec"
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/internal/clock"
+	"github.com/filecoin-project/go-f3/internal/powerstore"
+	"github.com/filecoin-project/go-f3/manifest"
+
+	"github.com/ipfs/go-datastore"
+	ds_sync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+type forgetfulEC struct {
+	*ec.FakeEC
+
+	ecFinality int64
+}
+
+// GetPowerTable implements ec.Backend.
+func (f *forgetfulEC) GetPowerTable(ctx context.Context, tsk gpbft.TipSetKey) (gpbft.PowerEntries, error) {
+	ts, err := f.GetTipset(ctx, tsk)
+	if err != nil {
+		return nil, err
+	}
+	head, err := f.GetHead(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if ts.Epoch() < head.Epoch()-2*f.ecFinality {
+		return nil, fmt.Errorf("oops, we forgot that power table, head %d, epoch %d", head.Epoch(), ts.Epoch())
+	}
+	pt, err := f.FakeEC.GetPowerTable(ctx, tsk)
+	if err != nil {
+		return nil, err
+	}
+
+	// make sure power changes over time by adding the current epoch to the first entry.
+	pt = slices.Clone(pt)
+	newPower := gpbft.NewStoragePower(ts.Epoch())
+	pt[0].Power = newPower.Add(newPower, pt[0].Power)
+
+	return pt, nil
+}
+
+var _ ec.Backend = (*forgetfulEC)(nil)
+
+var basePowerTable = gpbft.PowerEntries{
+	{ID: 1, Power: gpbft.NewStoragePower(50), PubKey: gpbft.PubKey("1")},
+	{ID: 3, Power: gpbft.NewStoragePower(10), PubKey: gpbft.PubKey("2")},
+	{ID: 4, Power: gpbft.NewStoragePower(4), PubKey: gpbft.PubKey("3")},
+}
+
+func TestPowerStore(t *testing.T) {
+	ctx, clk := clock.WithMockClock(context.Background())
+
+	m := manifest.LocalDevnetManifest()
+
+	ec := &forgetfulEC{
+		FakeEC:     ec.NewFakeEC(ctx, 1234, m.BootstrapEpoch, m.ECPeriod, basePowerTable, true),
+		ecFinality: m.ECFinality,
+	}
+
+	head, err := ec.GetHead(ctx)
+	require.NoError(t, err)
+	require.Equal(t, m.BootstrapEpoch, head.Epoch())
+
+	bsTs, err := ec.GetTipsetByEpoch(ctx, m.BootstrapEpoch-m.ECFinality)
+	require.NoError(t, err)
+
+	pt, err := ec.GetPowerTable(ctx, bsTs.Key())
+	require.NoError(t, err)
+
+	ds := ds_sync.MutexWrap(datastore.NewMapDatastore())
+	cs, err := certstore.CreateStore(ctx, ds, m.InitialInstance, pt)
+	require.NoError(t, err)
+
+	ps, err := powerstore.New(ctx, ec, ds, cs, m)
+	require.NoError(t, err)
+	require.NoError(t, ps.Start(ctx))
+	t.Cleanup(func() { require.NoError(t, ps.Stop(context.Background())) })
+
+	oldTs, err := ec.GetTipsetByEpoch(ctx, 200)
+	require.NoError(t, err)
+
+	expectedPt, err := ec.GetPowerTable(ctx, oldTs.Key())
+	require.NoError(t, err)
+
+	clk.Add(m.ECPeriod * time.Duration(m.ECFinality/2))
+	time.Sleep(10 * time.Millisecond)
+	clk.Add(m.ECPeriod * time.Duration(m.ECFinality))
+
+	head, err = ec.GetHead(ctx)
+	require.NoError(t, err)
+	require.Equal(t, m.BootstrapEpoch+(3*m.ECFinality)/2, head.Epoch())
+
+	_, err = ec.GetPowerTable(ctx, oldTs.Key())
+	require.Error(t, err)
+
+	actualPt, err := ps.GetPowerTable(ctx, oldTs.Key())
+	require.NoError(t, err)
+	require.Equal(t, expectedPt, actualPt)
+
+	// Stop/restart.
+	require.NoError(t, ps.Stop(ctx))
+	ps, err = powerstore.New(ctx, ec, ds, cs, m)
+	require.NoError(t, err)
+	require.NoError(t, ps.Start(ctx))
+	time.Sleep(10 * time.Millisecond)
+
+	// Advance time a bit making sure we can still get old power tables.
+	for i := 0; i < 5; i++ {
+		head, err = ec.GetHead(ctx)
+		require.NoError(t, err)
+		oldTs2, err := ec.GetTipsetByEpoch(ctx, head.Epoch()-m.ECFinality-1)
+		require.NoError(t, err)
+		expectedPt2, err := ps.GetPowerTable(ctx, oldTs2.Key())
+		require.NoError(t, err)
+
+		clk.Add(m.ECPeriod * time.Duration(m.ECFinality))
+		time.Sleep(10 * time.Millisecond)
+
+		// We should still be able to get the og old power table.
+		actualPt, err = ps.GetPowerTable(ctx, oldTs.Key())
+		require.NoError(t, err)
+		require.Equal(t, expectedPt, actualPt)
+
+		// And the bootstrap power table
+		actualPt, err = ps.GetPowerTable(ctx, bsTs.Key())
+		require.NoError(t, err)
+		require.Equal(t, pt, actualPt)
+
+		// And the "new" old power table.
+		actualPt2, err := ps.GetPowerTable(ctx, oldTs2.Key())
+		require.NoError(t, err)
+		require.Equal(t, expectedPt2, actualPt2)
+
+		// Which EC has now forgotten.
+		_, err = ec.GetPowerTable(ctx, oldTs2.Key())
+		require.Error(t, err)
+	}
+
+	// But if we go _way_ back to before F3 finality, it fails.
+
+	veryEarlyTs, err := ec.GetTipsetByEpoch(ctx, 50)
+	require.NoError(t, err)
+	_, err = ps.GetPowerTable(ctx, veryEarlyTs.Key())
+	require.Error(t, err)
+}


### PR DESCRIPTION
If we fall more than 1.5 EC finality behind, this will start storing power deltas up to EC finality (checking every 1/4 EC finalities).

NOTE: this records power deltas by-epoch. That should be safe enough for now but I'd like to switch to tipset keys before mainnet launch in case.

I implemented this as a completely separate service so the runner doesn't need to know that state can be garbage collected (and so we can keep it running even if we pause GPBFT). Although... we might not want to?

fixes #479