### PR TITLE
Align catch-up GPBFT start times with the expected instance interval

### DIFF
--- a/f3_test.go
+++ b/f3_test.go
@@ -258,6 +258,7 @@ var base = manifest.Manifest{
 	Gpbft:               manifest.DefaultGpbftConfig,
 	EC:                  manifest.DefaultEcConfig,
 	CertificateExchange: manifest.DefaultCxConfig,
+	CatchUpAlignment:    manifest.DefaultCatchUpAlignment,
 }
 
 type testNode struct {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -47,6 +47,12 @@ var (
 		MinimumPollInterval:  DefaultEcConfig.Period,
 		MaximumPollInterval:  4 * DefaultEcConfig.Period,
 	}
+
+	// Default instance alignment when catching up. Set to zero for now to avoid breaking
+	// things, we should probably bump the version compatibility when we set this to a non-zero
+	// value (although that's not required).
+	//DefaultCatchUpAlignment = 4 * DefaultGpbftConfig.Delta
+	DefaultCatchUpAlignment time.Duration = 0
 )
 
 type OnManifestChange func(ctx context.Context, prevManifest Manifest) error
@@ -169,6 +175,12 @@ type Manifest struct {
 	InitialPowerTable cid.Cid // !Defined() if nil
 	// We take the current power table from the head tipset this many instances ago.
 	CommitteeLookback uint64
+	// The alignment of instances while catching up. This should be slightly larger than the
+	// expected time to complete an instance.
+	//
+	// A good default is `4 * Manifest.Gpbft.Delta` (the expected time for a single-round
+	// instance).
+	CatchUpAlignment time.Duration
 	// Config parameters for gpbft
 	Gpbft GpbftConfig
 	// EC-specific parameters
@@ -252,6 +264,7 @@ func LocalDevnetManifest() *Manifest {
 		EC:                  DefaultEcConfig,
 		Gpbft:               DefaultGpbftConfig,
 		CertificateExchange: DefaultCxConfig,
+		CatchUpAlignment:    DefaultCatchUpAlignment,
 	}
 	return m
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -45,6 +45,7 @@ var base = manifest.Manifest{
 		MinimumPollInterval:  30 * time.Second,
 		MaximumPollInterval:  2 * time.Minute,
 	},
+	CatchUpAlignment: 0,
 }
 
 func TestManifest_Validation(t *testing.T) {


### PR DESCRIPTION
When catching up, we expect many single-round instances consisting of 4 phases. So we try to align our start times with that to avoid staggering.

This should probably have a simulation test...

fixes #550