### PR TITLE
Fix power overflow issues when checking for a potential strong quorum

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -150,7 +150,7 @@ func verifyFinalityCertificateSignature(verifier gpbft.Verifier, powerTable gpbf
 	}
 
 	signers := make([]gpbft.PubKey, 0, len(powerTable))
-	var signerPowers uint16
+	var signerPowers int64
 	if err := cert.Signers.ForEach(func(i uint64) error {
 		if i >= uint64(len(powerTable)) {
 			return fmt.Errorf(

--- a/certs/certs_test.go
+++ b/certs/certs_test.go
@@ -367,7 +367,7 @@ func TestBadFinalityCertificates(t *testing.T) {
 		}))
 		scaledPowerTable, totalPower, err := powerTableCpy.Scaled()
 		require.NoError(t, err)
-		var activePower uint16
+		var activePower int64
 		require.NoError(t, certificate.Signers.ForEach(func(i uint64) error {
 			activePower += scaledPowerTable[i]
 			return nil

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -1120,9 +1120,12 @@ func (q *quorumState) CouldReachStrongQuorumFor(key ChainKey, withAdversary bool
 	unvotedPower := q.powerTable.ScaledTotal - q.sendersTotalPower
 	adversaryPower := int64(0)
 	if withAdversary {
+		// Account for the fact that the adversary may have double-voted here.
 		adversaryPower = q.powerTable.ScaledTotal / 3
 	}
-	possibleSupport := supportingPower + unvotedPower + adversaryPower
+	// We're double-counting adversary power, so we need to cap the power at the total available
+	// power.
+	possibleSupport := min(supportingPower+unvotedPower+adversaryPower, q.powerTable.ScaledTotal)
 	return IsStrongQuorum(possibleSupport, q.powerTable.ScaledTotal)
 }
 

--- a/gpbft/message_builder.go
+++ b/gpbft/message_builder.go
@@ -19,7 +19,7 @@ type MessageBuilder struct {
 }
 
 type powerTableAccessor interface {
-	Get(ActorID) (uint16, PubKey)
+	Get(ActorID) (int64, PubKey)
 }
 
 type SignerWithMarshaler interface {

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -332,7 +332,7 @@ func (p *Participant) validateJustification(msg *GMessage, comt *committee) erro
 	}
 
 	// Check justification power and signature.
-	var justificationPower uint16
+	var justificationPower int64
 	signers := make([]PubKey, 0)
 	if err := msg.Justification.Signers.ForEach(func(bit uint64) error {
 		if int(bit) >= len(comt.power.Entries) {

--- a/gpbft/ticket_quality.go
+++ b/gpbft/ticket_quality.go
@@ -19,7 +19,7 @@ import (
 // This ends up being `-log(ticket) / power` where ticket is [0, 1).
 // We additionally use log-base-2 instead of natural logarithm as it is easier to implement,
 // and it is just a linear factor on all tickets, meaning it does not influence their ordering.
-func ComputeTicketQuality(ticket []byte, power uint16) float64 {
+func ComputeTicketQuality(ticket []byte, power int64) float64 {
 	// we could use Blake2b-128 but 256 is more common and more widely supported
 	ticketHash := blake2b.Sum256(ticket)
 	quality := linearToExpDist(ticketHash[:16])

--- a/sim/justification.go
+++ b/sim/justification.go
@@ -37,7 +37,7 @@ func MakeJustification(backend signing.Backend, nn gpbft.NetworkName, chain gpbf
 	msg := backend.MarshalPayloadForSigning(nn, &payload)
 	signers := rand.Perm(len(powerTable))
 	signersBitfield := bitfield.New()
-	var signingPower uint16
+	var signingPower int64
 
 	type vote struct {
 		index int


### PR DESCRIPTION
Because we're double-counting adversary power here, we could overflow. We fix this by:

1. Switching from uint16 int64 (which simplifies our code anyways).
2. Limiting the possible support to the total power.