### PR TITLE
test: verify that we can get the power table for an instance

### DIFF
--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -487,6 +487,8 @@ func testPowerInner(t *testing.T, firstInstance uint64) {
 		}
 		err := cs.Put(ctx, cert)
 		require.NoError(t, err)
+		_, err = cs.GetPowerTable(ctx, i+1)
+		require.NoError(t, err)
 	}
 
 	{
@@ -497,6 +499,8 @@ func testPowerInner(t *testing.T, firstInstance uint64) {
 		}
 		err = cs.Put(ctx, cert)
 		require.NoError(t, err)
+		_, err = cs.GetPowerTable(ctx, cert.GPBFTInstance+1)
+		require.NoError(t, err)
 	}
 
 	for i := uint64(9); i < 13; i++ {
@@ -505,6 +509,8 @@ func testPowerInner(t *testing.T, firstInstance uint64) {
 			SupplementalData: gpbft.SupplementalData{PowerTable: newPtCid},
 		}
 		err := cs.Put(ctx, cert)
+		require.NoError(t, err)
+		_, err = cs.GetPowerTable(ctx, i+1)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
No matter when we look. Previously, we had a "dead" instance immediately after we should have stored the power table (fixed in #490).