### PR TITLE
Use a fixed version of golangci-lint and fix lint issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /usr/bin/env bash
 
+GOLANGCILINT = go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
 
 all: generate test fuzz lint
 
@@ -25,7 +26,7 @@ fuzz: # List all fuzz tests across the repo, and run them one at a time with the
 
 lint:
 	go mod tidy
-	golangci-lint run ./...
+	$(GOLANGCILINT) run ./...
 .PHONY: lint
 
 generate:

--- a/certexchange/client.go
+++ b/certexchange/client.go
@@ -185,7 +185,7 @@ func (c *Client) Request(ctx context.Context, p peer.ID, req *Request) (_rh *Res
 			}
 		}
 		return nil
-	}()
+	}() //nolint:errcheck
 	return &resp, ch, nil
 }
 


### PR DESCRIPTION
Although the CI uses staticcheck only, the team's preference is to continue and use golangci in `make lint`.

Fix the version of golangci-lint used for a more consistent checking, and fix the golangci lint issues not picked up by CI.
