### PR TITLE
Restore default GOGC for CI fuzz tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ test/cover: GOTEST_ARGS=-coverprofile=coverage.txt -covermode=atomic -coverpkg=.
 .PHONY: test/cover
 
 fuzz: FUZZTIME ?= 10s # The duration to run fuzz testing, default to 10s if unset.
-fuzz: GOGC ?= 400 # Reduce GC frequency during testing, default to 400 if unset.
 fuzz: # List all fuzz tests across the repo, and run them one at a time with the configured fuzztime.
 	@set -e; \
 	go list ./... | while read -r package; do \


### PR DESCRIPTION
Remove the GOGC override for CI fuzz tests, because:
 * without it fuzz tests run faster,
 * we are close to the runner's memory limit, and we get false positive failures caused bo GitHub Actions SIGTERM if we go over the limit.