### PR TITLE
Add GPBFT backoff to manifest

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -30,15 +30,12 @@ var (
 	}
 
 	DefaultGpbftConfig = GpbftConfig{
-		Delta:                3 * time.Second,
-		DeltaBackOffExponent: 2.0,
-		MaxLookaheadRounds:   5,
-	}
-
-	DefaultGpbftOptions = []gpbft.Option{
-		gpbft.WithMaxLookaheadRounds(DefaultGpbftConfig.MaxLookaheadRounds),
-		gpbft.WithDelta(DefaultGpbftConfig.Delta),
-		gpbft.WithDeltaBackOffExponent(DefaultGpbftConfig.DeltaBackOffExponent),
+		Delta:                      3 * time.Second,
+		DeltaBackOffExponent:       2.0,
+		MaxLookaheadRounds:         5,
+		RebroadcastBackoffBase:     3 * time.Second,
+		RebroadcastBackoffExponent: 1.3,
+		RebroadcastBackoffMax:      30 * time.Second,
 	}
 
 	DefaultCxConfig = CxConfig{
@@ -92,6 +89,10 @@ type GpbftConfig struct {
 	Delta                time.Duration
 	DeltaBackOffExponent float64
 	MaxLookaheadRounds   uint64
+
+	RebroadcastBackoffBase     time.Duration
+	RebroadcastBackoffExponent float64
+	RebroadcastBackoffMax      time.Duration
 }
 
 func (g *GpbftConfig) Validate() error {
@@ -101,7 +102,33 @@ func (g *GpbftConfig) Validate() error {
 	if g.DeltaBackOffExponent < 1.0 {
 		return fmt.Errorf("GPBFT backoff exponent must be at least 1.0, was %f", g.DeltaBackOffExponent)
 	}
+
+	if g.RebroadcastBackoffBase <= 0 {
+		return fmt.Errorf("GPBFT rebroadcast backoff base must be greater than 0, was %s",
+			g.RebroadcastBackoffBase)
+	}
+	if g.RebroadcastBackoffExponent < 1.0 {
+		return fmt.Errorf("GPBFT rebroadcast backoff exponent must be at least 1.0, was %f",
+			g.RebroadcastBackoffExponent)
+	}
+	if g.RebroadcastBackoffMax < g.RebroadcastBackoffBase {
+		return fmt.Errorf("GPBFT rebroadcast backoff max (%s) must be at least the backoff base (%s)",
+			g.RebroadcastBackoffMax, g.RebroadcastBackoffBase)
+	}
 	return nil
+}
+
+func (g *GpbftConfig) ToOptions() []gpbft.Option {
+	return []gpbft.Option{
+		gpbft.WithDelta(g.Delta),
+		gpbft.WithDeltaBackOffExponent(g.DeltaBackOffExponent),
+		gpbft.WithMaxLookaheadRounds(g.MaxLookaheadRounds),
+		gpbft.WithRebroadcastBackoff(
+			DefaultGpbftConfig.RebroadcastBackoffExponent,
+			DefaultGpbftConfig.RebroadcastBackoffBase,
+			DefaultGpbftConfig.RebroadcastBackoffMax,
+		),
+	}
 }
 
 type EcConfig struct {
@@ -288,15 +315,5 @@ func PubSubTopicFromNetworkName(nn gpbft.NetworkName) string {
 }
 
 func (m *Manifest) GpbftOptions() []gpbft.Option {
-	if m.Gpbft == (GpbftConfig{}) {
-		return DefaultGpbftOptions
-	}
-	var opts []gpbft.Option
-	if m.Gpbft.Delta != 0 {
-		opts = append(opts, gpbft.WithDelta(m.Gpbft.Delta))
-	}
-	opts = append(opts, gpbft.WithDeltaBackOffExponent(m.Gpbft.DeltaBackOffExponent))
-	opts = append(opts, gpbft.WithMaxLookaheadRounds(m.Gpbft.MaxLookaheadRounds))
-
-	return opts
+	return m.Gpbft.ToOptions()
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -28,9 +28,12 @@ var base = manifest.Manifest{
 	},
 	CommitteeLookback: 10,
 	Gpbft: manifest.GpbftConfig{
-		Delta:                10,
-		DeltaBackOffExponent: 1.2,
-		MaxLookaheadRounds:   5,
+		Delta:                      10,
+		DeltaBackOffExponent:       1.2,
+		MaxLookaheadRounds:         5,
+		RebroadcastBackoffBase:     10,
+		RebroadcastBackoffExponent: 1.3,
+		RebroadcastBackoffMax:      30,
 	},
 	EC: manifest.EcConfig{
 		Finality:                 900,


### PR DESCRIPTION
This adds rebroadcast backoff config to the manifest. Unfortunately, this will require a network protocol bump if we actually want to change this.