### PR TITLE
Use built-in time.Seconds to measure elapsed time as float64

### DIFF
--- a/certexchange/client.go
+++ b/certexchange/client.go
@@ -62,8 +62,7 @@ func (c *Client) Request(ctx context.Context, p peer.ID, req *Request) (_rh *Res
 	requestStart := time.Now()
 	var dialSuceeded bool
 	defer func() {
-		d := float64(time.Since(requestStart)) / float64(time.Second)
-		metrics.requestLatency.Record(ctx, d, metric.WithAttributes(
+		metrics.requestLatency.Record(ctx, time.Since(requestStart).Seconds(), metric.WithAttributes(
 			mhelper.Status(ctx, _err),
 			mhelper.AttrDialSucceeded.Bool(dialSuceeded),
 		))
@@ -103,8 +102,7 @@ func (c *Client) Request(ctx context.Context, p peer.ID, req *Request) (_rh *Res
 	responseStart := time.Now()
 	defer func() {
 		if cancel != nil {
-			d := float64(time.Since(responseStart)) / float64(time.Second)
-			metrics.totalResponseTime.Record(ctx, d, metric.WithAttributes(
+			metrics.totalResponseTime.Record(ctx, time.Since(responseStart).Seconds(), metric.WithAttributes(
 				mhelper.Status(ctx, _err),
 			))
 		}
@@ -148,8 +146,7 @@ func (c *Client) Request(ctx context.Context, p peer.ID, req *Request) (_rh *Res
 				log.Error(err)
 			}
 
-			d := float64(time.Since(responseStart)) / float64(time.Second)
-			metrics.totalResponseTime.Record(ctx, d, metric.WithAttributes(
+			metrics.totalResponseTime.Record(ctx, time.Since(responseStart).Seconds(), metric.WithAttributes(
 				mhelper.Status(ctx, _err),
 			))
 
@@ -223,11 +220,11 @@ func FindInitialPowerTable(ctx context.Context, c Client, powerTableCID cid.Cid,
 		}
 		ptCID, err := certs.MakePowerTableCID(rh.PowerTable)
 		if err != nil {
-			log.Infow("computing iniital power table CID", "error", err)
+			log.Infow("computing initial power table CID", "error", err)
 			return nil, false
 		}
 		if !bytes.Equal(ptCID, powerTableCID.Bytes()) {
-			log.Infow("peer returned missmatching power table", "peer", p)
+			log.Infow("peer returned mismatching power table", "peer", p)
 			return nil, false
 		}
 		return rh.PowerTable, true

--- a/certexchange/polling/subscriber.go
+++ b/certexchange/polling/subscriber.go
@@ -124,8 +124,7 @@ func (s *Subscriber) run(ctx context.Context) error {
 			log.Debugf("predicted interval is %s (waiting %s)", nextInterval, delay)
 			timer.Reset(delay)
 
-			d := float64(delay) / float64(time.Second)
-			metrics.predictedPollingInterval.Record(ctx, d)
+			metrics.predictedPollingInterval.Record(ctx, delay.Seconds())
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -141,13 +140,12 @@ func (s *Subscriber) poll(ctx context.Context) (_progress uint64, _err error) {
 
 	startTime := time.Now()
 	defer func() {
-		d := float64(time.Since(startTime)) / float64(time.Second)
 		status := mhelper.AttrStatusSuccess
 		if _err != nil {
 			// All errors here are internal.
 			status = mhelper.AttrStatusInternalError
 		}
-		metrics.pollDuration.Record(ctx, d, metric.WithAttributes(
+		metrics.pollDuration.Record(ctx, time.Since(startTime).Seconds(), metric.WithAttributes(
 			status,
 			attrMadeProgress.Bool(_progress > 0),
 		))

--- a/certexchange/server.go
+++ b/certexchange/server.go
@@ -53,7 +53,7 @@ func (s *Server) handleRequest(ctx context.Context, stream network.Stream) (_err
 			_err = fmt.Errorf("panicked in server response: %v", perr)
 			log.Errorf("%s\n%s", _err, string(debug.Stack()))
 		}
-		d := float64(time.Since(start)) / float64(time.Second)
+		d := time.Since(start).Seconds()
 		if internalError {
 			metrics.serveTime.Record(ctx, d, metric.WithAttributes(
 				mhelper.AttrStatusInternalError,


### PR DESCRIPTION
Thanks to @kubuxu TIL this function exists. Use it instead of manually calculating elapsed time in seconds with float64 accuracy.