### PR TITLE
Measure the number of validated messages with a finer grain tagging

### DIFF
--- a/host.go
+++ b/host.go
@@ -293,7 +293,7 @@ func (h *gpbftRunner) validatePubsubMessage(ctx context.Context, _ peer.ID, msg 
 		log.Infof("unknown error during validation: %+v", err)
 		return pubsub.ValidationIgnore
 	default:
-		recordValidationDuplicates(ctx, validatedMessage)
+		recordValidatedMessage(ctx, validatedMessage)
 		msg.ValidatorData = validatedMessage
 		return pubsub.ValidationAccept
 	}


### PR DESCRIPTION
Measure the total number of duplicate messages, along with duplicates, justified, and duplicate justifications.

This should provide a finer grain data for a more educated cache design.