### PR TITLE
Remove time-less FakeEC

### DIFF
--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -112,7 +112,7 @@ var runCmd = cli.Command{
 		id := c.Uint64("id")
 		signingBackend.Allow(int(id))
 
-		ec := ec.NewFakeEC(ctx, 1, m.BootstrapEpoch, m.EC.Period, initialPowerTable, true)
+		ec := ec.NewFakeEC(ctx, 1, m.BootstrapEpoch, m.EC.Period, initialPowerTable)
 
 		module, err := f3.New(ctx, mprovider, ds, h, ps, signingBackend, ec)
 		if err != nil {

--- a/ec/powerdelta_test.go
+++ b/ec/powerdelta_test.go
@@ -29,7 +29,7 @@ var powerTableC = gpbft.PowerEntries{
 }
 
 func TestReplacePowerTable(t *testing.T) {
-	backend := ec.NewFakeEC(context.Background(), 0, 0, 0, powerTableA, false)
+	backend := ec.NewFakeEC(context.Background(), 0, 0, 30, powerTableA)
 	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, true)
 
 	head, err := modifiedBackend.GetHead(context.Background())
@@ -42,7 +42,7 @@ func TestReplacePowerTable(t *testing.T) {
 }
 
 func TestModifyPowerTable(t *testing.T) {
-	backend := ec.NewFakeEC(context.Background(), 0, 0, 0, powerTableA, false)
+	backend := ec.NewFakeEC(context.Background(), 0, 0, 30, powerTableA)
 	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, false)
 
 	head, err := modifiedBackend.GetHead(context.Background())
@@ -54,7 +54,7 @@ func TestModifyPowerTable(t *testing.T) {
 }
 
 func TestBypassModifiedPowerTable(t *testing.T) {
-	backend := ec.NewFakeEC(context.Background(), 0, 0, 0, powerTableA, false)
+	backend := ec.NewFakeEC(context.Background(), 0, 0, 30, powerTableA)
 	modifiedBackend := ec.WithModifiedPower(backend, nil, false)
 	require.Equal(t, backend, modifiedBackend)
 }

--- a/f3_test.go
+++ b/f3_test.go
@@ -428,7 +428,7 @@ func newTestEnvironment(t *testing.T, n int, dynamicManifest bool) *testEnv {
 		})
 	}
 	env.manifest = m
-	env.ec = ec.NewFakeEC(ctx, 1, m.BootstrapEpoch+m.EC.Finality, m.EC.Period, initialPowerTable, true)
+	env.ec = ec.NewFakeEC(ctx, 1, m.BootstrapEpoch+m.EC.Finality, m.EC.Period, initialPowerTable)
 
 	var manifestServer peer.ID
 	if dynamicManifest {

--- a/internal/powerstore/powerstore_test.go
+++ b/internal/powerstore/powerstore_test.go
@@ -68,7 +68,7 @@ func TestPowerStore(t *testing.T) {
 	m := manifest.LocalDevnetManifest()
 
 	ec := &forgetfulEC{
-		FakeEC:     ec.NewFakeEC(ctx, 1234, m.BootstrapEpoch, m.EC.Period, basePowerTable, true),
+		FakeEC:     ec.NewFakeEC(ctx, 1234, m.BootstrapEpoch, m.EC.Period, basePowerTable),
 		ecFinality: m.EC.Finality,
 	}
 


### PR DESCRIPTION
We now have mock time support, so we can just use that. As a matter of fact, none of our code actually _used_ EC without time (well, we had a few tests that constructed it without time but they never advanced head).