### PR TITLE
Engague the OhShitStore based on the f3Base, not the head

### DIFF
--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -297,7 +297,7 @@ func (cs *Store) GetPowerTable(ctx context.Context, instance uint64) (gpbft.Powe
 
 	powerTable, err := cs.readPowerTable(ctx, startInstance)
 	if err != nil {
-		return nil, fmt.Errorf("failed fo find expected power table for instance %d: %w", startInstance, err)
+		return nil, fmt.Errorf("failed to find expected power table for instance %d: %w", startInstance, err)
 	}
 	if startInstance == instance {
 		return powerTable, nil
@@ -389,8 +389,9 @@ func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error
 		return fmt.Errorf("putting the cert: %w", err)
 	}
 
-	if cert.GPBFTInstance%cs.powerTableFrequency == 0 {
-		if err := cs.putPowerTable(ctx, cert.GPBFTInstance, cs.latestPowerTable); err != nil {
+	// The new power table is the power table to validate the _next_ instance.
+	if (cert.GPBFTInstance+1)%cs.powerTableFrequency == 0 {
+		if err := cs.putPowerTable(ctx, cert.GPBFTInstance+1, newPowerTable); err != nil {
 			return err
 		}
 	}

--- a/internal/powerstore/powerstore.go
+++ b/internal/powerstore/powerstore.go
@@ -200,7 +200,7 @@ func (ps *Store) deleteAll(ctx context.Context) {
 
 		if err := ps.ds.Delete(ctx, datastore.NewKey(r.Key)); err != nil {
 			log.Errorw("failed to delete power-table diffs to delete", "error", err)
-			return
+			continue
 		}
 	}
 }

--- a/internal/powerstore/powerstore_test.go
+++ b/internal/powerstore/powerstore_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
@@ -15,6 +16,7 @@ import (
 	"github.com/filecoin-project/go-f3/manifest"
 
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
 	ds_sync "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/require"
 )
@@ -116,42 +118,138 @@ func TestPowerStore(t *testing.T) {
 	require.NoError(t, ps.Start(ctx))
 	time.Sleep(10 * time.Millisecond)
 
-	// Advance time a bit making sure we can still get old power tables.
-	for i := 0; i < 5; i++ {
-		head, err = ec.GetHead(ctx)
-		require.NoError(t, err)
-		oldTs2, err := ec.GetTipsetByEpoch(ctx, head.Epoch()-m.ECFinality-1)
-		require.NoError(t, err)
-		expectedPt2, err := ps.GetPowerTable(ctx, oldTs2.Key())
-		require.NoError(t, err)
+	// We should still be able to get the og old power table.
+	actualPt, err = ps.GetPowerTable(ctx, oldTs.Key())
+	require.NoError(t, err)
+	require.Equal(t, expectedPt, actualPt)
 
-		clk.Add(m.ECPeriod * time.Duration(m.ECFinality))
-		time.Sleep(10 * time.Millisecond)
-
-		// We should still be able to get the og old power table.
-		actualPt, err = ps.GetPowerTable(ctx, oldTs.Key())
-		require.NoError(t, err)
-		require.Equal(t, expectedPt, actualPt)
-
-		// And the bootstrap power table
-		actualPt, err = ps.GetPowerTable(ctx, bsTs.Key())
-		require.NoError(t, err)
-		require.Equal(t, pt, actualPt)
-
-		// And the "new" old power table.
-		actualPt2, err := ps.GetPowerTable(ctx, oldTs2.Key())
-		require.NoError(t, err)
-		require.Equal(t, expectedPt2, actualPt2)
-
-		// Which EC has now forgotten.
-		_, err = ec.GetPowerTable(ctx, oldTs2.Key())
-		require.Error(t, err)
-	}
+	// And the bootstrap power table
+	actualPt, err = ps.GetPowerTable(ctx, bsTs.Key())
+	require.NoError(t, err)
+	require.Equal(t, pt, actualPt)
 
 	// But if we go _way_ back to before F3 finality, it fails.
-
 	veryEarlyTs, err := ec.GetTipsetByEpoch(ctx, 50)
 	require.NoError(t, err)
 	_, err = ps.GetPowerTable(ctx, veryEarlyTs.Key())
 	require.Error(t, err)
+
+	// Ok, now we're going to try falling behind and catching up a few times.
+
+	isDsEmpty := func() bool {
+		res, err := ds.Query(ctx, query.Query{Prefix: "/ohshitstore"})
+		require.NoError(t, err)
+		defer res.Close()
+		_, ok := res.NextSync()
+		return !ok
+	}
+
+	epochsPerCert := 1
+	for i := 0; i < 3; i++ {
+		// Advance a few finalities.
+		for j := 0; j < 3; j++ {
+			clk.Add(m.ECPeriod * time.Duration(m.ECFinality))
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		// We should have power diffs in the datastore.
+		require.False(t, isDsEmpty())
+
+		// Now catch up. I need the current power base epoch to be within 0.5
+		// finality of head.
+		head, err := ec.GetHead(ctx)
+		require.NoError(t, err)
+		oldEnough, err := ec.GetTipsetByEpoch(ctx, head.Epoch()-m.ECFinality/3)
+		require.NoError(t, err)
+
+		advanceF3(t, m, ps, cs, oldEnough.Epoch(), epochsPerCert)
+		clk.Add(4 * m.ECPeriod)
+
+		// On the first two passes, we should eventually clear the datastore. On the last
+		// pass, base is 990 epochs behind which is more than the max 450 to cleanup. So we
+		// need to advance a bit more with smaller instances. That'll bring the base back
+		// into a reasonable range.
+		if i == 2 {
+			clk.Add(m.ECPeriod * time.Duration(m.ECFinality))
+			advanceF3(t, m, ps, cs, oldEnough.Epoch()+m.ECFinality, 10)
+			clk.Add(4 * m.ECPeriod)
+		}
+		require.Eventually(t, func() bool { return isDsEmpty() }, 10*time.Second, 10*time.Millisecond)
+
+		// by 1, 10, then 100 (well, 99).
+		epochsPerCert *= 10
+	}
+
+}
+
+func advanceF3(t *testing.T, m *manifest.Manifest, ps *powerstore.Store, cs *certstore.Store, until int64, epochsPerCert int) {
+	instance := uint64(0)
+	base := m.BootstrapEpoch - m.ECFinality
+	if latest := cs.Latest(); latest != nil {
+		instance = latest.GPBFTInstance + 1
+		base = latest.ECChain.Head().Epoch
+	}
+
+	ctx := context.Background()
+	ts, err := ps.GetTipsetByEpoch(ctx, until)
+	require.NoError(t, err)
+
+	chain := make([]ec.TipSet, 0, ts.Epoch())
+	chain = append(chain, ts)
+	for ts.Epoch() > base {
+		ts, err = ps.GetParent(ctx, ts)
+		require.NoError(t, err)
+		chain = append(chain, ts)
+	}
+	slices.Reverse(chain)
+
+	if len(chain) == 0 {
+		return
+	}
+
+	require.Equal(t, base, chain[0].Epoch())
+
+	var gpbftChain gpbft.ECChain
+	for _, ts := range chain {
+		pt, err := ps.GetPowerTable(ctx, ts.Key())
+		require.NoError(t, err)
+		ptcid, err := certs.MakePowerTableCID(pt)
+		require.NoError(t, err)
+		gpbftChain = append(gpbftChain, gpbft.TipSet{
+			Epoch:      ts.Epoch(),
+			Key:        ts.Key(),
+			PowerTable: ptcid,
+		})
+	}
+
+	basePt, err := cs.GetPowerTable(ctx, instance)
+	require.NoError(t, err)
+	for len(gpbftChain) > 1 {
+		count := min(len(gpbftChain), 1+epochsPerCert, gpbft.ChainMaxLen)
+		newChain := gpbftChain[:count]
+
+		nextPt := basePt
+		if instance >= m.InitialInstance+m.CommitteeLookback {
+			ptCert, err := cs.Get(ctx, instance-m.CommitteeLookback)
+			require.NoError(t, err)
+			nextPt, err = ps.GetPowerTable(ctx, ptCert.ECChain.Head().Key)
+			require.NoError(t, err)
+		}
+		ptCid, err := certs.MakePowerTableCID(nextPt)
+		require.NoError(t, err)
+
+		supp := gpbft.SupplementalData{PowerTable: ptCid}
+
+		cert := &certs.FinalityCertificate{
+			GPBFTInstance:    instance,
+			ECChain:          newChain,
+			SupplementalData: supp,
+			PowerTableDelta:  certs.MakePowerTableDiff(basePt, nextPt),
+		}
+		require.NoError(t, cs.Put(ctx, cert))
+
+		basePt = nextPt
+		gpbftChain = gpbftChain[count-1:]
+		instance++
+	}
 }

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -95,7 +95,7 @@ func TestF3FailRecover(t *testing.T) {
 			switch op {
 			case "put", "batch-put":
 				failDsWrite.Store(false)
-				return fmt.Errorf("FAILURE!")
+				return fmt.Errorf("Intentional error for testing, please ignore!")
 			}
 		}
 		return nil

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -145,7 +145,7 @@ func TestF3DynamicManifest_WithRebootstrap(t *testing.T) {
 	env.addParticipants(&env.manifest, []gpbft.ActorID{2, 3}, big.NewInt(1), false)
 	env.updateManifest()
 
-	env.waitForManifestChange(prev, 35*time.Second)
+	env.waitForManifestChange(prev, 60*time.Second)
 
 	// check that it rebootstrapped and the number of instances is below prevInstance
 	require.True(t, env.nodes[0].currentGpbftInstance() < prevInstance)


### PR DESCRIPTION
The certstore stores the _base_ power table, not "future" power tables. So we need to keep EC power tables around until we've passed the instance lookback.

Also, fix an issue in the certstore where we were storing power tables one epoch after we should have.