### PR TITLE
Improve certstore metrics

### DIFF
--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -63,6 +63,7 @@ func open(ctx context.Context, ds datastore.Datastore) (*Store, error) {
 	}
 
 	metrics.latestInstance.Record(ctx, int64(latestCert.GPBFTInstance))
+	metrics.latestFinalizedEpoch.Record(ctx, latestCert.ECChain.Head().Epoch)
 	cs.busCerts.Publish(latestCert)
 
 	return cs, nil
@@ -404,6 +405,8 @@ func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error
 
 	cs.latestPowerTable = newPowerTable
 	metrics.latestInstance.Record(ctx, int64(cert.GPBFTInstance))
+	metrics.tipsetsPerInstance.Record(ctx, int64(len(cert.ECChain.Suffix())))
+	metrics.latestFinalizedEpoch.Record(ctx, cert.ECChain.Head().Epoch)
 	cs.busCerts.Publish(cert)
 
 	return nil

--- a/certstore/metrics.go
+++ b/certstore/metrics.go
@@ -8,7 +8,21 @@ import (
 
 var meter = otel.Meter("f3/certstore")
 var metrics = struct {
-	latestInstance metric.Int64Gauge
+	latestInstance       metric.Int64Gauge
+	latestFinalizedEpoch metric.Int64Gauge
+	tipsetsPerInstance   metric.Int64Histogram
 }{
-	latestInstance: measurements.Must(meter.Int64Gauge("f3_certstore_latest_instance", metric.WithDescription("The latest instance available in certstore."))),
+	latestInstance: measurements.Must(meter.Int64Gauge("f3_certstore_latest_instance",
+		metric.WithDescription("The latest instance available in certstore."),
+		metric.WithUnit("{instance}"),
+	)),
+	latestFinalizedEpoch: measurements.Must(meter.Int64Gauge("f3_certstore_latest_finalized_epoch",
+		metric.WithDescription("The latest finalized epoch."),
+		metric.WithUnit("{epoch}"),
+	)),
+	tipsetsPerInstance: measurements.Must(meter.Int64Histogram("f3_certstore_tipsets_per_instance",
+		metric.WithDescription("The number of new tipsets finalized per instance."),
+		metric.WithUnit("{tipset}"),
+		metric.WithExplicitBucketBoundaries(0, 1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
+	)),
 }

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -814,8 +814,6 @@ func (i *instance) terminate(decision *Justification) {
 	metrics.phaseCounter.Add(context.TODO(), 1, metric.WithAttributes(attrTerminatedPhase))
 	metrics.roundHistogram.Record(context.TODO(), int64(i.round))
 	metrics.currentPhase.Record(context.TODO(), int64(TERMINATED_PHASE))
-	base, head := decision.Vote.Value.Base(), decision.Vote.Value.Head()
-	metrics.epochsPerInstance.Record(context.TODO(), head.Epoch-base.Epoch)
 }
 
 func (i *instance) terminated() bool {


### PR DESCRIPTION
1. Move the epochs-per-instance count into the certstore (works during catchup) and count tipsets (what we care about) not epochs (which includes null epochs). Also, make this a histogram.
2. Record the latest finalized epoch.
3. Add units.