### PR TITLE
Add topic scoring & reduce pubsub spam

### DIFF
--- a/cmd/f3/manifest.go
+++ b/cmd/f3/manifest.go
@@ -125,7 +125,7 @@ var manifestServeCmd = cli.Command{
 		&cli.DurationFlag{
 			Name:  "publishInterval",
 			Usage: "The interval at which manifest is published on pubsub.",
-			Value: 20 * time.Second,
+			Value: 2 * pubsub.TimeCacheDuration,
 		},
 	},
 
@@ -205,7 +205,11 @@ var manifestServeCmd = cli.Command{
 			return fmt.Errorf("loading initial manifest: %w", err)
 		}
 
-		pubSub, err := pubsub.NewGossipSub(c.Context, host, pubsub.WithPeerExchange(true))
+		pubSub, err := pubsub.NewGossipSub(c.Context, host,
+			pubsub.WithPeerExchange(true),
+			pubsub.WithFloodPublish(true),
+			pubsub.WithPeerScore(PubsubPeerScoreParams, PubsubPeerScoreThresholds),
+		)
 		if err != nil {
 			return fmt.Errorf("initialzing pubsub: %w", err)
 		}

--- a/cmd/f3/observer.go
+++ b/cmd/f3/observer.go
@@ -246,7 +246,7 @@ func observeManifest(ctx context.Context, manif *manifest.Manifest, pubSub *pubs
 		return fmt.Errorf("registering topic validator: %w", err)
 	}
 
-	topic, err := pubSub.Join(manif.PubSubTopic(), pubsub.WithTopicMessageIdFn(psutil.PubsubMsgIdHashData))
+	topic, err := pubSub.Join(manif.PubSubTopic(), pubsub.WithTopicMessageIdFn(psutil.GPBFTMessageIdFn))
 	if err != nil {
 		return fmt.Errorf("joining topic: %w", err)
 	}

--- a/cmd/f3/pusub.go
+++ b/cmd/f3/pusub.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 func init() {
@@ -20,3 +21,45 @@ func init() {
 	pubsub.GossipSubHistoryLength = 10
 	pubsub.GossipSubGossipFactor = 0.1
 }
+
+// Borrowed from lotus
+var PubsubPeerScoreParams = &pubsub.PeerScoreParams{
+	AppSpecificScore:  func(p peer.ID) float64 { return 0 },
+	AppSpecificWeight: 1,
+
+	// This sets the IP colocation threshold to 5 peers before we apply penalties
+	IPColocationFactorThreshold: 5,
+	IPColocationFactorWeight:    -100,
+	IPColocationFactorWhitelist: nil,
+
+	// P7: behavioural penalties, decay after 1hr
+	BehaviourPenaltyThreshold: 6,
+	BehaviourPenaltyWeight:    -10,
+	BehaviourPenaltyDecay:     pubsub.ScoreParameterDecay(time.Hour),
+
+	DecayInterval: pubsub.DefaultDecayInterval,
+	DecayToZero:   pubsub.DefaultDecayToZero,
+
+	// this retains non-positive scores for 6 hours
+	RetainScore: 6 * time.Hour,
+
+	// topic parameters
+	Topics: make(map[string]*pubsub.TopicScoreParams),
+}
+
+var PubsubPeerScoreThresholds = &pubsub.PeerScoreThresholds{
+	GossipThreshold:             GossipScoreThreshold,
+	PublishThreshold:            PublishScoreThreshold,
+	GraylistThreshold:           GraylistScoreThreshold,
+	AcceptPXThreshold:           AcceptPXScoreThreshold,
+	OpportunisticGraftThreshold: OpportunisticGraftScoreThreshold,
+}
+
+// Borrowed from lotus
+const (
+	GossipScoreThreshold             = -500
+	PublishScoreThreshold            = -1000
+	GraylistScoreThreshold           = -2500
+	AcceptPXScoreThreshold           = 1000
+	OpportunisticGraftScoreThreshold = 3.5
+)

--- a/f3_test.go
+++ b/f3_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/internal/clock"
+	"github.com/filecoin-project/go-f3/internal/psutil"
 	"github.com/filecoin-project/go-f3/manifest"
 	"github.com/filecoin-project/go-f3/sim/signing"
 
@@ -24,6 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
+
+func init() {
+	// Hash-based deduplication breaks fast rebroadcast, even if we set the time window to be
+	// really short because gossipsub has a minimum 1m cache scan interval.
+	psutil.GPBFTMessageIdFn = pubsub.DefaultMsgIdFn
+}
 
 var ManifestSenderTimeout = 2 * pubsub.TimeCacheDuration
 

--- a/f3_test.go
+++ b/f3_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const ManifestSenderTimeout = 30 * time.Second
+var ManifestSenderTimeout = 2 * pubsub.TimeCacheDuration
 
 func TestF3Simple(t *testing.T) {
 	t.Parallel()

--- a/f3_test.go
+++ b/f3_test.go
@@ -32,7 +32,7 @@ func init() {
 	psutil.GPBFTMessageIdFn = pubsub.DefaultMsgIdFn
 }
 
-var ManifestSenderTimeout = 2 * pubsub.TimeCacheDuration
+var ManifestSenderTimeout = 30 * time.Second
 
 func TestF3Simple(t *testing.T) {
 	t.Parallel()

--- a/host.go
+++ b/host.go
@@ -336,7 +336,7 @@ func (h *gpbftRunner) setupPubsub() error {
 	}
 
 	if err := topic.SetScoreParams(psutil.PubsubTopicScoreParams); err != nil {
-		log.Errorw("failed to set topic score params", "error", err)
+		log.Infow("failed to set topic score params", "error", err)
 	}
 
 	h.topic = topic

--- a/host.go
+++ b/host.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/internal/clock"
+	"github.com/filecoin-project/go-f3/internal/psutil"
 	"github.com/filecoin-project/go-f3/manifest"
 	"go.opentelemetry.io/otel/metric"
 
@@ -329,11 +330,17 @@ func (h *gpbftRunner) setupPubsub() error {
 	// Force the default (sender + seqno) message de-duplication mechanism instead of hashing
 	// the message (as lotus does) as we need to be able to re-broadcast duplicate messages with
 	// the same content.
-	topic, err := h.pubsub.Join(pubsubTopicName, pubsub.WithTopicMessageIdFn(pubsub.DefaultMsgIdFn))
+	topic, err := h.pubsub.Join(pubsubTopicName, pubsub.WithTopicMessageIdFn(psutil.PubsubMsgIdHashData))
 	if err != nil {
 		return fmt.Errorf("could not join on pubsub topic: %s: %w", pubsubTopicName, err)
 	}
+
+	if err := topic.SetScoreParams(psutil.PubsubTopicScoreParams); err != nil {
+		log.Error("failed to set topic score params", "error", err)
+	}
+
 	h.topic = topic
+
 	return nil
 }
 

--- a/host.go
+++ b/host.go
@@ -330,7 +330,7 @@ func (h *gpbftRunner) setupPubsub() error {
 	// Force the default (sender + seqno) message de-duplication mechanism instead of hashing
 	// the message (as lotus does) as we need to be able to re-broadcast duplicate messages with
 	// the same content.
-	topic, err := h.pubsub.Join(pubsubTopicName, pubsub.WithTopicMessageIdFn(psutil.PubsubMsgIdHashData))
+	topic, err := h.pubsub.Join(pubsubTopicName, pubsub.WithTopicMessageIdFn(psutil.GPBFTMessageIdFn))
 	if err != nil {
 		return fmt.Errorf("could not join on pubsub topic: %s: %w", pubsubTopicName, err)
 	}

--- a/host.go
+++ b/host.go
@@ -336,7 +336,7 @@ func (h *gpbftRunner) setupPubsub() error {
 	}
 
 	if err := topic.SetScoreParams(psutil.PubsubTopicScoreParams); err != nil {
-		log.Error("failed to set topic score params", "error", err)
+		log.Errorw("failed to set topic score params", "error", err)
 	}
 
 	h.topic = topic

--- a/internal/psutil/psutil.go
+++ b/internal/psutil/psutil.go
@@ -1,0 +1,94 @@
+package psutil
+
+import (
+	"encoding/binary"
+	"time"
+
+	"golang.org/x/crypto/blake2b"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+)
+
+// Generate a pubsub ID from the message topic + data.
+func PubsubMsgIdHashData(m *pubsub_pb.Message) string {
+	hasher, err := blake2b.New256(nil)
+	if err != nil {
+		panic("failed to construct hasher")
+	}
+
+	topic := []byte(m.GetTopic())
+	if err := binary.Write(hasher, binary.BigEndian, uint32(len(topic))); err != nil {
+		panic(err)
+	}
+	if _, err := hasher.Write(topic); err != nil {
+		panic(err)
+	}
+
+	hash := blake2b.Sum256(m.Data)
+	return string(hash[:])
+}
+
+// Generate a pubsub ID from the message topic + sender + data.
+func PubsubMsgIdHashDataAndSender(m *pubsub_pb.Message) string {
+	hasher, err := blake2b.New256(nil)
+	if err != nil {
+		panic("failed to construct hasher")
+	}
+
+	topic := []byte(m.GetTopic())
+	if err := binary.Write(hasher, binary.BigEndian, uint32(len(topic))); err != nil {
+		panic(err)
+	}
+	if _, err := hasher.Write(topic); err != nil {
+		panic(err)
+	}
+	if err := binary.Write(hasher, binary.BigEndian, uint32(len(m.From))); err != nil {
+		panic(err)
+	}
+	if _, err := hasher.Write(m.From); err != nil {
+		panic(err)
+	}
+
+	hash := blake2b.Sum256(m.Data)
+	return string(hash[:])
+}
+
+// Borrowed from lotus
+var PubsubTopicScoreParams = &pubsub.TopicScoreParams{
+	// expected > 400 msgs/second on average.
+	//
+	TopicWeight: 0.1, // max cap is 5, single invalid message is -100
+
+	// 1 tick per second, maxes at 1 hour
+	// XXX
+	TimeInMeshWeight:  0.0002778, // ~1/3600
+	TimeInMeshQuantum: time.Second,
+	TimeInMeshCap:     1,
+
+	// NOTE: Gives weight to the peer that tends to deliver first.
+	// deliveries decay after 10min, cap at 100 tx
+	FirstMessageDeliveriesWeight: 0.5, // max value is 50
+	FirstMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(10 * time.Minute),
+	FirstMessageDeliveriesCap:    100, // 100 messages in 10 minutes
+
+	// Mesh Delivery Failure is currently turned off for messages
+	// This is on purpose as the network is still too small, which results in
+	// asymmetries and potential unmeshing from negative scores.
+	// // tracks deliveries in the last minute
+	// // penalty activates at 1 min and expects 2.5 txs
+	// MeshMessageDeliveriesWeight:     -16, // max penalty is -100
+	// MeshMessageDeliveriesDecay:      pubsub.ScoreParameterDecay(time.Minute),
+	// MeshMessageDeliveriesCap:        100, // 100 txs in a minute
+	// MeshMessageDeliveriesThreshold:  2.5, // 60/12/2 txs/minute
+	// MeshMessageDeliveriesWindow:     10 * time.Millisecond,
+	// MeshMessageDeliveriesActivation: time.Minute,
+
+	// // decays after 5min
+	// MeshFailurePenaltyWeight: -16,
+	// MeshFailurePenaltyDecay:  pubsub.ScoreParameterDecay(5 * time.Minute),
+
+	// invalid messages decay after 1 hour
+	InvalidMessageDeliveriesWeight: -1000,
+	InvalidMessageDeliveriesDecay:  pubsub.ScoreParameterDecay(time.Hour),
+}

--- a/internal/psutil/psutil.go
+++ b/internal/psutil/psutil.go
@@ -10,8 +10,11 @@ import (
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
 )
 
+var ManifestMessageIdFn = pubsubMsgIdHashDataAndSender
+var GPBFTMessageIdFn = pubsubMsgIdHashData
+
 // Generate a pubsub ID from the message topic + data.
-func PubsubMsgIdHashData(m *pubsub_pb.Message) string {
+func pubsubMsgIdHashData(m *pubsub_pb.Message) string {
 	hasher, err := blake2b.New256(nil)
 	if err != nil {
 		panic("failed to construct hasher")
@@ -30,7 +33,7 @@ func PubsubMsgIdHashData(m *pubsub_pb.Message) string {
 }
 
 // Generate a pubsub ID from the message topic + sender + data.
-func PubsubMsgIdHashDataAndSender(m *pubsub_pb.Message) string {
+func pubsubMsgIdHashDataAndSender(m *pubsub_pb.Message) string {
 	hasher, err := blake2b.New256(nil)
 	if err != nil {
 		panic("failed to construct hasher")

--- a/manifest/dynamic_manifest_provider.go
+++ b/manifest/dynamic_manifest_provider.go
@@ -101,7 +101,7 @@ func (m *DynamicManifestProvider) Start(startCtx context.Context) error {
 
 	// Use the message hash as the message ID to reduce the chances of routing cycles. We ensure
 	// our rebroadcast interval is greater than our cache timeout.
-	manifestTopic, err := m.pubsub.Join(ManifestPubSubTopicName, pubsub.WithTopicMessageIdFn(psutil.PubsubMsgIdHashDataAndSender))
+	manifestTopic, err := m.pubsub.Join(ManifestPubSubTopicName, pubsub.WithTopicMessageIdFn(psutil.ManifestMessageIdFn))
 	if err != nil {
 		return fmt.Errorf("could not join manifest pubsub topic: %w", err)
 	}

--- a/manifest/dynamic_manifest_provider.go
+++ b/manifest/dynamic_manifest_provider.go
@@ -22,7 +22,7 @@ var log = logging.Logger("f3/dynamic-manifest")
 
 var _ ManifestProvider = (*DynamicManifestProvider)(nil)
 
-const ManifestPubSubTopicName = "/f3/manifests/0.0.1"
+const ManifestPubSubTopicName = "/f3/manifests/0.0.2"
 
 // DynamicManifestProvider is a manifest provider that allows
 // the manifest to be changed at runtime.

--- a/manifest/dynamic_manifest_provider.go
+++ b/manifest/dynamic_manifest_provider.go
@@ -107,7 +107,7 @@ func (m *DynamicManifestProvider) Start(startCtx context.Context) error {
 	}
 
 	if err := manifestTopic.SetScoreParams(psutil.PubsubTopicScoreParams); err != nil {
-		log.Error("failed to set topic score params", "error", err)
+		log.Errorw("failed to set topic score params", "error", err)
 	}
 
 	manifestSub, err := manifestTopic.Subscribe()

--- a/manifest/dynamic_manifest_provider.go
+++ b/manifest/dynamic_manifest_provider.go
@@ -107,7 +107,7 @@ func (m *DynamicManifestProvider) Start(startCtx context.Context) error {
 	}
 
 	if err := manifestTopic.SetScoreParams(psutil.PubsubTopicScoreParams); err != nil {
-		log.Errorw("failed to set topic score params", "error", err)
+		log.Infow("failed to set topic score params", "error", err)
 	}
 
 	manifestSub, err := manifestTopic.Subscribe()

--- a/manifest/dynamic_manifest_sender.go
+++ b/manifest/dynamic_manifest_sender.go
@@ -53,7 +53,7 @@ func NewManifestSender(ctx context.Context, h host.Host, ps *pubsub.PubSub, firs
 	}
 
 	var err error
-	m.manifestTopic, err = m.pubsub.Join(ManifestPubSubTopicName, pubsub.WithTopicMessageIdFn(psutil.PubsubMsgIdHashDataAndSender))
+	m.manifestTopic, err = m.pubsub.Join(ManifestPubSubTopicName, pubsub.WithTopicMessageIdFn(psutil.ManifestMessageIdFn))
 	if err != nil {
 		return nil, fmt.Errorf("could not join on pubsub topic: %s: %w", ManifestPubSubTopicName, err)
 	}

--- a/manifest/dynamic_manifest_sender.go
+++ b/manifest/dynamic_manifest_sender.go
@@ -32,14 +32,6 @@ type ManifestSender struct {
 }
 
 func NewManifestSender(ctx context.Context, h host.Host, ps *pubsub.PubSub, firstManifest *Manifest, publishInterval time.Duration) (*ManifestSender, error) {
-	// The rebroadcast interval must be larger than the time cache duration. Default to 2x just in case.
-	if minInterval := 2 * pubsub.TimeCacheDuration; publishInterval < minInterval {
-		log.Warnf("manifest sender publish interval is too short (%s), increasing to 2x the time-cache duration %s",
-			publishInterval, minInterval,
-		)
-		publishInterval = minInterval
-	}
-
 	clk := clock.GetClock(ctx)
 	m := &ManifestSender{
 		manifest: firstManifest,

--- a/manifest/dynamic_manifest_sender.go
+++ b/manifest/dynamic_manifest_sender.go
@@ -58,7 +58,7 @@ func NewManifestSender(ctx context.Context, h host.Host, ps *pubsub.PubSub, firs
 		return nil, fmt.Errorf("could not join on pubsub topic: %s: %w", ManifestPubSubTopicName, err)
 	}
 	if err := m.manifestTopic.SetScoreParams(psutil.PubsubTopicScoreParams); err != nil {
-		log.Errorw("could not set topic score params", "error", err)
+		log.Infow("could not set topic score params", "error", err)
 	}
 
 	// Record one-off attributes about the sender for easier runtime debugging.

--- a/manifest/dynamic_manifest_sender.go
+++ b/manifest/dynamic_manifest_sender.go
@@ -58,7 +58,7 @@ func NewManifestSender(ctx context.Context, h host.Host, ps *pubsub.PubSub, firs
 		return nil, fmt.Errorf("could not join on pubsub topic: %s: %w", ManifestPubSubTopicName, err)
 	}
 	if err := m.manifestTopic.SetScoreParams(psutil.PubsubTopicScoreParams); err != nil {
-		return nil, fmt.Errorf("could not join set topic params: %s: %w", ManifestPubSubTopicName, err)
+		log.Errorw("could not set topic score params", "error", err)
 	}
 
 	// Record one-off attributes about the sender for easier runtime debugging.

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -324,7 +324,7 @@ func (m *Manifest) PubSubTopic() string {
 }
 
 func PubSubTopicFromNetworkName(nn gpbft.NetworkName) string {
-	return "/f3/granite/0.0.1/" + string(nn)
+	return "/f3/granite/0.0.2/" + string(nn)
 }
 
 func (m *Manifest) GpbftOptions() []gpbft.Option {

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -111,7 +111,7 @@ func TestManifest_NetworkName(t *testing.T) {
 			require.True(t, strings.HasPrefix(gotDsPrefix, "/f3"))
 			require.True(t, strings.HasSuffix(gotDsPrefix, string(test.subject)))
 			gotPubSubTopic := m.PubSubTopic()
-			require.True(t, strings.HasPrefix(gotPubSubTopic, "/f3/granite/0.0.1/"))
+			require.True(t, strings.HasPrefix(gotPubSubTopic, "/f3/granite/0.0.2/"))
 			require.True(t, strings.HasSuffix(gotPubSubTopic, string(test.subject)))
 		})
 	}


### PR DESCRIPTION
1. Add topic scoring to both the GPBFT topic and the manifest topic.
2. Use hashing for message IDs in the manifest network and increase the rebroadcast time.
3. In the manifest validator, drop messages with old sequence numbers.