### PR TITLE
Use fixed size byte array for public key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,7 @@ build: f3
 f3:
 	go build ./cmd/f3
 .PHONY: f3
+
+gen:
+	go generate ./...
+.PHONY: gen

--- a/blssig/cache_test.go
+++ b/blssig/cache_test.go
@@ -24,7 +24,7 @@ func TestCacheMemory(t *testing.T) {
 		pubKeyB, err := pub.MarshalBinary()
 		require.NoError(t, err)
 		require.Len(t, pubKeyB, 48)
-		keys[i] = pubKeyB
+		copy(keys[i][:], pubKeyB)
 	}
 
 	runtime.GC()

--- a/blssig/signer.go
+++ b/blssig/signer.go
@@ -1,7 +1,6 @@
 package blssig
 
 import (
-	"bytes"
 	"context"
 	"errors"
 
@@ -28,7 +27,7 @@ func SignerWithKeyOnG1(pub gpbft.PubKey, privKey kyber.Scalar) *Signer {
 }
 
 func (s *Signer) Sign(_ context.Context, sender gpbft.PubKey, msg []byte) ([]byte, error) {
-	if !bytes.Equal(sender, s.pubKey) {
+	if sender != s.pubKey {
 		return nil, errors.New("cannot sign: unknown sender")
 	}
 	return s.scheme.Sign(s.privKey, msg)

--- a/blssig/verifier_test.go
+++ b/blssig/verifier_test.go
@@ -6,6 +6,7 @@ import (
 
 	bls12381 "github.com/drand/kyber-bls12381"
 	"github.com/drand/kyber/sign/bdn"
+	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,17 +17,25 @@ func BenchmarkBLSSigning(b *testing.B) {
 	)
 	privKey, pubKey := blsSchema.NewKeyPair(blsSuit.RandomStream())
 	pubKeyB, err := pubKey.MarshalBinary()
+	var pubK gpbft.PubKey
+	copy(pubK[:], pubKeyB)
 	require.NoError(b, err)
-	signer := SignerWithKeyOnG1(pubKeyB, privKey)
+	signer := SignerWithKeyOnG1(pubK, privKey)
 	verifier := VerifierWithKeyOnG1()
 	ctx := context.Background()
 
-	sig, err := signer.Sign(ctx, pubKeyB, pubKeyB)
+	sig, err := signer.Sign(ctx, pubK, pubKeyB)
 	require.NoError(b, err)
 	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		err := verifier.Verify(pubKeyB, pubKeyB, sig)
-		require.NoError(b, err)
-	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			err := verifier.Verify(pubK, pubKeyB, sig)
+			require.NoError(b, err)
+		}
+	})
+	//for i := 0; i < b.N; i++ {
+	//	err := verifier.Verify(pubKeyB, pubKeyB, sig)
+	//	require.NoError(b, err)
+	//}
 }

--- a/certexchange/protocol_test.go
+++ b/certexchange/protocol_test.go
@@ -24,10 +24,10 @@ func testPowerTable(entries int64) (gpbft.PowerEntries, gpbft.CID) {
 
 	for i := range powerTable {
 		powerTable[i] = gpbft.PowerEntry{
-			ID:     gpbft.ActorID(i + 1),
-			Power:  gpbft.NewStoragePower(int64(len(powerTable)*2 - i/2)),
-			PubKey: []byte("fake key"),
+			ID:    gpbft.ActorID(i + 1),
+			Power: gpbft.NewStoragePower(int64(len(powerTable)*2 - i/2)),
 		}
+		copy(powerTable[i].PubKey[:], "fake key")
 	}
 	k, err := certs.MakePowerTableCID(powerTable)
 	if err != nil {

--- a/certs/cbor_gen.go
+++ b/certs/cbor_gen.go
@@ -44,7 +44,7 @@ func (t *PowerTableDelta) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.SigningKey (gpbft.PubKey) (slice)
+	// t.SigningKey (gpbft.PubKey) (array)
 	if len(t.SigningKey) > 2097152 {
 		return xerrors.Errorf("Byte array in field t.SigningKey was too long")
 	}
@@ -53,10 +53,9 @@ func (t *PowerTableDelta) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if _, err := cw.Write(t.SigningKey); err != nil {
+	if _, err := cw.Write(t.SigningKey[:]); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -106,7 +105,7 @@ func (t *PowerTableDelta) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 	}
-	// t.SigningKey (gpbft.PubKey) (slice)
+	// t.SigningKey (gpbft.PubKey) (array)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {
@@ -119,15 +118,14 @@ func (t *PowerTableDelta) UnmarshalCBOR(r io.Reader) (err error) {
 	if maj != cbg.MajByteString {
 		return fmt.Errorf("expected byte array")
 	}
-
-	if extra > 0 {
-		t.SigningKey = make([]uint8, extra)
+	if extra != 48 {
+		return fmt.Errorf("expected array to have 48 elements")
 	}
 
-	if _, err := io.ReadFull(cr, t.SigningKey); err != nil {
+	t.SigningKey = [48]uint8{}
+	if _, err := io.ReadFull(cr, t.SigningKey[:]); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -409,7 +409,7 @@ func TestBadFinalityCertificates(t *testing.T) {
 		certCpy.PowerTableDelta = slices.Clone(certCpy.PowerTableDelta)
 		// empty diff is invalid.
 		certCpy.PowerTableDelta[0].PowerDelta = gpbft.NewStoragePower(0)
-		certCpy.PowerTableDelta[0].SigningKey = nil
+		certCpy.PowerTableDelta[0].SigningKey = *new(gpbft.PubKey)
 
 		nextInstance, chain, newPowerTable, err := certs.ValidateFinalityCertificates(backend, networkName, powerTable, 1, nil, certCpy)
 		require.ErrorContains(t, err, "failed to apply power table delta")

--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -19,10 +19,10 @@ func testPowerTable(entries int64) (gpbft.PowerEntries, gpbft.CID) {
 
 	for i := range powerTable {
 		powerTable[i] = gpbft.PowerEntry{
-			ID:     gpbft.ActorID(i + 1),
-			Power:  gpbft.NewStoragePower(int64(len(powerTable)*2 - i/2)),
-			PubKey: []byte("fake key"),
+			ID:    gpbft.ActorID(i + 1),
+			Power: gpbft.NewStoragePower(int64(len(powerTable)*2 - i/2)),
 		}
+		copy(powerTable[i].PubKey[:], "fake key")
 	}
 	k, err := certs.MakePowerTableCID(powerTable)
 	if err != nil {
@@ -98,6 +98,9 @@ func TestPutWrongPowerDelta(t *testing.T) {
 	cs, err := CreateStore(ctx, ds, 0, pt)
 	require.NoError(t, err)
 
+	var key gpbft.PubKey
+	copy(key[:], "testkey")
+
 	// Make sure we sanity check the produced power table.
 	cert := &certs.FinalityCertificate{
 		GPBFTInstance:    0,
@@ -105,7 +108,7 @@ func TestPutWrongPowerDelta(t *testing.T) {
 		PowerTableDelta: certs.PowerTableDiff{{
 			ParticipantID: 0,
 			PowerDelta:    gpbft.NewStoragePower(10),
-			SigningKey:    []byte("testkey"),
+			SigningKey:    key,
 		}}}
 
 	err = cs.Put(ctx, cert)
@@ -368,7 +371,7 @@ func TestCreateOpen(t *testing.T) {
 
 	pt, _ := testPowerTable(20)
 	newPt := slices.Clone(pt)
-	newPt[0].PubKey = []byte("other key")
+	copy(newPt[0].PubKey[:], "other key")
 
 	// Cannot open if it doesn't exist.
 	_, err := OpenStore(ctx, ds)
@@ -461,7 +464,7 @@ func testPowerInner(t *testing.T, firstInstance uint64) {
 
 	pt, ptCid := testPowerTable(20)
 	newPt := slices.Clone(pt)
-	newPt[0].PubKey = []byte("other key")
+	copy(newPt[0].PubKey[:], "other key")
 	newPtCid, err := certs.MakePowerTableCID(newPt)
 	require.NoError(t, err)
 

--- a/emulator/instance.go
+++ b/emulator/instance.go
@@ -36,9 +36,9 @@ func NewInstance(t *testing.T, id uint64, powerEntries gpbft.PowerEntries, propo
 
 	powerEntries = slices.Clone(powerEntries)
 	for i, entry := range powerEntries {
-		if len(entry.PubKey) == 0 {
+		if entry.PubKey.IsZero() {
 			// Populate missing public key to avoid power table validation errors.
-			powerEntries[i].PubKey = []byte(fmt.Sprintf("🪪%d", entry.ID))
+			copy(powerEntries[i].PubKey[:], fmt.Sprintf("🪪%d", entry.ID))
 		}
 	}
 	ptCid, err := certs.MakePowerTableCID(powerEntries)

--- a/emulator/signing.go
+++ b/emulator/signing.go
@@ -26,7 +26,7 @@ type adhocSigning struct{}
 
 func (s adhocSigning) Sign(_ context.Context, sender gpbft.PubKey, msg []byte) ([]byte, error) {
 	hasher := crc32.NewIEEE()
-	if _, err := hasher.Write(sender); err != nil {
+	if _, err := hasher.Write(sender[:]); err != nil {
 		return nil, err
 	}
 	if _, err := hasher.Write(msg); err != nil {
@@ -52,7 +52,7 @@ func (s adhocSigning) Aggregate(signers []gpbft.PubKey, sigs [][]byte) ([]byte, 
 	}
 	hasher := crc32.NewIEEE()
 	for i, signer := range signers {
-		if _, err := hasher.Write(signer); err != nil {
+		if _, err := hasher.Write(signer[:]); err != nil {
 			return nil, err
 		}
 		if _, err := hasher.Write(sigs[i]); err != nil {

--- a/gpbft/cbor_gen.go
+++ b/gpbft/cbor_gen.go
@@ -780,7 +780,7 @@ func (t *PowerEntry) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.PubKey (gpbft.PubKey) (slice)
+	// t.PubKey (gpbft.PubKey) (array)
 	if len(t.PubKey) > 2097152 {
 		return xerrors.Errorf("Byte array in field t.PubKey was too long")
 	}
@@ -789,10 +789,9 @@ func (t *PowerEntry) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if _, err := cw.Write(t.PubKey); err != nil {
+	if _, err := cw.Write(t.PubKey[:]); err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -842,7 +841,7 @@ func (t *PowerEntry) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 	}
-	// t.PubKey (gpbft.PubKey) (slice)
+	// t.PubKey (gpbft.PubKey) (array)
 
 	maj, extra, err = cr.ReadHeader()
 	if err != nil {
@@ -855,15 +854,14 @@ func (t *PowerEntry) UnmarshalCBOR(r io.Reader) (err error) {
 	if maj != cbg.MajByteString {
 		return fmt.Errorf("expected byte array")
 	}
-
-	if extra > 0 {
-		t.PubKey = make([]uint8, extra)
+	if extra != 48 {
+		return fmt.Errorf("expected array to have 48 elements")
 	}
 
-	if _, err := io.ReadFull(cr, t.PubKey); err != nil {
+	t.PubKey = [48]uint8{}
+	if _, err := io.ReadFull(cr, t.PubKey[:]); err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/gpbft/message_builder.go
+++ b/gpbft/message_builder.go
@@ -57,7 +57,7 @@ type SignatureBuilder struct {
 
 func (mb *MessageBuilder) PrepareSigningInputs(id ActorID) (*SignatureBuilder, error) {
 	effectivePower, pubKey := mb.PowerTable.Get(id)
-	if pubKey == nil || effectivePower == 0 {
+	if pubKey.IsZero() || effectivePower == 0 {
 		return nil, fmt.Errorf("could not find pubkey for actor %d: %w", id, ErrNoPower)
 	}
 	sb := SignatureBuilder{
@@ -65,8 +65,7 @@ func (mb *MessageBuilder) PrepareSigningInputs(id ActorID) (*SignatureBuilder, e
 		NetworkName:   mb.NetworkName,
 		Payload:       mb.Payload,
 		Justification: mb.Justification,
-
-		PubKey: pubKey,
+		PubKey:        pubKey,
 	}
 
 	sb.PayloadToSign = mb.SigningMarshaler.MarshalPayloadForSigning(mb.NetworkName, &mb.Payload)

--- a/gpbft/message_builder_test.go
+++ b/gpbft/message_builder_test.go
@@ -21,12 +21,12 @@ func TestMessageBuilder(t *testing.T) {
 	err := pt.Add([]PowerEntry{
 		{
 			ID:     0,
-			PubKey: PubKey{0},
+			PubKey: PubKey{01},
 			Power:  big.NewInt(1),
 		},
 		{
 			ID:     1,
-			PubKey: PubKey{1},
+			PubKey: PubKey{02},
 			Power:  big.NewInt(1),
 		},
 	}...)
@@ -52,7 +52,7 @@ func TestMessageBuilder(t *testing.T) {
 
 	require.Equal(t, st.Payload, payload)
 	require.Equal(t, st.ParticipantID, ActorID(0))
-	require.Equal(t, st.PubKey, PubKey{0})
+	require.Equal(t, st.PubKey, PubKey{01})
 	require.NotNil(t, st.PayloadToSign)
 	require.Nil(t, st.VRFToSign)
 
@@ -61,7 +61,7 @@ func TestMessageBuilder(t *testing.T) {
 
 	require.Equal(t, st.Payload, payload)
 	require.Equal(t, st.ParticipantID, ActorID(1))
-	require.Equal(t, st.PubKey, PubKey{1})
+	require.Equal(t, st.PubKey, PubKey{02})
 	require.NotNil(t, st.PayloadToSign)
 	require.Nil(t, st.VRFToSign)
 }
@@ -71,12 +71,12 @@ func TestMessageBuilderWithVRF(t *testing.T) {
 	err := pt.Add([]PowerEntry{
 		{
 			ID:     0,
-			PubKey: PubKey{0},
+			PubKey: PubKey{01},
 			Power:  big.NewInt(1),
 		},
 		{
 			ID:     1,
-			PubKey: PubKey{1},
+			PubKey: PubKey{02},
 			Power:  big.NewInt(1),
 		},
 	}...)
@@ -100,7 +100,7 @@ func TestMessageBuilderWithVRF(t *testing.T) {
 
 	require.Equal(t, st.Payload, payload)
 	require.Equal(t, st.ParticipantID, ActorID(0))
-	require.Equal(t, st.PubKey, PubKey{0})
+	require.Equal(t, st.PubKey, PubKey{01})
 	require.NotNil(t, st.PayloadToSign)
 	require.NotNil(t, st.VRFToSign)
 
@@ -109,7 +109,7 @@ func TestMessageBuilderWithVRF(t *testing.T) {
 
 	require.Equal(t, st.Payload, payload)
 	require.Equal(t, st.ParticipantID, ActorID(1))
-	require.Equal(t, st.PubKey, PubKey{1})
+	require.Equal(t, st.PubKey, PubKey{02})
 	require.NotNil(t, st.PayloadToSign)
 	require.NotNil(t, st.VRFToSign)
 }

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -17,7 +17,7 @@ import (
 var somePowerEntry = gpbft.PowerEntry{
 	ID:     1513,
 	Power:  gpbft.NewStoragePower(1514),
-	PubKey: gpbft.PubKey("ghoti"),
+	PubKey: pubKeyFrom("ghoti"),
 }
 
 type participantTestSubject struct {
@@ -55,7 +55,7 @@ func newParticipantTestSubject(t *testing.T, seed int64, instance uint64) *parti
 		t:              t,
 		rng:            rng,
 		id:             gpbft.ActorID(rng.Uint64()),
-		pubKey:         generateRandomBytes(rng),
+		pubKey:         pubKeyFrom(generateRandomBytes(rng)),
 		delta:          delta,
 		instance:       instance,
 		networkName:    "fish",
@@ -471,7 +471,7 @@ func TestParticipant_ValidateMessage(t *testing.T) {
 		zeroPowerEntry = gpbft.PowerEntry{
 			ID:     1613,
 			Power:  gpbft.NewStoragePower(0),
-			PubKey: gpbft.PubKey("fishmonger"),
+			PubKey: pubKeyFrom("fishmonger"),
 		}
 		signature = []byte("barreleye")
 	)

--- a/gpbft/powertable_test.go
+++ b/gpbft/powertable_test.go
@@ -13,10 +13,10 @@ import (
 func TestPowerTable(t *testing.T) {
 
 	var (
-		oneValidEntry        = gpbft.PowerEntry{ID: 1413, Power: gpbft.NewStoragePower(1414000), PubKey: []byte("fish")}
-		anotherValidEntry    = gpbft.PowerEntry{ID: 1513, Power: gpbft.NewStoragePower(1514000), PubKey: []byte("lobster")}
-		yetAnotherValidEntry = gpbft.PowerEntry{ID: 1490, Power: gpbft.NewStoragePower(1491000), PubKey: []byte("lobster")}
-		zeroPowerEntry       = gpbft.PowerEntry{ID: 1613, Power: gpbft.NewStoragePower(0), PubKey: []byte("fish")}
+		oneValidEntry        = gpbft.PowerEntry{ID: 1413, Power: gpbft.NewStoragePower(1414000), PubKey: pubKeyFrom("fish")}
+		anotherValidEntry    = gpbft.PowerEntry{ID: 1513, Power: gpbft.NewStoragePower(1514000), PubKey: pubKeyFrom("lobster")}
+		yetAnotherValidEntry = gpbft.PowerEntry{ID: 1490, Power: gpbft.NewStoragePower(1491000), PubKey: pubKeyFrom("lobster")}
+		zeroPowerEntry       = gpbft.PowerEntry{ID: 1613, Power: gpbft.NewStoragePower(0), PubKey: pubKeyFrom("fish")}
 		noPubKeyEntry        = gpbft.PowerEntry{ID: 1613, Power: gpbft.NewStoragePower(1614000)}
 	)
 
@@ -29,7 +29,7 @@ func TestPowerTable(t *testing.T) {
 			subject := gpbft.NewPowerTable()
 			gotPower, gotKey := subject.Get(1413)
 			require.Zero(t, gotPower)
-			require.Nil(t, gotKey)
+			require.True(t, gotKey.IsZero())
 		})
 	})
 	t.Run("on Add", func(t *testing.T) {
@@ -71,7 +71,7 @@ func TestPowerTable(t *testing.T) {
 			samePowerEntryWithSmallerID := gpbft.PowerEntry{
 				ID:     oneValidEntry.ID - 1,
 				Power:  oneValidEntry.Power,
-				PubKey: []byte("barreleye"),
+				PubKey: pubKeyFrom("barreleye"),
 			}
 			require.NoError(t, subject.Add(oneValidEntry, samePowerEntryWithSmallerID))
 			requireAddedToPowerTable(t, subject, oneValidEntry)

--- a/gpbft/types.go
+++ b/gpbft/types.go
@@ -6,7 +6,7 @@ type ActorID uint64
 
 type StoragePower = big.Int
 
-type PubKey []byte
+type PubKey [48]byte
 
 // NetworkName provides separation between different networks
 // it is implicitly included in all signatures and VRFs
@@ -15,4 +15,10 @@ type NetworkName string
 // Creates a new StoragePower struct with a specific value and returns the result
 func NewStoragePower(value int64) StoragePower {
 	return big.NewInt(value)
+}
+
+var zeroPubKey PubKey
+
+func (pk PubKey) IsZero() bool {
+	return pk == zeroPubKey
 }

--- a/gpbft/types_test.go
+++ b/gpbft/types_test.go
@@ -1,0 +1,20 @@
+package gpbft_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/stretchr/testify/require"
+)
+
+func pubKeyFrom[V string | []byte](v V) gpbft.PubKey {
+	var subject gpbft.PubKey
+	copy(subject[:], v)
+	return subject
+}
+
+func TestPubKey_IsZero(t *testing.T) {
+	var subject gpbft.PubKey
+	require.True(t, subject.IsZero())
+	require.False(t, pubKeyFrom("fish").IsZero())
+}

--- a/internal/powerstore/powerstore_test.go
+++ b/internal/powerstore/powerstore_test.go
@@ -57,9 +57,15 @@ func (f *forgetfulEC) GetPowerTable(ctx context.Context, tsk gpbft.TipSetKey) (g
 var _ ec.Backend = (*forgetfulEC)(nil)
 
 var basePowerTable = gpbft.PowerEntries{
-	{ID: 1, Power: gpbft.NewStoragePower(50), PubKey: gpbft.PubKey("1")},
-	{ID: 3, Power: gpbft.NewStoragePower(10), PubKey: gpbft.PubKey("2")},
-	{ID: 4, Power: gpbft.NewStoragePower(4), PubKey: gpbft.PubKey("3")},
+	{ID: 1, Power: gpbft.NewStoragePower(50), PubKey: pubKeyFromString("1")},
+	{ID: 3, Power: gpbft.NewStoragePower(10), PubKey: pubKeyFromString("2")},
+	{ID: 4, Power: gpbft.NewStoragePower(4), PubKey: pubKeyFromString("3")},
+}
+
+func pubKeyFromString(v string) gpbft.PubKey {
+	var pubKey gpbft.PubKey
+	copy(pubKey[:], v)
+	return pubKey
 }
 
 func TestPowerStore(t *testing.T) {

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -18,12 +18,12 @@ var base = manifest.Manifest{
 		{
 			ID:     2,
 			Power:  gpbft.NewStoragePower(1),
-			PubKey: gpbft.PubKey{0},
+			PubKey: gpbft.PubKey{01},
 		},
 		{
 			ID:     3,
 			Power:  gpbft.NewStoragePower(1),
-			PubKey: gpbft.PubKey{1},
+			PubKey: gpbft.PubKey{02},
 		},
 	},
 	CommitteeLookback: 10,

--- a/sim/adversary/decide.go
+++ b/sim/adversary/decide.go
@@ -102,7 +102,8 @@ func (i *ImmediateDecide) StartInstanceAt(instance uint64, _when time.Time) erro
 	)
 
 	if err := signers.ForEach(func(j uint64) error {
-		pubkey := gpbft.PubKey("fake pubkeyaaaaa")
+		var pubkey gpbft.PubKey
+		copy(pubkey[:], "fake pubkeyaaaaa")
 		sig := []byte("fake sig")
 		if j < uint64(len(powertable.Entries)) {
 			pubkey = powertable.Entries[j].PubKey


### PR DESCRIPTION
GPBFT used BLS public keys which are fixed to 48 bytes. Use fixed size array to represent it in code and reflect the changes across the repo.

Fixes https://github.com/filecoin-project/go-f3/issues/547