### PR TITLE
Encode BigInts with a leading sign byte as we do everywhere else

### DIFF
--- a/big/int.go
+++ b/big/int.go
@@ -1,0 +1,270 @@
+package big
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+// BigIntMaxSerializedLen is the max length of a byte slice representing a CBOR serialized big.
+const BigIntMaxSerializedLen = 128
+
+type Int big.Int
+
+func NewInt(i int64) *Int {
+	return (*Int)(big.NewInt(i))
+}
+
+func (i *Int) int() *big.Int {
+	return (*big.Int)(i)
+}
+
+func FromString(s string) (*Int, error) {
+	v, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse string as a big int")
+	}
+
+	return (*Int)(v), nil
+}
+
+func (bi *Int) Copy() *Int {
+	return (*Int)(new(big.Int).Set(bi.int()))
+}
+
+func Mul(a, b *Int) *Int {
+	return (*Int)(new(big.Int).Mul(a.int(), b.int()))
+}
+
+func (bi *Int) MulAssign(o *Int) {
+	bi.int().Mul(bi.int(), o.int())
+}
+
+func Div(a, b *Int) *Int {
+	return (*Int)(new(big.Int).Div(a.int(), b.int()))
+}
+
+func (bi *Int) DivAssign(o *Int) {
+	bi.int().Div(bi.int(), o.int())
+}
+
+func Mod(a, b *Int) *Int {
+	return (*Int)(new(big.Int).Mod(a.int(), b.int()))
+}
+
+func (bi *Int) ModAssign(o *Int) {
+	bi.int().Mod(bi.int(), o.int())
+}
+
+func Add(a, b *Int) *Int {
+	return (*Int)(new(big.Int).Add(a.int(), b.int()))
+}
+
+func (bi *Int) AddAssign(o *Int) {
+	bi.int().Add(bi.int(), o.int())
+}
+
+func Sub(a, b *Int) *Int {
+	return (*Int)(new(big.Int).Sub(a.int(), b.int()))
+}
+
+func (bi *Int) SubAssign(o *Int) {
+	bi.int().Sub(bi.int(), o.int())
+}
+
+// Returns a**e unless e <= 0 (in which case returns 1).
+func Exp(a *Int, e *Int) *Int {
+	return (*Int)(new(big.Int).Exp(a.int(), e.int(), nil))
+}
+
+// Returns x << n
+func Lsh(a *Int, n uint) *Int {
+	return (*Int)(new(big.Int).Lsh(a.int(), n))
+}
+
+// Returns x >> n
+func Rsh(a *Int, n uint) *Int {
+	return (*Int)(new(big.Int).Rsh(a.int(), n))
+}
+
+func BitLen(a *Int) uint {
+	return uint(a.int().BitLen())
+}
+
+func Cmp(a, b *Int) int {
+	return a.Cmp(b)
+}
+
+func (bi *Int) Cmp(o *Int) int {
+	return bi.int().Cmp(o.int())
+}
+
+// LessThan returns true if bi < o
+func (bi *Int) LessThan(o *Int) bool {
+	return bi.Cmp(o) < 0
+}
+
+// LessThanEqual returns true if bi <= o
+func (bi *Int) LessThanEqual(o *Int) bool {
+	return bi.Cmp(o) <= 0
+}
+
+// GreaterThan returns true if bi > o
+func (bi *Int) GreaterThan(o *Int) bool {
+	return bi.Cmp(o) > 0
+}
+
+// GreaterThanEqual returns true if bi >= o
+func (bi *Int) GreaterThanEqual(o *Int) bool {
+	return bi.Cmp(o) >= 0
+}
+
+// Neg returns the negative of bi.
+func (bi *Int) Neg() *Int {
+	return (*Int)(new(big.Int).Neg(bi.int()))
+}
+
+// Abs returns the absolute value of bi.
+func (bi *Int) Abs() *Int {
+	return (*Int)(new(big.Int).Abs(bi.int()))
+}
+
+// Equals returns true if bi == o
+func (bi *Int) Equals(o *Int) bool {
+	return bi.Cmp(o) == 0
+}
+
+func (bi *Int) MarshalJSON() ([]byte, error) {
+	if bi == nil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(bi.int().String())
+}
+
+func (bi *Int) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	_, ok := bi.int().SetString(s, 10)
+	if !ok {
+		return fmt.Errorf("failed to parse big string: '%s'", string(b))
+	}
+
+	return nil
+}
+
+func (bi *Int) Bytes() ([]byte, error) {
+	if bi == nil {
+		return []byte{}, fmt.Errorf("failed to convert to bytes, big is nil")
+	}
+
+	switch {
+	case bi.Sign() > 0:
+		return append([]byte{0}, bi.int().Bytes()...), nil
+	case bi.Sign() < 0:
+		return append([]byte{1}, bi.int().Bytes()...), nil
+	default: //  bi.Sign() == 0:
+		return []byte{}, nil
+	}
+}
+
+func (bi *Int) MarshalBinary() ([]byte, error) {
+	return bi.Bytes()
+}
+
+func (bi *Int) UnmarshalBinary(buf []byte) error {
+	*bi = Int{}
+	if len(buf) == 0 {
+		return nil
+	}
+
+	var negative bool
+	switch buf[0] {
+	case 0:
+		negative = false
+	case 1:
+		negative = true
+	default:
+		return fmt.Errorf("big int prefix should be either 0 or 1, got %d", buf[0])
+	}
+
+	bi.int().SetBytes(buf[1:])
+	if negative {
+		bi.int().Neg(bi.int())
+	}
+
+	return nil
+}
+
+func (bi *Int) MarshalCBOR(w io.Writer) error {
+	if bi == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	enc, err := bi.Bytes()
+	if err != nil {
+		return err
+	}
+
+	encLen := len(enc)
+	if encLen > BigIntMaxSerializedLen {
+		return fmt.Errorf("big integer byte array too long (%d bytes)", encLen)
+	}
+
+	header := cbg.CborEncodeMajorType(cbg.MajByteString, uint64(encLen))
+	if _, err := w.Write(header); err != nil {
+		return err
+	}
+
+	if _, err := w.Write(enc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (bi *Int) UnmarshalCBOR(br io.Reader) error {
+	*bi = Int{}
+
+	maj, extra, err := cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("cbor input for fil big int was not a byte string (%x)", maj)
+	}
+
+	if extra == 0 {
+		return nil
+	}
+
+	if extra > BigIntMaxSerializedLen {
+		return fmt.Errorf("big integer byte array too long (%d bytes)", extra)
+	}
+
+	buf := make([]byte, extra)
+	if _, err := io.ReadFull(br, buf); err != nil {
+		return err
+	}
+
+	return bi.UnmarshalBinary(buf)
+}
+
+func (i *Int) Sign() int {
+	return i.int().Sign()
+}
+
+func (i *Int) String() string {
+	return i.int().String()
+}
+
+func (i *Int) Format(f fmt.State, verb rune) {
+	i.int().Format(f, verb)
+}

--- a/big/int_test.go
+++ b/big/int_test.go
@@ -1,0 +1,181 @@
+package big
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+func TestBigIntSerializationRoundTrip(t *testing.T) {
+	testValues := []string{
+		"0", "1", "10", "-10", "9999", "12345678901234567891234567890123456789012345678901234567890",
+	}
+
+	for _, v := range testValues {
+		bi, err := FromString(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		buf := new(bytes.Buffer)
+		if err := bi.MarshalCBOR(buf); err != nil {
+			t.Fatal(err)
+		}
+
+		var out Int
+		if err := out.UnmarshalCBOR(buf); err != nil {
+			t.Fatal(err)
+		}
+
+		if Cmp(&out, bi) != 0 {
+			t.Fatal("failed to round trip Int through cbor")
+		}
+
+	}
+
+	// nil check
+	bi := Int{}
+	var buf bytes.Buffer
+	err := bi.MarshalCBOR(&buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, "@", buf.String())
+
+}
+
+func TestNewInt(t *testing.T) {
+	a := int64(999)
+	ta := NewInt(a)
+	b := big.NewInt(999)
+	tb := (*Int)(b)
+	assert.True(t, ta.Equals(tb))
+	assert.Equal(t, "999", ta.String())
+
+	td := (*Int)(b)
+	assert.True(t, td.Equals(tb))
+	assert.Equal(t, td.int(), b)
+}
+
+func TestInt_MarshalUnmarshalJSON(t *testing.T) {
+	ta := NewInt(54321)
+	tb := NewInt(0)
+
+	res, err := ta.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "\"54321\"", string(res[:]))
+
+	require.NoError(t, tb.UnmarshalJSON(res))
+	assert.Equal(t, ta, tb)
+
+	assert.EqualError(t, tb.UnmarshalJSON([]byte("123garbage"[:])), "invalid character 'g' after top-level value")
+
+	tnil := Int{}
+	s, err := tnil.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "\"0\"", string(s))
+}
+
+func TestOperations(t *testing.T) {
+	testCases := []struct {
+		name     string
+		f        func(*Int, *Int) *Int
+		expected *Int
+	}{
+		{name: "Add", f: Add, expected: NewInt(7000)},
+		{name: "Sub", f: Sub, expected: NewInt(3000)},
+		{name: "Mul", f: Mul, expected: NewInt(10000000)},
+		{name: "Div", f: Div, expected: NewInt(2)},
+		{name: "Mod", f: Mod, expected: NewInt(1000)},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ta := NewInt(5000)
+			tb := NewInt(2000)
+			assert.Equal(t, testCase.expected, testCase.f(ta, tb))
+		})
+	}
+
+	ta := NewInt(5000)
+	tb := NewInt(2000)
+	tc := NewInt(2000)
+	assert.Equal(t, Cmp(ta, tb), 1)
+	assert.Equal(t, Cmp(tb, ta), -1)
+	assert.Equal(t, Cmp(tb, tc), 0)
+	assert.True(t, ta.GreaterThan(tb))
+	assert.False(t, ta.LessThan(tb))
+	assert.True(t, tb.Equals(tc))
+}
+
+func TestCopy(t *testing.T) {
+	b1 := NewInt(1)
+	b2 := b1.Copy()
+	require.EqualValues(t, b1, b2)
+
+	require.EqualValues(t, NewInt(0), NewInt(0).Copy())
+}
+
+func TestInt_Format(t *testing.T) {
+	ta := NewInt(33333000000)
+
+	s := fmt.Sprintf("%s", ta) // nolint: gosimple
+	assert.Equal(t, "33333000000", s)
+
+	s1 := fmt.Sprintf("%v", ta) // nolint: gosimple
+	assert.Equal(t, "33333000000", s1)
+
+	s2 := fmt.Sprintf("%-15d", ta) // nolint: gosimple
+	assert.Equal(t, "33333000000    ", s2)
+}
+
+func TestFromString(t *testing.T) {
+	_, err := FromString("garbage")
+	assert.EqualError(t, err, "failed to parse string as a big int")
+
+	res, err := FromString("12345")
+	require.NoError(t, err)
+	expected := NewInt(12345)
+	assert.Equal(t, expected, res)
+}
+
+func TestCBOR(t *testing.T) {
+	t.Run("happy", func(t *testing.T) {
+		ints := []*Int{
+			NewInt(0),
+			NewInt(-1),
+			NewInt(1),
+			NewInt(1e18),
+			Lsh(NewInt(1), 80),
+		}
+		for _, n := range ints {
+			var b bytes.Buffer
+			assert.NoError(t, n.MarshalCBOR(&b))
+			var out Int
+			assert.NoError(t, out.UnmarshalCBOR(&b))
+			assert.Equal(t, n, &out)
+		}
+	})
+
+	t.Run("fails to marshal too large", func(t *testing.T) {
+		giant := Lsh(NewInt(1), 8*(BigIntMaxSerializedLen-1))
+		var b bytes.Buffer
+		assert.Error(t, giant.MarshalCBOR(&b))
+	})
+
+	t.Run("fails to unmarshal too large", func(t *testing.T) {
+		// Construct CBOR for a too-large byte array
+		var b bytes.Buffer
+		header := cbg.CborEncodeMajorType(cbg.MajByteString, uint64(BigIntMaxSerializedLen+1))
+		_, err := b.Write(header)
+		require.NoError(t, err)
+		_, err = b.Write(make([]byte, BigIntMaxSerializedLen+1))
+		require.NoError(t, err)
+
+		var out Int
+		assert.Error(t, out.UnmarshalCBOR(&b))
+	})
+}

--- a/certs/cbor_gen.go
+++ b/certs/cbor_gen.go
@@ -8,11 +8,11 @@ import (
 	"math"
 	"sort"
 
+	big "github.com/filecoin-project/go-f3/big"
 	gpbft "github.com/filecoin-project/go-f3/gpbft"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
-	big "math/big"
 )
 
 var _ = xerrors.Errorf
@@ -41,21 +41,8 @@ func (t *PowerTableDelta) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PowerDelta (big.Int) (struct)
-	{
-		if err := cw.CborWriteHeader(cbg.MajTag, 2); err != nil {
-			return err
-		}
-		var b []byte
-		if t.PowerDelta != nil {
-			b = t.PowerDelta.Bytes()
-		}
-
-		if err := cw.CborWriteHeader(cbg.MajByteString, uint64(len(b))); err != nil {
-			return err
-		}
-		if _, err := cw.Write(b); err != nil {
-			return err
-		}
+	if err := t.PowerDelta.MarshalCBOR(cw); err != nil {
+		return err
 	}
 
 	// t.SigningKey (gpbft.PubKey) (slice)
@@ -113,36 +100,22 @@ func (t *PowerTableDelta) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.PowerDelta (big.Int) (struct)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if maj != cbg.MajTag || extra != 2 {
-		return fmt.Errorf("big ints should be cbor bignums")
-	}
-
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("big ints should be tagged cbor byte strings")
-	}
-
-	if extra > 256 {
-		return fmt.Errorf("t.PowerDelta: cbor bignum was too large")
-	}
-
-	if extra > 0 {
-		buf := make([]byte, extra)
-		if _, err := io.ReadFull(cr, buf); err != nil {
+		b, err := cr.ReadByte()
+		if err != nil {
 			return err
 		}
-		t.PowerDelta = big.NewInt(0).SetBytes(buf)
-	} else {
-		t.PowerDelta = big.NewInt(0)
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+			t.PowerDelta = new(big.Int)
+			if err := t.PowerDelta.UnmarshalCBOR(cr); err != nil {
+				return xerrors.Errorf("unmarshaling t.PowerDelta pointer: %w", err)
+			}
+		}
+
 	}
 	// t.SigningKey (gpbft.PubKey) (slice)
 

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/filecoin-project/go-bitfield"
+	"github.com/filecoin-project/go-f3/big"
 	"github.com/filecoin-project/go-f3/gpbft"
 )
 
@@ -212,7 +213,7 @@ func MakePowerTableDiff(oldPowerTable, newPowerTable gpbft.PowerEntries) PowerTa
 		delta := PowerTableDelta{ParticipantID: newEntry.ID}
 		if oldEntry, ok := oldPowerMap[newEntry.ID]; ok {
 			delete(oldPowerMap, newEntry.ID)
-			delta.PowerDelta = new(gpbft.StoragePower).Sub(newEntry.Power, oldEntry.Power)
+			delta.PowerDelta = big.Sub(newEntry.Power, oldEntry.Power)
 			if !bytes.Equal(newEntry.PubKey, oldEntry.PubKey) {
 				delta.SigningKey = newEntry.PubKey
 			}
@@ -228,7 +229,7 @@ func MakePowerTableDiff(oldPowerTable, newPowerTable gpbft.PowerEntries) PowerTa
 	for _, e := range oldPowerMap {
 		diff = append(diff, PowerTableDelta{
 			ParticipantID: e.ID,
-			PowerDelta:    new(gpbft.StoragePower).Neg(e.Power),
+			PowerDelta:    e.Power.Neg(),
 		})
 	}
 	slices.SortFunc(diff, func(a, b PowerTableDelta) int {
@@ -268,7 +269,7 @@ func ApplyPowerTableDiffs(prevPowerTable gpbft.PowerEntries, diffs ...PowerTable
 					return nil, fmt.Errorf("diff %d delta for participant %d includes an unchanged key", j, pe.ID)
 				}
 				if d.PowerDelta.Sign() != 0 {
-					pe.Power = new(gpbft.StoragePower).Add(d.PowerDelta, pe.Power)
+					pe.Power = big.Add(d.PowerDelta, pe.Power)
 				}
 				if len(d.SigningKey) > 0 {
 					// If we end up with no power, we shouldn't have replaced the key.

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -1,12 +1,14 @@
 package certs_test
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"slices"
 	"sort"
 	"testing"
 
+	"github.com/filecoin-project/go-f3/big"
 	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/sim"
@@ -47,10 +49,13 @@ func TestPowerTableDiff(t *testing.T) {
 
 			expDeltaRemove[i] = certs.PowerTableDelta{
 				ParticipantID: e.ID,
-				PowerDelta:    new(gpbft.StoragePower).Neg(e.Power),
+				PowerDelta:    e.Power.Neg(),
 			}
 
 		}
+		testRoundTrip(t, expDeltaRemove)
+		testRoundTrip(t, expDeltaAdd)
+
 		require.Equal(t, expDeltaRemove, certs.MakePowerTableDiff(powerTable, nil))
 		require.Equal(t, expDeltaAdd, certs.MakePowerTableDiff(nil, powerTable))
 
@@ -102,7 +107,7 @@ func TestPowerTableDiff(t *testing.T) {
 		}})
 		require.NoError(t, err)
 		require.Equal(t,
-			new(gpbft.StoragePower).Sub(newPowerTable[0].Power, powerTable[0].Power),
+			big.Sub(newPowerTable[0].Power, powerTable[0].Power),
 			gpbft.NewStoragePower(1),
 		)
 
@@ -114,7 +119,7 @@ func TestPowerTableDiff(t *testing.T) {
 		}})
 		require.NoError(t, err)
 		require.Equal(t,
-			new(gpbft.StoragePower).Sub(newPowerTable[0].Power, powerTable[0].Power),
+			big.Sub(newPowerTable[0].Power, powerTable[0].Power),
 			gpbft.NewStoragePower(1),
 		)
 		require.Equal(t, newPowerTable[0].PubKey, powerTable[1].PubKey)
@@ -149,7 +154,7 @@ func TestPowerTableDiff(t *testing.T) {
 		// Remove all power and change key.
 		_, err = certs.ApplyPowerTableDiffs(powerTable, certs.PowerTableDiff{{
 			ParticipantID: powerTable[0].ID,
-			PowerDelta:    new(gpbft.StoragePower).Neg(powerTable[0].Power),
+			PowerDelta:    powerTable[0].Power.Neg(),
 			SigningKey:    powerTable[1].PubKey,
 		}})
 		require.ErrorContains(t, err, "removes all power for participant 1 while specifying a new key")
@@ -180,11 +185,21 @@ func TestPowerTableDiff(t *testing.T) {
 		// Remove more power than we have.
 		_, err = certs.ApplyPowerTableDiffs(powerTable, certs.PowerTableDiff{{
 			ParticipantID: powerTable[0].ID,
-			PowerDelta:    new(gpbft.StoragePower).Sub(gpbft.NewStoragePower(-1), powerTable[0].Power),
+			PowerDelta:    big.Sub(gpbft.NewStoragePower(-1), powerTable[0].Power),
 		}})
 		require.ErrorContains(t, err, "resulted in negative power")
 	}
 
+}
+
+func testRoundTrip(t *testing.T, diff certs.PowerTableDiff) {
+	var b bytes.Buffer
+	require.NoError(t, diff.MarshalCBOR(&b))
+
+	var out certs.PowerTableDiff
+	require.NoError(t, out.UnmarshalCBOR(&b))
+
+	require.EqualValues(t, diff, out)
 }
 
 func TestFinalityCertificates(t *testing.T) {
@@ -319,7 +334,7 @@ func TestBadFinalityCertificates(t *testing.T) {
 		require.NoError(t, err)
 		powerTableCpy := slices.Clone(powerTable)
 		// increase so we definitely have enough power
-		powerTableCpy[firstSigner].Power = new(gpbft.StoragePower).Add(powerTableCpy[firstSigner].Power, gpbft.NewStoragePower(1))
+		powerTableCpy[firstSigner].Power = big.Add(powerTableCpy[firstSigner].Power, gpbft.NewStoragePower(1))
 		nextInstance, chain, _, err := certs.ValidateFinalityCertificates(backend, networkName, powerTableCpy, 1, nil, *certificate)
 		require.ErrorContains(t, err, "incorrect power diff")
 		require.EqualValues(t, 1, nextInstance)

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"os"
 
 	"github.com/filecoin-project/go-f3"
+	"github.com/filecoin-project/go-f3/big"
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"

--- a/gpbft/cbor_gen.go
+++ b/gpbft/cbor_gen.go
@@ -8,10 +8,10 @@ import (
 	"math"
 	"sort"
 
+	big "github.com/filecoin-project/go-f3/big"
 	cid "github.com/ipfs/go-cid"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	xerrors "golang.org/x/xerrors"
-	big "math/big"
 )
 
 var _ = xerrors.Errorf
@@ -777,21 +777,8 @@ func (t *PowerEntry) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Power (big.Int) (struct)
-	{
-		if err := cw.CborWriteHeader(cbg.MajTag, 2); err != nil {
-			return err
-		}
-		var b []byte
-		if t.Power != nil {
-			b = t.Power.Bytes()
-		}
-
-		if err := cw.CborWriteHeader(cbg.MajByteString, uint64(len(b))); err != nil {
-			return err
-		}
-		if _, err := cw.Write(b); err != nil {
-			return err
-		}
+	if err := t.Power.MarshalCBOR(cw); err != nil {
+		return err
 	}
 
 	// t.PubKey (gpbft.PubKey) (slice)
@@ -849,36 +836,22 @@ func (t *PowerEntry) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 	// t.Power (big.Int) (struct)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if maj != cbg.MajTag || extra != 2 {
-		return fmt.Errorf("big ints should be cbor bignums")
-	}
-
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
-
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("big ints should be tagged cbor byte strings")
-	}
-
-	if extra > 256 {
-		return fmt.Errorf("t.Power: cbor bignum was too large")
-	}
-
-	if extra > 0 {
-		buf := make([]byte, extra)
-		if _, err := io.ReadFull(cr, buf); err != nil {
+		b, err := cr.ReadByte()
+		if err != nil {
 			return err
 		}
-		t.Power = big.NewInt(0).SetBytes(buf)
-	} else {
-		t.Power = big.NewInt(0)
+		if b != cbg.CborNull[0] {
+			if err := cr.UnreadByte(); err != nil {
+				return err
+			}
+			t.Power = new(big.Int)
+			if err := t.Power.UnmarshalCBOR(cr); err != nil {
+				return xerrors.Errorf("unmarshaling t.Power pointer: %w", err)
+			}
+		}
+
 	}
 	// t.PubKey (gpbft.PubKey) (slice)
 

--- a/gpbft/message_builder_test.go
+++ b/gpbft/message_builder_test.go
@@ -1,8 +1,9 @@
 package gpbft
 
 import (
-	"math/big"
 	"testing"
+
+	"github.com/filecoin-project/go-f3/big"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/gpbft/powertable_test.go
+++ b/gpbft/powertable_test.go
@@ -110,7 +110,7 @@ func TestPowerTable(t *testing.T) {
 				subject: func() *gpbft.PowerTable {
 					subject := gpbft.NewPowerTable()
 					require.NoError(t, subject.Add(oneValidEntry, anotherValidEntry))
-					subject.Total.Sub(subject.Total, gpbft.NewStoragePower(1))
+					subject.Total.SubAssign(gpbft.NewStoragePower(1))
 					return subject
 				},
 				wantErr: "total power does not match",
@@ -133,7 +133,7 @@ func TestPowerTable(t *testing.T) {
 					subject.Entries = append(subject.Entries, noPubKeyEntry)
 					subject.ScaledPower = append(subject.ScaledPower, 0)
 					subject.Lookup[noPubKeyEntry.ID] = 0
-					subject.Total.Add(subject.Total, noPubKeyEntry.Power)
+					subject.Total.AddAssign(noPubKeyEntry.Power)
 					return subject
 				},
 				wantErr: "unspecified public key",

--- a/gpbft/types.go
+++ b/gpbft/types.go
@@ -1,8 +1,6 @@
 package gpbft
 
-import (
-	"math/big"
-)
+import "github.com/filecoin-project/go-f3/big"
 
 type ActorID uint64
 
@@ -16,5 +14,5 @@ type NetworkName string
 
 // Creates a new StoragePower struct with a specific value and returns the result
 func NewStoragePower(value int64) *StoragePower {
-	return new(big.Int).SetInt64(value)
+	return big.NewInt(value)
 }

--- a/internal/powerstore/powerstore_test.go
+++ b/internal/powerstore/powerstore_test.go
@@ -48,7 +48,8 @@ func (f *forgetfulEC) GetPowerTable(ctx context.Context, tsk gpbft.TipSetKey) (g
 	// make sure power changes over time by adding the current epoch to the first entry.
 	pt = slices.Clone(pt)
 	newPower := gpbft.NewStoragePower(ts.Epoch())
-	pt[0].Power = newPower.Add(newPower, pt[0].Power)
+	newPower.AddAssign(pt[0].Power)
+	pt[0].Power = newPower
 
 	return pt, nil
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -2,11 +2,11 @@ package manifest_test
 
 import (
 	"bytes"
-	"math/big"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-f3/big"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/stretchr/testify/require"

--- a/sim/ec.go
+++ b/sim/ec.go
@@ -128,7 +128,7 @@ func (eci *ECInstance) validateDecision(decision *gpbft.Justification) error {
 		if int(bit) >= len(powerTable.Entries) {
 			return fmt.Errorf("invalid signer index: %d", bit)
 		}
-		justificationPower.Add(justificationPower, powerTable.Entries[bit].Power)
+		justificationPower.AddAssign(powerTable.Entries[bit].Power)
 		signers = append(signers, powerTable.Entries[bit].PubKey)
 		return nil
 	}); err != nil {
@@ -136,9 +136,9 @@ func (eci *ECInstance) validateDecision(decision *gpbft.Justification) error {
 	}
 	// Check signers have strong quorum
 	strongQuorum := gpbft.NewStoragePower(0)
-	strongQuorum = strongQuorum.Mul(strongQuorum, gpbft.NewStoragePower(2))
-	strongQuorum = strongQuorum.Div(strongQuorum, gpbft.NewStoragePower(3))
-	if justificationPower.Cmp(strongQuorum) < 0 {
+	strongQuorum.MulAssign(gpbft.NewStoragePower(2))
+	strongQuorum.DivAssign(gpbft.NewStoragePower(3))
+	if justificationPower.LessThan(strongQuorum) {
 		return fmt.Errorf("decision lacks strong quorum: %v", decision)
 	}
 	// Verify aggregate signature

--- a/test/f3_test.go
+++ b/test/f3_test.go
@@ -3,12 +3,12 @@ package test
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/filecoin-project/go-f3"
+	"github.com/filecoin-project/go-f3/big"
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/internal/clock"


### PR DESCRIPTION
Previously, we dropped the sign. Unfortunately, the only ways to do this were to:

1. Replace the StoragePower type (what I did here).
2. Hack marshaling/unmarshaling for anything containing this type (which I really didn't want to do).

I mostly copied the big-int code from go-state-types, but I cleaned it up a bit and removed some unused parts. I also renamed/tweaked some functions because I _really_ hate the go big int interface.

fixes #517 