### PR TITLE
Add basic certificate exchange metrics

### DIFF
--- a/certexchange/client.go
+++ b/certexchange/client.go
@@ -16,8 +16,6 @@ import (
 	cid "github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
 )
 
 // We've estimated the max power table size to be less than 1MiB:
@@ -25,26 +23,6 @@ import (
 // 1. For 10k participants.
 // 2. <100 bytes per entry (key + id + power)
 const maxPowerTableSize = 1024 * 1024
-
-var clientMeter = otel.Meter("f3/certexchange/client")
-var clientMetrics = struct {
-	requests        metric.Int64Counter
-	dialFailures    metric.Int64Counter
-	requestFailures metric.Int64Counter
-}{
-	requests: must(clientMeter.Int64Counter(
-		"f3_certexchange_client_requests",
-		metric.WithDescription("The total number of requests made."),
-	)),
-	dialFailures: must(clientMeter.Int64Counter(
-		"f3_certexchange_client_failed_dials",
-		metric.WithDescription("The number of failed certexchange dials."),
-	)),
-	requestFailures: must(clientMeter.Int64Counter(
-		"f3_certexchange_client_failed_requests",
-		metric.WithDescription("The number of failed certexchange requests (total)."),
-	)),
-}
 
 // Client is a libp2p certificate exchange client for requesting finality certificates from specific
 // peers.

--- a/certexchange/metrics.go
+++ b/certexchange/metrics.go
@@ -1,0 +1,61 @@
+package certexchange
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var meter = otel.Meter("f3/certexchange")
+
+var clientMetrics = struct {
+	requests        metric.Int64Counter
+	dialFailures    metric.Int64Counter
+	requestFailures metric.Int64Counter
+}{
+	requests: must(meter.Int64Counter(
+		"f3_certexchange_client_requests",
+		metric.WithDescription("The total number of requests made."),
+	)),
+	dialFailures: must(meter.Int64Counter(
+		"f3_certexchange_client_failed_dials",
+		metric.WithDescription("The number of failed certexchange dials."),
+	)),
+	requestFailures: must(meter.Int64Counter(
+		"f3_certexchange_client_failed_requests",
+		metric.WithDescription("The number of failed certexchange requests (total)."),
+	)),
+}
+
+var serverMetrics = struct {
+	requests                      metric.Int64Counter
+	requestsFailed                metric.Int64Counter
+	certificatesServed            metric.Int64Counter
+	powerTablesServed             metric.Int64Counter
+	certificatesServedPerResponse metric.Int64Histogram
+	responseTimeMS                metric.Int64Histogram
+}{
+	requests: must(meter.Int64Counter(
+		"f3_certexchange_server_requests",
+		metric.WithDescription("The total number of requests received."),
+	)),
+	requestsFailed: must(meter.Int64Counter(
+		"f3_certexchange_server_requests_failed",
+		metric.WithDescription("The total number of requests failed."),
+	)),
+	powerTablesServed: must(meter.Int64Counter(
+		"f3_certexchange_server_power_tables_served",
+		metric.WithDescription("The number of power tables served."),
+	)),
+	certificatesServed: must(meter.Int64Counter(
+		"f3_certexchange_server_certificates_served",
+		metric.WithDescription("The number of certificates served."),
+	)),
+	certificatesServedPerResponse: must(meter.Int64Histogram(
+		"f3_certexchange_server_certificates_served_per_response",
+		metric.WithDescription("The number of certificates served per response."),
+	)),
+	responseTimeMS: must(meter.Int64Histogram(
+		"f3_certexchange_server_response_time_ms",
+		metric.WithDescription("The time it takes to respond to requests, excluding failures (milliseconds)."),
+	)),
+}

--- a/certexchange/metrics.go
+++ b/certexchange/metrics.go
@@ -1,65 +1,13 @@
 package certexchange
 
 import (
-	"context"
-	"errors"
-	"os"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
 var meter = otel.Meter("f3/certexchange")
-
-var (
-	attrStatus = attribute.Key("status")
-
-	attrStatusSuccess = attribute.KeyValue{
-		Key:   attrStatus,
-		Value: attribute.StringValue("success"),
-	}
-	attrStatusError = attribute.KeyValue{
-		Key:   attrStatus,
-		Value: attribute.StringValue("error-other"),
-	}
-	attrStatusCanceled = attribute.KeyValue{
-		Key:   attrStatus,
-		Value: attribute.StringValue("error-canceled"),
-	}
-	attrStatusTimeout = attribute.KeyValue{
-		Key:   attrStatus,
-		Value: attribute.StringValue("error-timeout"),
-	}
-	attrStatusInternalError = attribute.KeyValue{
-		Key:   attrStatus,
-		Value: attribute.StringValue("error-internal"),
-	}
-
-	attrDialFailed = attribute.Key("dial-failed")
-
-	attrWithPowerTable = attribute.Key("with-power-table")
-)
-
-func status(ctx context.Context, err error) attribute.KeyValue {
-	if err == nil {
-		return attrStatusSuccess
-	}
-
-	if os.IsTimeout(err) || errors.Is(err, os.ErrDeadlineExceeded) {
-		return attrStatusTimeout
-	}
-
-	switch ctx.Err() {
-	case nil:
-		return attrStatusError
-	case context.DeadlineExceeded:
-		return attrStatusTimeout
-	default:
-		return attrStatusCanceled
-	}
-
-}
+var attrWithPowerTable = attribute.Key("with-power-table")
 
 var metrics = struct {
 	requestLatency     metric.Float64Histogram

--- a/certexchange/metrics.go
+++ b/certexchange/metrics.go
@@ -1,61 +1,90 @@
 package certexchange
 
 import (
+	"context"
+	"errors"
+	"os"
+
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
 var meter = otel.Meter("f3/certexchange")
 
-var clientMetrics = struct {
-	requests        metric.Int64Counter
-	dialFailures    metric.Int64Counter
-	requestFailures metric.Int64Counter
-}{
-	requests: must(meter.Int64Counter(
-		"f3_certexchange_client_requests",
-		metric.WithDescription("The total number of requests made."),
-	)),
-	dialFailures: must(meter.Int64Counter(
-		"f3_certexchange_client_failed_dials",
-		metric.WithDescription("The number of failed certexchange dials."),
-	)),
-	requestFailures: must(meter.Int64Counter(
-		"f3_certexchange_client_failed_requests",
-		metric.WithDescription("The number of failed certexchange requests (total)."),
-	)),
+var (
+	attrStatus = attribute.Key("status")
+
+	attrStatusSuccess = attribute.KeyValue{
+		Key:   attrStatus,
+		Value: attribute.StringValue("success"),
+	}
+	attrStatusError = attribute.KeyValue{
+		Key:   attrStatus,
+		Value: attribute.StringValue("error-other"),
+	}
+	attrStatusCanceled = attribute.KeyValue{
+		Key:   attrStatus,
+		Value: attribute.StringValue("error-canceled"),
+	}
+	attrStatusTimeout = attribute.KeyValue{
+		Key:   attrStatus,
+		Value: attribute.StringValue("error-timeout"),
+	}
+	attrStatusInternalError = attribute.KeyValue{
+		Key:   attrStatus,
+		Value: attribute.StringValue("error-internal"),
+	}
+
+	attrDialFailed = attribute.Key("dial-failed")
+
+	attrWithPowerTable = attribute.Key("with-power-table")
+)
+
+func status(ctx context.Context, err error) attribute.KeyValue {
+	if err == nil {
+		return attrStatusSuccess
+	}
+
+	if os.IsTimeout(err) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return attrStatusTimeout
+	}
+
+	switch ctx.Err() {
+	case nil:
+		return attrStatusError
+	case context.DeadlineExceeded:
+		return attrStatusTimeout
+	default:
+		return attrStatusCanceled
+	}
+
 }
 
-var serverMetrics = struct {
-	requests                      metric.Int64Counter
-	requestsFailed                metric.Int64Counter
-	certificatesServed            metric.Int64Counter
-	powerTablesServed             metric.Int64Counter
-	certificatesServedPerResponse metric.Int64Histogram
-	responseTimeMS                metric.Int64Histogram
+var metrics = struct {
+	requestLatency     metric.Float64Histogram
+	totalResponseTime  metric.Float64Histogram
+	serveTime          metric.Float64Histogram
+	certificatesServed metric.Int64Histogram
 }{
-	requests: must(meter.Int64Counter(
-		"f3_certexchange_server_requests",
-		metric.WithDescription("The total number of requests received."),
+	requestLatency: must(meter.Float64Histogram(
+		"f3_certexchange_request_latency_s",
+		metric.WithDescription("The outbound request latency."),
+		metric.WithUnit("s"),
 	)),
-	requestsFailed: must(meter.Int64Counter(
-		"f3_certexchange_server_requests_failed",
-		metric.WithDescription("The total number of requests failed."),
+	totalResponseTime: must(meter.Float64Histogram(
+		"f3_certexchange_total_response_time_s",
+		metric.WithDescription("The total time for outbound requests."),
+		metric.WithUnit("s"),
 	)),
-	powerTablesServed: must(meter.Int64Counter(
-		"f3_certexchange_server_power_tables_served",
-		metric.WithDescription("The number of power tables served."),
+	serveTime: must(meter.Float64Histogram(
+		"f3_certexchange_serve_time_s",
+		metric.WithDescription("The time spent serving requests."),
+		metric.WithUnit("s"),
 	)),
-	certificatesServed: must(meter.Int64Counter(
-		"f3_certexchange_server_certificates_served",
-		metric.WithDescription("The number of certificates served."),
-	)),
-	certificatesServedPerResponse: must(meter.Int64Histogram(
-		"f3_certexchange_server_certificates_served_per_response",
-		metric.WithDescription("The number of certificates served per response."),
-	)),
-	responseTimeMS: must(meter.Int64Histogram(
-		"f3_certexchange_server_response_time_ms",
-		metric.WithDescription("The time it takes to respond to requests, excluding failures (milliseconds)."),
+	certificatesServed: must(meter.Int64Histogram(
+		"f3_certexchange_certificates_served",
+		metric.WithDescription("The number of certificates served (per request)."),
+		metric.WithUnit("{certificate}"),
 	)),
 }

--- a/certexchange/metrics.go
+++ b/certexchange/metrics.go
@@ -16,17 +16,17 @@ var metrics = struct {
 	certificatesServed metric.Int64Histogram
 }{
 	requestLatency: must(meter.Float64Histogram(
-		"f3_certexchange_request_latency_s",
+		"f3_certexchange_request_latency",
 		metric.WithDescription("The outbound request latency."),
 		metric.WithUnit("s"),
 	)),
 	totalResponseTime: must(meter.Float64Histogram(
-		"f3_certexchange_total_response_time_s",
+		"f3_certexchange_total_response_time",
 		metric.WithDescription("The total time for outbound requests."),
 		metric.WithUnit("s"),
 	)),
 	serveTime: must(meter.Float64Histogram(
-		"f3_certexchange_serve_time_s",
+		"f3_certexchange_serve_time",
 		metric.WithDescription("The time spent serving requests."),
 		metric.WithUnit("s"),
 	)),

--- a/certexchange/polling/metrics.go
+++ b/certexchange/polling/metrics.go
@@ -17,37 +17,37 @@ var metrics = struct {
 	pollEfficiency           metric.Float64Histogram
 }{
 	activePeers: must(meter.Int64Gauge(
-		"f3_certexchange_active_peers",
+		"f3_certexchange_polling_active_peers",
 		metric.WithDescription("The number of active certificate exchange peers."),
 		metric.WithUnit("{peer}"),
 	)),
 	backoffPeers: must(meter.Int64Gauge(
-		"f3_certexchange_backoff_peers",
+		"f3_certexchange_polling_backoff_peers",
 		metric.WithDescription("The number of active certificate exchange peers on backoff."),
 		metric.WithUnit("{peer}"),
 	)),
 	predictedPollingInterval: must(meter.Float64Gauge(
-		"f3_certexchange_predicted_polling_interval",
+		"f3_certexchange_polling_predicted_interval",
 		metric.WithDescription("The predicted certificate exchange polling interval."),
 		metric.WithUnit("s"),
 	)),
 	pollDuration: must(meter.Float64Histogram(
-		"f3_certexchange_poll_duration",
+		"f3_certexchange_polling_poll_duration",
 		metric.WithDescription("The certificate exchange total poll duration."),
 		metric.WithUnit("s"),
 	)),
 	peersPolled: must(meter.Int64Histogram(
-		"f3_certexchange_peers_polld",
+		"f3_certexchange_polling_peers_polld",
 		metric.WithDescription("The number of peers polled per certificate exchange poll."),
 		metric.WithUnit("{peer}"),
 	)),
 	peersRequiredPerPoll: must(meter.Int64Histogram(
-		"f3_certexchange_peers_required_per_poll",
+		"f3_certexchange_polling_peers_required_per_poll",
 		metric.WithDescription("The number of peers we should be selecting per poll (optimally)."),
 		metric.WithUnit("{peer}"),
 	)),
 	pollEfficiency: must(meter.Float64Histogram(
-		"f3_certexchange_poll_efficiency",
+		"f3_certexchange_polling_poll_efficiency",
 		metric.WithDescription("The fraction of requests necessary to make progress."),
 	)),
 }

--- a/certexchange/polling/metrics.go
+++ b/certexchange/polling/metrics.go
@@ -1,0 +1,62 @@
+package polling
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var meter = otel.Meter("f3/certexchange/polling")
+var metrics = struct {
+	activePeers              metric.Int64Gauge
+	backoffPeers             metric.Int64Gauge
+	predictedPollingInterval metric.Float64Gauge
+	pollDuration             metric.Float64Histogram
+	peersPolled              metric.Int64Histogram
+	peersRequiredPerPoll     metric.Int64Histogram
+	pollEfficiency           metric.Float64Histogram
+}{
+	activePeers: must(meter.Int64Gauge(
+		"f3_certexchange_active_peers",
+		metric.WithDescription("The number of active certificate exchange peers."),
+		metric.WithUnit("{peer}"),
+	)),
+	backoffPeers: must(meter.Int64Gauge(
+		"f3_certexchange_backoff_peers",
+		metric.WithDescription("The number of active certificate exchange peers on backoff."),
+		metric.WithUnit("{peer}"),
+	)),
+	predictedPollingInterval: must(meter.Float64Gauge(
+		"f3_certexchange_predicted_polling_interval",
+		metric.WithDescription("The predicted certificate exchange polling interval."),
+		metric.WithUnit("s"),
+	)),
+	pollDuration: must(meter.Float64Histogram(
+		"f3_certexchange_poll_duration",
+		metric.WithDescription("The certificate exchange total poll duration."),
+		metric.WithUnit("s"),
+	)),
+	peersPolled: must(meter.Int64Histogram(
+		"f3_certexchange_peers_polld",
+		metric.WithDescription("The number of peers polled per certificate exchange poll."),
+		metric.WithUnit("{peer}"),
+	)),
+	peersRequiredPerPoll: must(meter.Int64Histogram(
+		"f3_certexchange_peers_required_per_poll",
+		metric.WithDescription("The number of peers we should be selecting per poll (optimally)."),
+		metric.WithUnit("{peer}"),
+	)),
+	pollEfficiency: must(meter.Float64Histogram(
+		"f3_certexchange_poll_efficiency",
+		metric.WithDescription("The fraction of requests necessary to make progress."),
+	)),
+}
+
+var attrMadeProgress = attribute.Key("made-progress")
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/certexchange/polling/peerTracker_test.go
+++ b/certexchange/polling/peerTracker_test.go
@@ -108,6 +108,7 @@ func TestPeerRecordExponentialBackoff(t *testing.T) {
 
 func TestPeerTracker(t *testing.T) {
 	pt := newPeerTracker(clock.NewMock())
+	ctx := context.Background()
 
 	var peers []peer.ID
 	discoverPeers := func(count int) {
@@ -121,20 +122,20 @@ func TestPeerTracker(t *testing.T) {
 	for _, n := range []int{0, 1, defaultRequests / 2, defaultRequests/2 - 1} {
 		discoverPeers(n)
 		pt.lastHitRound = pt.currentRound
-		suggested := pt.suggestPeers(context.Background())
+		suggested := pt.suggestPeers(ctx)
 		require.ElementsMatch(t, peers, suggested)
 	}
 
 	// Too many peers
 	discoverPeers(1)
 	pt.lastHitRound = pt.currentRound
-	require.Less(t, len(pt.suggestPeers(context.Background())), len(peers))
+	require.Less(t, len(pt.suggestPeers(ctx)), len(peers))
 
 	// fail a peer and we should pick the other peers now.
 	pt.recordMiss(peers[0])
 	pt.lastHitRound = pt.currentRound
 
-	require.ElementsMatch(t, peers[1:], pt.suggestPeers(context.Background()))
+	require.ElementsMatch(t, peers[1:], pt.suggestPeers(ctx))
 
 	// Now ensure we select that peer. It should be first because it's the best.
 	pt.recordHit(peers[0])
@@ -143,19 +144,19 @@ func TestPeerTracker(t *testing.T) {
 	pt.recordHit(peers[1])
 	pt.recordMiss(peers[1]) // needs to be worse than peer 1
 
-	require.Equal(t, pt.suggestPeers(context.Background())[0], peers[0])
+	require.Equal(t, pt.suggestPeers(ctx)[0], peers[0])
 
 	// Now check to make sure we backoff that peer.
 	{
 		pt.recordFailure(peers[0])
 		pt.recordMiss(peers[1])
-		suggested := pt.suggestPeers(context.Background())
+		suggested := pt.suggestPeers(ctx)
 		require.Equal(t, 1, pt.backoff.Len())
 		require.NotContains(t, suggested, peers[0])
 		require.Equal(t, suggested[0], peers[1])
 
 		// Peer 0 should be back on-top after one round absent.
-		suggested = pt.suggestPeers(context.Background())
+		suggested = pt.suggestPeers(ctx)
 		require.Empty(t, pt.backoff)
 		require.Equal(t, suggested[0], peers[0])
 	}
@@ -166,17 +167,17 @@ func TestPeerTracker(t *testing.T) {
 		pt.recordFailure(peers[0])
 		pt.recordFailure(peers[1])
 
-		suggested := pt.suggestPeers(context.Background())
+		suggested := pt.suggestPeers(ctx)
 		require.Equal(t, 2, pt.backoff.Len())
 		require.NotContains(t, suggested, peers[0])
 		require.NotContains(t, suggested, peers[1])
 
-		suggested = pt.suggestPeers(context.Background())
+		suggested = pt.suggestPeers(ctx)
 		require.Equal(t, 1, pt.backoff.Len())
 		require.Contains(t, suggested, peers[1])
 		require.NotContains(t, suggested, peers[0])
 
-		suggested = pt.suggestPeers(context.Background())
+		suggested = pt.suggestPeers(ctx)
 		require.Len(t, pt.backoff, 0)
 		require.Contains(t, pt.active, peers[0])
 		require.Contains(t, suggested, peers[0])
@@ -185,11 +186,11 @@ func TestPeerTracker(t *testing.T) {
 
 	// Then four rounds.
 	pt.recordFailure(peers[0])
-	require.NotContains(t, pt.suggestPeers(context.Background()), peers[0])
-	require.NotContains(t, pt.suggestPeers(context.Background()), peers[0])
-	require.NotContains(t, pt.suggestPeers(context.Background()), peers[0])
-	require.NotContains(t, pt.suggestPeers(context.Background()), peers[0])
-	require.Contains(t, pt.suggestPeers(context.Background()), peers[0])
+	require.NotContains(t, pt.suggestPeers(ctx), peers[0])
+	require.NotContains(t, pt.suggestPeers(ctx), peers[0])
+	require.NotContains(t, pt.suggestPeers(ctx), peers[0])
+	require.NotContains(t, pt.suggestPeers(ctx), peers[0])
+	require.Contains(t, pt.suggestPeers(ctx), peers[0])
 
 	// Now, give that peer a perfect success rate
 	for i := 0; i < 100; i++ {
@@ -198,7 +199,7 @@ func TestPeerTracker(t *testing.T) {
 
 	// We always pick at least 4 peers, even if we have high confidence in one.
 	{
-		suggested := pt.suggestPeers(context.Background())
+		suggested := pt.suggestPeers(ctx)
 		require.Len(t, suggested, minRequests)
 		require.Equal(t, peers[0], suggested[0])
 	}
@@ -206,7 +207,7 @@ func TestPeerTracker(t *testing.T) {
 	// Now mark that peer as evil, we should never pick it again.
 	pt.recordInvalid(peers[0])
 	for i := 0; i < 5; i++ {
-		require.NotContains(t, pt.suggestPeers(context.Background()), peers[0])
+		require.NotContains(t, pt.suggestPeers(ctx), peers[0])
 
 		// No matter what we do.
 		pt.recordHit(peers[0])
@@ -214,7 +215,7 @@ func TestPeerTracker(t *testing.T) {
 	}
 
 	pt.recordHit(peers[1])
-	require.Contains(t, pt.suggestPeers(context.Background()), peers[1])
+	require.Contains(t, pt.suggestPeers(ctx), peers[1])
 	pt.lastHitRound = pt.currentRound
 
 	// Discover a whole bunch of peers.
@@ -225,7 +226,7 @@ func TestPeerTracker(t *testing.T) {
 
 	{
 		// The new peers shouldn't affect out discovered peers.
-		require.Contains(t, pt.suggestPeers(context.Background()), peers[1])
+		require.Contains(t, pt.suggestPeers(ctx), peers[1])
 	}
 
 	// We should never suggest more than 32 peers at a time.
@@ -236,7 +237,7 @@ func TestPeerTracker(t *testing.T) {
 			}
 		}
 
-		require.Len(t, pt.suggestPeers(context.Background()), maxRequests)
+		require.Len(t, pt.suggestPeers(ctx), maxRequests)
 	}
 
 }

--- a/certexchange/polling/subscriber.go
+++ b/certexchange/polling/subscriber.go
@@ -18,7 +18,7 @@ import (
 
 const maxRequestLength = 256
 
-var meter = otel.Meter("f3/certexchange")
+var meter = otel.Meter("f3/certexchange/polling")
 var metrics = struct {
 	activePeers                metric.Int64Gauge
 	backoffPeers               metric.Int64Gauge

--- a/certexchange/polling/subscriber.go
+++ b/certexchange/polling/subscriber.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/filecoin-project/go-f3/certexchange"
 	"github.com/filecoin-project/go-f3/certstore"
@@ -15,6 +17,58 @@ import (
 )
 
 const maxRequestLength = 256
+
+var meter = otel.Meter("f3/certexchange")
+var metrics = struct {
+	activePeers                metric.Int64Gauge
+	backoffPeers               metric.Int64Gauge
+	predictedPollingIntervalMS metric.Int64Gauge
+	pollRTTMS                  metric.Int64Histogram
+	pollTotalMS                metric.Int64Histogram
+	peersSelectedPerPoll       metric.Int64Histogram
+	peersRequiredPerPoll       metric.Int64Histogram
+	pollEfficiency             metric.Float64Histogram
+}{
+	activePeers: must(meter.Int64Gauge(
+		"f3_certexchange_active_peers",
+		metric.WithDescription("The number of active certificate exchange peers."),
+	)),
+	backoffPeers: must(meter.Int64Gauge(
+		"f3_certexchange_backoff_peers",
+		metric.WithDescription("The number of active certificate exchange peers on backoff."),
+	)),
+	predictedPollingIntervalMS: must(meter.Int64Gauge(
+		"f3_certexchange_predicted_polling_interval_ms",
+		metric.WithDescription("The predicted certificate exchange polling interval (milliseconds)."),
+	)),
+	pollRTTMS: must(meter.Int64Histogram(
+		"f3_certexchange_poll_rtt_ms",
+		metric.WithDescription("The certificate exchange per-peer polling round-trip time (milliseconds)."),
+	)),
+	pollTotalMS: must(meter.Int64Histogram(
+		"f3_certexchange_poll_total_ms",
+		metric.WithDescription("The certificate exchange total poll duration (milliseconds)."),
+	)),
+	peersSelectedPerPoll: must(meter.Int64Histogram(
+		"f3_certexchange_peers_selected_per_poll",
+		metric.WithDescription("The number of peers selected per certificate exchange poll."),
+	)),
+	peersRequiredPerPoll: must(meter.Int64Histogram(
+		"f3_certexchange_peers_required_per_poll",
+		metric.WithDescription("The number of peers we should be selecting per poll (optimally)."),
+	)),
+	pollEfficiency: must(meter.Float64Histogram(
+		"f3_certexchange_poll_efficiency",
+		metric.WithDescription("The fraction of requests necessary to make progress."),
+	)),
+}
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
 
 // A polling Subscriber will continuously poll the network for new finality certificates.
 type Subscriber struct {
@@ -109,10 +163,12 @@ func (s *Subscriber) run(ctx context.Context) error {
 			}
 			// Otherwise, poll the network.
 			if progress == 0 {
+				start := s.clock.Now()
 				progress, err = s.poll(ctx)
 				if err != nil {
 					return err
 				}
+				metrics.pollTotalMS.Record(ctx, s.clock.Since(start).Milliseconds())
 			}
 
 			nextInterval := predictor.update(progress)
@@ -120,6 +176,8 @@ func (s *Subscriber) run(ctx context.Context) error {
 			delay := max(s.clock.Until(nextPollTime), 0)
 			log.Debugf("predicted interval is %s (waiting %s)", nextInterval, delay)
 			timer.Reset(delay)
+
+			metrics.predictedPollingIntervalMS.Record(ctx, delay.Milliseconds())
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -133,9 +191,11 @@ func (s *Subscriber) poll(ctx context.Context) (uint64, error) {
 		hits   []peer.ID
 	)
 
-	peers := s.peerTracker.suggestPeers()
+	peers := s.peerTracker.suggestPeers(ctx)
 	start := s.poller.NextInstance
+
 	log.Debugf("polling %d peers for instance %d", len(peers), s.poller.NextInstance)
+	pollsSinceLastProgress := 0
 	for _, peer := range peers {
 		oldInstance := s.poller.NextInstance
 		res, err := s.poller.Poll(ctx, peer)
@@ -153,9 +213,11 @@ func (s *Subscriber) poll(ctx context.Context) (uint64, error) {
 		case PollMiss:
 			misses = append(misses, peer)
 			s.peerTracker.updateLatency(peer, res.Latency)
+			metrics.pollRTTMS.Record(ctx, res.Latency.Milliseconds())
 		case PollHit:
 			hits = append(hits, peer)
 			s.peerTracker.updateLatency(peer, res.Latency)
+			metrics.pollRTTMS.Record(ctx, res.Latency.Milliseconds())
 		case PollFailed:
 			s.peerTracker.recordFailure(peer)
 		case PollIllegal:
@@ -163,6 +225,25 @@ func (s *Subscriber) poll(ctx context.Context) (uint64, error) {
 		default:
 			panic(fmt.Sprintf("unexpected polling.PollResult: %#v", res))
 		}
+
+		if res.Progress == 0 {
+			pollsSinceLastProgress++
+		} else {
+			pollsSinceLastProgress = 0
+		}
+	}
+
+	// Record our metrics. Both:
+	// 1. How many peers we polled.
+	// 2. How many peers we needed to poll.
+	// 3. The faction of peers we should have polled (i.e., how "optimally" we're polling).
+
+	metrics.peersSelectedPerPoll.Record(ctx, int64(len(peers)))
+	if len(peers) > 0 && pollsSinceLastProgress < len(peers) {
+		required := len(peers) - pollsSinceLastProgress
+		metrics.peersRequiredPerPoll.Record(ctx, int64(required))
+		efficiency := float64(required) / float64(len(peers))
+		metrics.pollEfficiency.Record(ctx, efficiency)
 	}
 
 	// If we've made progress, record hits/misses. Otherwise, we just have to assume that we

--- a/certexchange/server.go
+++ b/certexchange/server.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/gpbft"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -20,41 +18,6 @@ import (
 )
 
 var log = logging.Logger("f3/certexchange")
-
-var serverMeter = otel.Meter("f3/certexchange/server")
-var serverMetrics = struct {
-	requests                      metric.Int64Counter
-	requestsFailed                metric.Int64Counter
-	certificatesServed            metric.Int64Counter
-	powerTablesServed             metric.Int64Counter
-	certificatesServedPerResponse metric.Int64Histogram
-	responseTimeMS                metric.Int64Histogram
-}{
-	requests: must(serverMeter.Int64Counter(
-		"f3_certexchange_server_requests",
-		metric.WithDescription("The total number of requests received."),
-	)),
-	requestsFailed: must(serverMeter.Int64Counter(
-		"f3_certexchange_server_requests_failed",
-		metric.WithDescription("The total number of requests failed."),
-	)),
-	powerTablesServed: must(serverMeter.Int64Counter(
-		"f3_certexchange_server_power_tables_served",
-		metric.WithDescription("The number of power tables served."),
-	)),
-	certificatesServed: must(serverMeter.Int64Counter(
-		"f3_certexchange_server_certificates_served",
-		metric.WithDescription("The number of certificates served."),
-	)),
-	certificatesServedPerResponse: must(serverMeter.Int64Histogram(
-		"f3_certexchange_server_certificates_served_per_response",
-		metric.WithDescription("The number of certificates served per response."),
-	)),
-	responseTimeMS: must(serverMeter.Int64Histogram(
-		"f3_certexchange_server_response_time_ms",
-		metric.WithDescription("The time it takes to respond to requests, excluding failures (milliseconds)."),
-	)),
-}
 
 const maxResponseLen = 256
 

--- a/certexchange/server.go
+++ b/certexchange/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/internal/mhelper"
 	"go.opentelemetry.io/otel/metric"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -54,10 +55,12 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 		}
 		d := float64(time.Since(start)) / float64(time.Second)
 		if internalError {
-			metrics.serveTime.Record(ctx, d, metric.WithAttributes(attrStatusInternalError))
+			metrics.serveTime.Record(ctx, d, metric.WithAttributes(
+				mhelper.AttrStatusInternalError,
+			))
 		} else {
 			metrics.serveTime.Record(ctx, d, metric.WithAttributes(
-				status(ctx, _err),
+				mhelper.Status(ctx, _err),
 				attrWithPowerTable.Bool(servedPowerTable),
 			))
 		}
@@ -106,7 +109,7 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 	defer func() {
 		metrics.certificatesServed.Record(ctx, int64(certsServed),
 			metric.WithAttributes(
-				status(ctx, _err),
+				mhelper.Status(ctx, _err),
 				attrWithPowerTable.Bool(servedPowerTable),
 			),
 		)

--- a/certexchange/util.go
+++ b/certexchange/util.go
@@ -1,0 +1,8 @@
+package certexchange
+
+func must[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/internal/mhelper/mhelper.go
+++ b/internal/mhelper/mhelper.go
@@ -31,7 +31,7 @@ var (
 		Value: attribute.StringValue("error-internal"),
 	}
 
-	AttrStatusDialFailed = attribute.Key("dial-failed")
+	AttrDialSucceeded = attribute.Key("dial-succeded")
 )
 
 func Status(ctx context.Context, err error) attribute.KeyValue {

--- a/internal/mhelper/mhelper.go
+++ b/internal/mhelper/mhelper.go
@@ -1,0 +1,54 @@
+package mhelper
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var (
+	AttrStatus        = attribute.Key("status")
+	AttrStatusSuccess = attribute.KeyValue{
+		Key:   AttrStatus,
+		Value: attribute.StringValue("success"),
+	}
+	AttrStatusError = attribute.KeyValue{
+		Key:   AttrStatus,
+		Value: attribute.StringValue("error-other"),
+	}
+	AttrStatusCanceled = attribute.KeyValue{
+		Key:   AttrStatus,
+		Value: attribute.StringValue("error-canceled"),
+	}
+	AttrStatusTimeout = attribute.KeyValue{
+		Key:   AttrStatus,
+		Value: attribute.StringValue("error-timeout"),
+	}
+	AttrStatusInternalError = attribute.KeyValue{
+		Key:   AttrStatus,
+		Value: attribute.StringValue("error-internal"),
+	}
+
+	AttrStatusDialFailed = attribute.Key("dial-failed")
+)
+
+func Status(ctx context.Context, err error) attribute.KeyValue {
+	if err == nil {
+		return AttrStatusSuccess
+	}
+
+	if os.IsTimeout(err) || errors.Is(err, os.ErrDeadlineExceeded) {
+		return AttrStatusTimeout
+	}
+
+	switch ctx.Err() {
+	case nil:
+		return AttrStatusError
+	case context.DeadlineExceeded:
+		return AttrStatusTimeout
+	default:
+		return AttrStatusCanceled
+	}
+}


### PR DESCRIPTION
This adds basic metrics so we can know how many requests we're making, how many peers we're talking to, how often we're polling, etc.

I still want to add some metrics around how often we're polling when we don't _need_ to, but I also want to rework some of that logic at the same time to reduce the number of unnecessary polls. So I'm punting that out of this round of work.