### PR TITLE
Measure time spent on validation as seconds in float64

### DIFF
--- a/gpbft/metrics.go
+++ b/gpbft/metrics.go
@@ -33,27 +33,25 @@ var (
 		TERMINATED_PHASE: attrTerminatedPhase,
 	}
 
-	metrics struct {
+	metrics = struct {
 		phaseCounter              metric.Int64Counter
 		roundHistogram            metric.Int64Histogram
 		broadcastCounter          metric.Int64Counter
 		reBroadcastCounter        metric.Int64Counter
 		reBroadcastAttemptCounter metric.Int64Counter
 		errorCounter              metric.Int64Counter
+	}{
+		phaseCounter: must(meter.Int64Counter("f3_gpbft_phase_counter", metric.WithDescription("Number of times phases change"))),
+		roundHistogram: must(meter.Int64Histogram("f3_gpbft_round_histogram",
+			metric.WithDescription("Histogram of rounds per instance"),
+			metric.WithExplicitBucketBoundaries(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0, 50.0, 100.0, 1000.0),
+		)),
+		broadcastCounter:          must(meter.Int64Counter("f3_gpbft_broadcast_counter", metric.WithDescription("Number of broadcasted messages"))),
+		reBroadcastCounter:        must(meter.Int64Counter("f3_gpbft_rebroadcast_counter", metric.WithDescription("Number of rebroadcasted messages"))),
+		reBroadcastAttemptCounter: must(meter.Int64Counter("f3_gpbft_rebroadcast_attempt_counter", metric.WithDescription("Number of rebroadcast attempts"))),
+		errorCounter:              must(meter.Int64Counter("f3_gpbft_error_counter", metric.WithDescription("Number of errors"))),
 	}
 )
-
-func init() {
-	metrics.phaseCounter = must(meter.Int64Counter("f3_gpbft_phase_counter", metric.WithDescription("Number of times phases change")))
-	metrics.roundHistogram = must(meter.Int64Histogram("f3_gpbft_round_histogram",
-		metric.WithDescription("Histogram of rounds per instance"),
-		metric.WithExplicitBucketBoundaries(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0, 50.0, 100.0, 1000.0),
-	))
-	metrics.broadcastCounter = must(meter.Int64Counter("f3_gpbft_broadcast_counter", metric.WithDescription("Number of broadcasted messages")))
-	metrics.reBroadcastCounter = must(meter.Int64Counter("f3_gpbft_rebroadcast_counter", metric.WithDescription("Number of rebroadcasted messages")))
-	metrics.reBroadcastAttemptCounter = must(meter.Int64Counter("f3_gpbft_rebroadcast_attempt_counter", metric.WithDescription("Number of rebroadcast attempts")))
-	metrics.errorCounter = must(meter.Int64Counter("f3_gpbft_error_counter", metric.WithDescription("Number of errors")))
-}
 
 func metricAttributeFromError(err error) attribute.KeyValue {
 	var v string

--- a/metrics.go
+++ b/metrics.go
@@ -41,7 +41,7 @@ func recordValidationTime(ctx context.Context, start time.Time, result pubsub.Va
 	}
 	metrics.validationTime.Record(
 		ctx,
-		float64(time.Since(start))/float64(time.Second),
+		time.Since(start).Seconds(),
 		metric.WithAttributes(attribute.KeyValue{Key: "result", Value: attribute.StringValue(v)}))
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -15,15 +15,15 @@ var metrics = struct {
 	headDiverged      metric.Int64Counter
 	reconfigured      metric.Int64Counter
 	manifestsReceived metric.Int64Counter
-	validationTime    metric.Int64Histogram
+	validationTime    metric.Float64Histogram
 }{
 	headDiverged:      must(meter.Int64Counter("f3_head_diverged", metric.WithDescription("Number of times we encountered the head has diverged from base scenario."))),
 	reconfigured:      must(meter.Int64Counter("f3_reconfigured", metric.WithDescription("Number of times we reconfigured due to new manifest being delivered."))),
 	manifestsReceived: must(meter.Int64Counter("f3_manifests_received", metric.WithDescription("Number of manifests we have received"))),
-	validationTime: must(meter.Int64Histogram("f3_validation_time_ms",
-		metric.WithDescription("Histogram of time spent validating broadcasted in milliseconds"),
-		metric.WithExplicitBucketBoundaries(1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 100.0, 200.0, 300.0, 400.0, 500.0, 1000.0),
-		metric.WithUnit("ms"),
+	validationTime: must(meter.Float64Histogram("f3_validation_time",
+		metric.WithDescription("Histogram of time spent validating broadcasted in seconds"),
+		metric.WithExplicitBucketBoundaries(0.001, 0.002, 0.003, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0),
+		metric.WithUnit("s"),
 	)),
 }
 
@@ -41,7 +41,7 @@ func recordValidationTime(ctx context.Context, start time.Time, result pubsub.Va
 	}
 	metrics.validationTime.Record(
 		ctx,
-		time.Since(start).Milliseconds(),
+		float64(time.Since(start))/float64(time.Second),
 		metric.WithAttributes(attribute.KeyValue{Key: "result", Value: attribute.StringValue(v)}))
 }
 


### PR DESCRIPTION
For better accuracy and compliance with otel best practices measure the time spent on validating messages as float64 seconds.

While at it, use inline var struct instantiation instead of init to follow a consistent convention across the repo.