### PR TITLE
Implement nil manifest unmarshalling

### DIFF
--- a/cmd/f3/manifest.go
+++ b/cmd/f3/manifest.go
@@ -229,9 +229,6 @@ func loadManifest(path string) (*manifest.Manifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("opening %s to load manifest: %w", path, err)
 	}
-	defer f.Close()
-	var m manifest.Manifest
-
-	err = m.Unmarshal(f)
-	return &m, err
+	defer func() { _ = f.Close() }()
+	return manifest.Unmarshal(f)
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -164,12 +164,9 @@ func (m *Manifest) Marshal() ([]byte, error) {
 	return b, nil
 }
 
-func (m *Manifest) Unmarshal(r io.Reader) error {
-	err := json.NewDecoder(r).Decode(&m)
-	if err != nil {
-		return fmt.Errorf("decoding JSON: %w", err)
-	}
-	return nil
+func Unmarshal(r io.Reader) (*Manifest, error) {
+	var m *Manifest
+	return m, json.NewDecoder(r).Decode(&m)
 }
 
 func (m *Manifest) DatastorePrefix() datastore.Key {


### PR DESCRIPTION
Move manifest unmarshalling to a package level function that can correctly unmarshal "null" JSON string as `nil` manifest pointer.

Add tests that assert expected behaviour.
