### PR TITLE
Manifest: Separate sections per subsystem

### DIFF
--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -113,7 +113,7 @@ var runCmd = cli.Command{
 		id := c.Uint64("id")
 		signingBackend.Allow(int(id))
 
-		ec := ec.NewFakeEC(ctx, 1, m.BootstrapEpoch, m.ECPeriod, initialPowerTable, true)
+		ec := ec.NewFakeEC(ctx, 1, m.BootstrapEpoch, m.EC.Period, initialPowerTable, true)
 
 		module, err := f3.New(ctx, mprovider, ds, h, ps, signingBackend, ec)
 		if err != nil {

--- a/f3.go
+++ b/f3.go
@@ -142,11 +142,11 @@ func (m *F3) computeBootstrapDelay(manifest *manifest.Manifest) (time.Duration, 
 		return 0, nil
 	}
 	epochDelay := manifest.BootstrapEpoch - currentEpoch
-	start := ts.Timestamp().Add(time.Duration(epochDelay) * manifest.ECPeriod)
+	start := ts.Timestamp().Add(time.Duration(epochDelay) * manifest.EC.Period)
 	delay := m.clock.Until(start)
 	// Add additional delay to skip over null epochs. That way we wait the full 900 epochs.
 	if delay <= 0 {
-		delay = manifest.ECPeriod + delay%manifest.ECPeriod
+		delay = manifest.EC.Period + delay%manifest.EC.Period
 	}
 	return delay, nil
 }
@@ -327,7 +327,7 @@ func (m *F3) resumeInternal(ctx context.Context) error {
 		certClient := certexchange.Client{
 			Host:           m.host,
 			NetworkName:    m.manifest.NetworkName,
-			RequestTimeout: m.manifest.ClientRequestTimeout,
+			RequestTimeout: m.manifest.CertificateExchange.ClientRequestTimeout,
 		}
 		cs, err := openCertstore(m.runningCtx, mPowerEc, m.ds, m.manifest, certClient)
 		if err != nil {
@@ -350,7 +350,7 @@ func (m *F3) resumeInternal(ctx context.Context) error {
 
 	m.certserv = &certexchange.Server{
 		NetworkName:    m.manifest.NetworkName,
-		RequestTimeout: m.manifest.ServerRequestTimeout,
+		RequestTimeout: m.manifest.CertificateExchange.ServerRequestTimeout,
 		Host:           m.host,
 		Store:          m.cs,
 	}
@@ -362,13 +362,13 @@ func (m *F3) resumeInternal(ctx context.Context) error {
 		Client: certexchange.Client{
 			Host:           m.host,
 			NetworkName:    m.manifest.NetworkName,
-			RequestTimeout: m.manifest.ClientRequestTimeout,
+			RequestTimeout: m.manifest.CertificateExchange.ClientRequestTimeout,
 		},
 		Store:               m.cs,
 		SignatureVerifier:   m.verifier,
-		InitialPollInterval: m.manifest.ECPeriod,
-		MaximumPollInterval: m.manifest.MaximumPollInterval,
-		MinimumPollInterval: m.manifest.MinimumPollInterval,
+		InitialPollInterval: m.manifest.EC.Period,
+		MaximumPollInterval: m.manifest.CertificateExchange.MaximumPollInterval,
+		MinimumPollInterval: m.manifest.CertificateExchange.MinimumPollInterval,
 	}
 	if err := m.certsub.Start(ctx); err != nil {
 		return err

--- a/internal/powerstore/powerstore.go
+++ b/internal/powerstore/powerstore.go
@@ -121,12 +121,12 @@ func (ps *Store) GetPowerTable(ctx context.Context, tsk gpbft.TipSetKey) (gpbft.
 }
 
 func (ps *Store) f3PowerBase(ctx context.Context) (int64, uint64, error) {
-	baseEpoch := ps.manifest.BootstrapEpoch - ps.manifest.ECFinality
+	baseEpoch := ps.manifest.BootstrapEpoch - ps.manifest.EC.Finality
 	baseInstance := ps.manifest.InitialInstance
 	if lastCert := ps.cs.Latest(); lastCert != nil {
 		baseInstance = lastCert.GPBFTInstance + 1
-		if lastCert.GPBFTInstance > ps.manifest.InitialInstance+ps.manifest.CommitteeLookback {
-			baseCert, err := ps.cs.Get(ctx, lastCert.GPBFTInstance-ps.manifest.CommitteeLookback)
+		if lastCert.GPBFTInstance > ps.manifest.InitialInstance+ps.manifest.EC.CommitteeLookback {
+			baseCert, err := ps.cs.Get(ctx, lastCert.GPBFTInstance-ps.manifest.EC.CommitteeLookback)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -206,11 +206,11 @@ func (ps *Store) deleteAll(ctx context.Context) {
 }
 
 func (ps *Store) run(ctx context.Context) error {
-	ticker := ps.clock.Ticker(2 * ps.manifest.ECPeriod)
+	ticker := ps.clock.Ticker(2 * ps.manifest.EC.Period)
 	defer ticker.Stop()
 
-	startThreshold := max(ps.manifest.ECFinality*3/2, 1)
-	stopThreshold := max(ps.manifest.ECFinality/2, 1)
+	startThreshold := max(ps.manifest.EC.Finality*3/2, 1)
+	stopThreshold := max(ps.manifest.EC.Finality/2, 1)
 
 	var initialized bool
 	for ctx.Err() == nil {
@@ -269,7 +269,7 @@ func (ps *Store) run(ctx context.Context) error {
 }
 
 func (ps *Store) advance(ctx context.Context, head int64) error {
-	targetEpoch := head - ps.manifest.ECFinality
+	targetEpoch := head - ps.manifest.EC.Finality
 	// Only store tipsets before finality.
 	if ps.lastStoredEpoch >= targetEpoch {
 		return nil

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -19,10 +19,10 @@ const VersionCapability = 1
 var (
 	// Default configuration for the EC Backend
 	DefaultEcConfig = EcConfig{
-		ECFinality:        900,
+		Finality:          900,
 		CommitteeLookback: 10,
-		ECPeriod:          30 * time.Second,
-		ECDelayMultiplier: 2.,
+		Period:            30 * time.Second,
+		DelayMultiplier:   2.,
 		// MaxBackoff is 15min given default params
 		BaseDecisionBackoffTable: []float64{1.3, 1.69, 2.2, 2.86, 3.71, 4.83, 6.27, 7.5},
 	}
@@ -42,8 +42,8 @@ var (
 	DefaultCxConfig = CxConfig{
 		ClientRequestTimeout: 10 * time.Second,
 		ServerRequestTimeout: time.Minute,
-		MinimumPollInterval:  DefaultEcConfig.ECPeriod,
-		MaximumPollInterval:  4 * DefaultEcConfig.ECPeriod,
+		MinimumPollInterval:  DefaultEcConfig.Period,
+		MaximumPollInterval:  4 * DefaultEcConfig.Period,
 	}
 )
 
@@ -78,21 +78,21 @@ type GpbftConfig struct {
 
 type EcConfig struct {
 	// The delay between tipsets.
-	ECPeriod time.Duration
+	Period time.Duration
 	// Number of epochs required to reach EC defined finality
-	ECFinality int64
-	// The multiplier on top of the ECPeriod of the time we will wait before starting a new instance,
+	Finality int64
+	// The multiplier on top of the Period of the time we will wait before starting a new instance,
 	// referencing the timestamp of the latest finalized tipset.
-	ECDelayMultiplier float64
-	// Table of incremental multipliers to backoff in units of ECDelay in case of base decisions
+	DelayMultiplier float64
+	// Table of incremental multipliers to backoff in units of Delay in case of base decisions
 	BaseDecisionBackoffTable []float64
 	CommitteeLookback        uint64
 }
 
 func (e *EcConfig) Equal(o *EcConfig) bool {
-	return e.ECPeriod == o.ECPeriod &&
-		e.ECFinality == o.ECFinality &&
-		e.ECDelayMultiplier == o.ECDelayMultiplier &&
+	return e.Period == o.Period &&
+		e.Finality == o.Finality &&
+		e.DelayMultiplier == o.DelayMultiplier &&
 		e.CommitteeLookback == o.CommitteeLookback &&
 		slices.Equal(e.BaseDecisionBackoffTable, o.BaseDecisionBackoffTable)
 }
@@ -115,11 +115,11 @@ type Manifest struct {
 	// InitialPowerTable specifies the optional CID of the initial power table
 	InitialPowerTable *cid.Cid
 	// Config parameters for gpbft
-	GpbftConfig
+	Gpbft GpbftConfig
 	// EC-specific parameters
-	EcConfig
+	EC EcConfig
 	// Certificate Exchange specific parameters
-	CxConfig
+	CertificateExchange CxConfig
 }
 
 func (m *Manifest) Equal(o *Manifest) bool {
@@ -132,9 +132,9 @@ func (m *Manifest) Equal(o *Manifest) bool {
 		m.BootstrapEpoch == o.BootstrapEpoch &&
 		m.IgnoreECPower == o.IgnoreECPower &&
 		m.ExplicitPower.Equal(o.ExplicitPower) &&
-		m.GpbftConfig == o.GpbftConfig &&
-		m.EcConfig.Equal(&o.EcConfig) &&
-		m.CxConfig == o.CxConfig &&
+		m.Gpbft == o.Gpbft &&
+		m.EC.Equal(&o.EC) &&
+		m.CertificateExchange == o.CertificateExchange &&
 		m.ProtocolVersion == o.ProtocolVersion
 
 }
@@ -143,12 +143,12 @@ func LocalDevnetManifest() *Manifest {
 	rng := make([]byte, 4)
 	_, _ = rand.Read(rng)
 	m := &Manifest{
-		ProtocolVersion: 1,
-		NetworkName:     gpbft.NetworkName(fmt.Sprintf("localnet-%X", rng)),
-		BootstrapEpoch:  1000,
-		EcConfig:        DefaultEcConfig,
-		GpbftConfig:     DefaultGpbftConfig,
-		CxConfig:        DefaultCxConfig,
+		ProtocolVersion:     1,
+		NetworkName:         gpbft.NetworkName(fmt.Sprintf("localnet-%X", rng)),
+		BootstrapEpoch:      1000,
+		EC:                  DefaultEcConfig,
+		Gpbft:               DefaultGpbftConfig,
+		CertificateExchange: DefaultCxConfig,
 	}
 	return m
 }
@@ -182,15 +182,15 @@ func PubSubTopicFromNetworkName(nn gpbft.NetworkName) string {
 }
 
 func (m *Manifest) GpbftOptions() []gpbft.Option {
-	if m.GpbftConfig == (GpbftConfig{}) {
+	if m.Gpbft == (GpbftConfig{}) {
 		return DefaultGpbftOptions
 	}
 	var opts []gpbft.Option
-	if m.Delta != 0 {
-		opts = append(opts, gpbft.WithDelta(m.Delta))
+	if m.Gpbft.Delta != 0 {
+		opts = append(opts, gpbft.WithDelta(m.Gpbft.Delta))
 	}
-	opts = append(opts, gpbft.WithDeltaBackOffExponent(m.DeltaBackOffExponent))
-	opts = append(opts, gpbft.WithMaxLookaheadRounds(m.MaxLookaheadRounds))
+	opts = append(opts, gpbft.WithDeltaBackOffExponent(m.Gpbft.DeltaBackOffExponent))
+	opts = append(opts, gpbft.WithMaxLookaheadRounds(m.Gpbft.MaxLookaheadRounds))
 
 	return opts
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -27,19 +27,19 @@ var base = manifest.Manifest{
 			PubKey: gpbft.PubKey{1},
 		},
 	},
-	GpbftConfig: manifest.GpbftConfig{
+	Gpbft: manifest.GpbftConfig{
 		Delta:                10,
 		DeltaBackOffExponent: 0.2,
 		MaxLookaheadRounds:   10,
 	},
-	EcConfig: manifest.EcConfig{
-		ECFinality:               900,
+	EC: manifest.EcConfig{
+		Finality:                 900,
 		CommitteeLookback:        5,
-		ECDelayMultiplier:        2.0,
-		ECPeriod:                 30 * time.Second,
+		DelayMultiplier:          2.0,
+		Period:                   30 * time.Second,
 		BaseDecisionBackoffTable: []float64{1.3, 1.69, 2.2, 2.86, 3.71, 4.83, 6.27, 8.16, 10.6, 13.79, 15.},
 	},
-	CxConfig: manifest.CxConfig{
+	CertificateExchange: manifest.CxConfig{
 		ClientRequestTimeout: 10 * time.Second,
 		ServerRequestTimeout: time.Minute,
 		MinimumPollInterval:  30 * time.Second,

--- a/store.go
+++ b/store.go
@@ -27,7 +27,7 @@ func openCertstore(ctx context.Context, ec ec.Backend, ds datastore.Datastore,
 		return nil, err
 	}
 
-	ts, err := ec.GetTipsetByEpoch(ctx, m.BootstrapEpoch-m.ECFinality)
+	ts, err := ec.GetTipsetByEpoch(ctx, m.BootstrapEpoch-m.EC.Finality)
 	var initialPowerTable gpbft.PowerEntries
 
 	if err == nil {
@@ -38,7 +38,7 @@ func openCertstore(ctx context.Context, ec ec.Backend, ds datastore.Datastore,
 	} else if m.InitialPowerTable != nil {
 		log.Errorw("could not get initial power table from EC, trying finality exchange", "error", err)
 		initialPowerTable, err = certexchange.FindInitialPowerTable(ctx, certClient,
-			*m.InitialPowerTable, m.ECPeriod)
+			*m.InitialPowerTable, m.EC.Period)
 
 		if err != nil {
 			log.Errorw("could not get initial power table from finality exchange", "error", err)

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -65,7 +65,7 @@ func TestF3PauseResumeCatchup(t *testing.T) {
 	env.waitForInstanceNumber(resumeInstance, 30*time.Second, false)
 
 	// Wait until we're far enough that pure GPBFT catchup should be impossible.
-	targetInstance := resumeInstance + env.manifest.CommitteeLookback
+	targetInstance := resumeInstance + env.manifest.EC.CommitteeLookback
 	env.waitForInstanceNumber(targetInstance, 30*time.Second, false)
 
 	pausedInstance := env.nodes[2].currentGpbftInstance()
@@ -200,21 +200,20 @@ var base = manifest.Manifest{
 	BootstrapEpoch:  950,
 	InitialInstance: 0,
 	NetworkName:     gpbft.NetworkName("f3-test/0"),
-	GpbftConfig: manifest.GpbftConfig{
+	Gpbft: manifest.GpbftConfig{
 		Delta:                3 * time.Second,
 		DeltaBackOffExponent: 2.,
 		MaxLookaheadRounds:   5,
 	},
-	// EcConfig:        manifest.DefaultEcConfig,
-	EcConfig: manifest.EcConfig{
-		ECFinality:        10,
+	EC: manifest.EcConfig{
+		Finality:          10,
 		CommitteeLookback: 5,
 		// increased delay and period to accelerate test times.
-		ECPeriod:                 30 * time.Second,
-		ECDelayMultiplier:        1.0,
+		Period:                   30 * time.Second,
+		DelayMultiplier:          1.0,
 		BaseDecisionBackoffTable: []float64{1., 1.2},
 	},
-	CxConfig: manifest.DefaultCxConfig}
+	CertificateExchange: manifest.DefaultCxConfig}
 
 type testNode struct {
 	e         *testEnv
@@ -382,7 +381,7 @@ func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) *testEnv {
 		})
 	}
 	env.manifest = m
-	env.ec = ec.NewFakeEC(ctx, 1, m.BootstrapEpoch+m.ECFinality, m.ECPeriod, initialPowerTable, true)
+	env.ec = ec.NewFakeEC(ctx, 1, m.BootstrapEpoch+m.EC.Finality, m.EC.Period, initialPowerTable, true)
 
 	var manifestServer peer.ID
 	if dynamicManifest {


### PR DESCRIPTION
Don't embed them all in a single object, it makes it hard to read the encoded JSON.