### PR TITLE
Go back to using a gauge for instance sizes

### DIFF
--- a/certstore/metrics.go
+++ b/certstore/metrics.go
@@ -10,7 +10,7 @@ var meter = otel.Meter("f3/certstore")
 var metrics = struct {
 	latestInstance       metric.Int64Gauge
 	latestFinalizedEpoch metric.Int64Gauge
-	tipsetsPerInstance   metric.Int64Histogram
+	tipsetsPerInstance   metric.Int64Gauge
 }{
 	latestInstance: measurements.Must(meter.Int64Gauge("f3_certstore_latest_instance",
 		metric.WithDescription("The latest instance available in certstore."),
@@ -20,9 +20,8 @@ var metrics = struct {
 		metric.WithDescription("The latest finalized epoch."),
 		metric.WithUnit("{epoch}"),
 	)),
-	tipsetsPerInstance: measurements.Must(meter.Int64Histogram("f3_certstore_tipsets_per_instance",
+	tipsetsPerInstance: measurements.Must(meter.Int64Gauge("f3_certstore_tipsets_per_instance",
 		metric.WithDescription("The number of new tipsets finalized per instance."),
 		metric.WithUnit("{tipset}"),
-		metric.WithExplicitBucketBoundaries(0, 1, 2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100),
 	)),
 }


### PR DESCRIPTION
Unfortunately, otel only works well with timeseries data and we don't have that here. So I'm switching back to a gauge because that's the best we can do.