### PR TITLE
Prefix all metric names with f3

### DIFF
--- a/gpbft/metrics.go
+++ b/gpbft/metrics.go
@@ -35,15 +35,15 @@ var (
 )
 
 func init() {
-	metrics.phaseCounter = must(meter.Int64Counter("phase_counter", metric.WithDescription("Number of times phases change")))
-	metrics.roundHistogram = must(meter.Int64Histogram("round_histogram",
+	metrics.phaseCounter = must(meter.Int64Counter("f3_gpbft_phase_counter", metric.WithDescription("Number of times phases change")))
+	metrics.roundHistogram = must(meter.Int64Histogram("f3_gpbft_round_histogram",
 		metric.WithDescription("Histogram of rounds per instance"),
 		metric.WithExplicitBucketBoundaries(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0, 50.0, 100.0, 1000.0),
 	))
-	metrics.broadcastCounter = must(meter.Int64Counter("broadcast_counter", metric.WithDescription("Number of broadcasted messages")))
-	metrics.reBroadcastCounter = must(meter.Int64Counter("rebroadcast_counter", metric.WithDescription("Number of rebroadcasted messages")))
-	metrics.reBroadcastAttemptCounter = must(meter.Int64Counter("rebroadcast_attempt_counter", metric.WithDescription("Number of rebroadcast attempts")))
-	metrics.errorCounter = must(meter.Int64Counter("error_counter", metric.WithDescription("Number of errors")))
+	metrics.broadcastCounter = must(meter.Int64Counter("f3_gpbft_broadcast_counter", metric.WithDescription("Number of broadcasted messages")))
+	metrics.reBroadcastCounter = must(meter.Int64Counter("f3_gpbft_rebroadcast_counter", metric.WithDescription("Number of rebroadcasted messages")))
+	metrics.reBroadcastAttemptCounter = must(meter.Int64Counter("f3_gpbft_rebroadcast_attempt_counter", metric.WithDescription("Number of rebroadcast attempts")))
+	metrics.errorCounter = must(meter.Int64Counter("f3_gpbft_error_counter", metric.WithDescription("Number of errors")))
 }
 
 func metricAttributeFromError(err error) attribute.KeyValue {

--- a/metrics.go
+++ b/metrics.go
@@ -9,7 +9,7 @@ var meter = otel.Meter("f3")
 var metrics = struct {
 	headDiverged metric.Int64Counter
 }{
-	headDiverged: must(meter.Int64Counter("head_diverged", metric.WithDescription("Number of times we encountered the head has diverged from base scenario."))),
+	headDiverged: must(meter.Int64Counter("f3_head_diverged", metric.WithDescription("Number of times we encountered the head has diverged from base scenario."))),
 }
 
 func must[V any](v V, err error) V {


### PR DESCRIPTION
To avoid reporter specific behaviour manually prefix all metrics with f3 (and package when appropriate).
