### PR TITLE
Remove releaser custom secret from CI

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -15,8 +15,3 @@ concurrency:
 jobs:
   releaser:
     uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
-    with:
-      # Use default GitHub actions secrets until a UCI-specific secret is created.
-      # See: https://github.com/filecoin-project/go-f3/issues/449
-      # UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
-      UCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems later version of unified CI have fixed the missing input to releaser Github actions workflow. The reason custom releaser secret exists is to allow release to trigger other work flows _if_ the custom secret is set.

F3 does not have that need, and the default behaviour falls back on the built-in github secrets token. Hence, the removal of custom secret config altogether.

See:
 - https://github.com/ipdxco/unified-github-workflows/commit/6e469c704d60a96626da7d2131ae46859d311a67

Fixes #449