### PR TITLE
Measure duplicate validated messages within a bounded size

### DIFF
--- a/host.go
+++ b/host.go
@@ -293,6 +293,7 @@ func (h *gpbftRunner) validatePubsubMessage(ctx context.Context, _ peer.ID, msg 
 		log.Infof("unknown error during validation: %+v", err)
 		return pubsub.ValidationIgnore
 	default:
+		recordValidationDuplicates(ctx, validatedMessage)
 		msg.ValidatorData = validatedMessage
 		return pubsub.ValidationAccept
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -2,8 +2,10 @@ package f3
 
 import (
 	"context"
+	"sync"
 	"time"
 
+	"github.com/filecoin-project/go-f3/gpbft"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -11,13 +13,38 @@ import (
 )
 
 var meter = otel.Meter("f3")
+var sampleSets = struct {
+	messages       *sampleSet
+	justifications *sampleSet
+}{
+	// The the max size of 25K is based on network size of ~3K and 5 phases of GPBFT,
+	// where the vast majority of instances should complete in one round. That makes
+	// up ~15K messages per instance. We may observe messages from previous or future
+	// rounds, hence an additional capacity of 10K, making a total of 25K messages.
+	//
+	// Although, the number of observable messages with justification are expected to
+	// be less than the total number of observed messages we use the same 25K bounded
+	// size for justifications. The memory footprint of the additionally stored
+	// samples is negligible in return for a larger sample size and ultimately a more
+	// accurate measurement considering justification signature validation is more
+	// expensive than message signature validation.
+	//
+	// Since sampleSet caps the max size of cache keys to 96 bytes (the length
+	// of BLS signatures) the total memory footprint for 50K samples should be be
+	// below 10MB (5MB * 2 due to bookkeeping overhead).
+	messages:       newSampleSet(25_000),
+	justifications: newSampleSet(25_000),
+}
+
 var metrics = struct {
-	headDiverged       metric.Int64Counter
-	reconfigured       metric.Int64Counter
-	manifestsReceived  metric.Int64Counter
-	validationTime     metric.Float64Histogram
-	proposalFetchTime  metric.Float64Histogram
-	committeeFetchTime metric.Float64Histogram
+	headDiverged                      metric.Int64Counter
+	reconfigured                      metric.Int64Counter
+	manifestsReceived                 metric.Int64Counter
+	validationTime                    metric.Float64Histogram
+	proposalFetchTime                 metric.Float64Histogram
+	committeeFetchTime                metric.Float64Histogram
+	validationDuplicateMessages       metric.Int64Counter
+	validationDuplicateJustifications metric.Int64Counter
 }{
 	headDiverged:      must(meter.Int64Counter("f3_head_diverged", metric.WithDescription("Number of times we encountered the head has diverged from base scenario."))),
 	reconfigured:      must(meter.Int64Counter("f3_reconfigured", metric.WithDescription("Number of times we reconfigured due to new manifest being delivered."))),
@@ -37,6 +64,23 @@ var metrics = struct {
 		metric.WithExplicitBucketBoundaries(0.001, 0.003, 0.005, 0.01, 0.03, 0.05, 0.1, 0.3, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0),
 		metric.WithUnit("s"),
 	)),
+	validationDuplicateMessages:       must(meter.Int64Counter("f3_validation_duplicate_messages", metric.WithDescription("Number of duplicate GPBFT messages validated."))),
+	validationDuplicateJustifications: must(meter.Int64Counter("f3_validation_duplicate_justifications", metric.WithDescription("Number of duplicate GPBFT justifications validated."))),
+}
+
+func recordValidationDuplicates(ctx context.Context, msg gpbft.ValidatedMessage) {
+	// The given msg and its validated value should never be nil; but defensively
+	// check anyway.
+	if msg == nil || msg.Message() == nil {
+		return
+	}
+	vmsg := msg.Message()
+	if sampleSets.messages.contains(vmsg.Signature) {
+		metrics.validationDuplicateMessages.Add(ctx, 1)
+	}
+	if vmsg.Justification != nil && sampleSets.justifications.contains(vmsg.Justification.Signature) {
+		metrics.validationDuplicateJustifications.Add(ctx, 1)
+	}
 }
 
 func recordValidationTime(ctx context.Context, start time.Time, result pubsub.ValidationResult) {
@@ -75,4 +119,74 @@ func must[V any](v V, err error) V {
 		panic(err)
 	}
 	return v
+}
+
+// sampleSet stores a bounded set of samples and exposes the ability to check
+// whether it contains a given sample. See sampleSet.contains.
+//
+// Internally, sampleSet uses two maps to store samples, each of which can grow
+// up to the specified max size. When one map fills up, the sampleSet switches to
+// the other, effectively flipping between them. This allows the set to check for
+// sample existence across a range of approximately max size to twice the max size,
+// offering a larger sample set compared to implementations that track insertion
+// order with similar memory footprint.
+//
+// The worst case memory footprint of sampleSet is around 2 * maxSize * 96
+// bytes.
+type sampleSet struct {
+
+	// We can use existing LRU implementations for this at the price of slightly
+	// higher memory footprint and explanation that recency is unused. Hence the
+	// hand-rolled data structure here.
+
+	// maxSize defines the maximum number of samples to store per each internal set.
+	maxSize int
+	// mu protects access to flip and flop.
+	mu sync.Mutex
+	// flip stores one set of samples until until it reaches maxSize.
+	flip map[string]struct{}
+	// flop stores another set of samples until it reaches maxSize.
+	flop map[string]struct{}
+}
+
+// newSampleSet creates a new sampleSet with a specified max size per sample
+// subset.
+func newSampleSet(maxSize int) *sampleSet {
+	maxSize = max(1, maxSize)
+	return &sampleSet{
+		maxSize: maxSize,
+		flip:    make(map[string]struct{}, maxSize),
+		flop:    make(map[string]struct{}, maxSize),
+	}
+}
+
+// contains checks if the given sample v is contained within flip set.
+func (ss *sampleSet) contains(v []byte) bool {
+	// The number 96 comes from the length of BLS signatures, the kind of value we
+	// expect as the argument. Defensively re-slice it if it is larger at the price
+	// of losing accuracy.
+	//
+	// Alternatively we could hash the values but considering the memory footprint of
+	// these measurements (sub 10MB for a total of 50K samples) we choose larger
+	// memory consumption over CPU footprint.
+	key := string(v[:min(len(v), 96)])
+
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	// Check if the sample exists in either sets and if not insert it.
+	if _, exists := ss.flip[key]; exists {
+		return true
+	}
+	if _, exists := ss.flop[key]; exists {
+		return true
+	}
+	ss.flip[key] = struct{}{}
+
+	// Check if flip exceeds maxSize and if so do the flippity flop.
+	if len(ss.flip) >= ss.maxSize {
+		clear(ss.flop)
+		ss.flop, ss.flip = ss.flip, ss.flop
+	}
+	return false
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,60 @@
+package f3
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSampleSet(t *testing.T) {
+	subject := newSampleSet(2)
+
+	v1 := []byte("fish")
+	v2 := []byte("lobster")
+	v3 := []byte("barreleye")
+	v4 := []byte("lobstermuncher")
+
+	t.Run("does not contain unseen values", func(t *testing.T) {
+		require.False(t, subject.contains(v1))
+		require.False(t, subject.contains(v2))
+	})
+	t.Run("contains seen values", func(t *testing.T) {
+		require.True(t, subject.contains(v1))
+		require.True(t, subject.contains(v2))
+	})
+	t.Run("evicts first half once 2X capacity is reached", func(t *testing.T) {
+		require.False(t, subject.contains(v3))
+		require.True(t, subject.contains(v1))
+		require.True(t, subject.contains(v2))
+
+		require.False(t, subject.contains(v4))
+		require.False(t, subject.contains(v1))
+		require.False(t, subject.contains(v2))
+	})
+	t.Run("limits keys to 96 bytes", func(t *testing.T) {
+		longKey := make([]byte, 100)
+		n, err := rand.Read(longKey)
+		require.NoError(t, err)
+		require.Equal(t, 100, n)
+		require.False(t, subject.contains(longKey))
+		require.True(t, subject.contains(longKey))
+		require.True(t, subject.contains(longKey[:96]))
+	})
+}
+
+func TestSampleSet_MinSizeIsOne(t *testing.T) {
+	subject := newSampleSet(-1)
+	require.False(t, subject.contains([]byte("a")))
+	require.False(t, subject.contains([]byte("b")))
+	require.False(t, subject.contains([]byte("c")))
+
+	require.False(t, subject.contains([]byte("a")))
+	require.True(t, subject.contains([]byte("a")))
+
+	require.False(t, subject.contains([]byte("b")))
+	require.True(t, subject.contains([]byte("b")))
+
+	require.False(t, subject.contains([]byte("c")))
+	require.True(t, subject.contains([]byte("c")))
+}


### PR DESCRIPTION
As part of understanding duplicated effort and eventually designing a caching mechanism to reduce it, measure the number validations that are performed for messages, and separately for justifications.

The most expensive part of validation is signature validation, two of which exists at `GMessage` and `Justification`. Measuring the duplicate validations at the top level should help us understand the gain in caching already validated signatures.

The implementation introduces a new data structure to determine whether a given message/justification is seen before or not, identified by signatures. The implementation uses a total bounded size of 50K entries divided equally across counting duplicate messages and duplicate justifications. This number should be large enough to provide a reasonable signal about the amount of duplicate validations at runtime.

Relates to https://github.com/filecoin-project/go-f3/issues/131