### PR TITLE
Adjust epsilon for ticket quality tests

### DIFF
--- a/gpbft/ticket_quality_test.go
+++ b/gpbft/ticket_quality_test.go
@@ -38,8 +38,13 @@ func TestTQ_BigLog2_Table(t *testing.T) {
 			bigInt, ok := new(big.Int).SetString(test.input, 16)
 			require.True(t, ok, "parsing int")
 			integer, fract := bigLog2(bigInt)
-			assert.EqualValues(t, test.integer, integer, "wrong integer part")
-			assert.EqualValues(t, test.fract, fract, "wrong fractional part")
+			assert.Equal(t, test.integer, integer, "wrong integer part")
+			assert.InDelta(t, test.fract, fract, 1e-15, "wrong fractional delta")
+			if test.fract != 0.0 {
+				assert.InEpsilon(t, test.fract, fract, 1e-03, "wrong fractional epsilon")
+			} else {
+				assert.Equal(t, test.fract, fract, "wrong fractional epsilon")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Depending on the CPU architecture, the ticket quality tests fail due to differences in exact fraction calculation.

Update the tests to:

* always assert delta of 1e-15 for fraction
* assert epsilon error of 1e-3 when fraction is non-zero (otherwise relative error can't be calculated)
* assert exact equality when fraction is zero.

This is an slight overkill in assertion for the benefit of documenting intent in an executable test.