### PR TITLE
Improve GPBFT Logging

### DIFF
--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -754,8 +754,8 @@ func (i *instance) getRound(r uint64) *roundState {
 }
 
 func (i *instance) beginNextRound() {
+	i.log("moving to round %d with %s", i.round+1, i.proposal.String())
 	i.round += 1
-	i.log("moving to round %d with %s", i.round, i.proposal.String())
 	metrics.currentRound.Record(context.TODO(), int64(i.round))
 
 	prevRound := i.getRound(i.round - 1)

--- a/logging.go
+++ b/logging.go
@@ -6,7 +6,7 @@ import (
 )
 
 var log = logging.Logger("f3")
-var tracer gpbft.Tracer = (*gpbftTracer)(logging.WithSkip(logging.Logger("f3/gpbft"), 1))
+var tracer gpbft.Tracer = (*gpbftTracer)(logging.WithSkip(logging.Logger("f3/gpbft"), 2))
 
 // Tracer used by GPBFT, backed by a Zap logger.
 type gpbftTracer logging.ZapEventLogger


### PR DESCRIPTION
1. Update round after logging so we log with the correct round.
2. Fix the logger skip.