### PR TITLE
Enforce maximum public key size to 48 bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,7 @@ build: f3
 f3:
 	go build ./cmd/f3
 .PHONY: f3
+
+gen:
+	go generate ./...
+.PHONY: gen

--- a/certs/cbor_gen.go
+++ b/certs/cbor_gen.go
@@ -45,7 +45,7 @@ func (t *PowerTableDelta) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.SigningKey (gpbft.PubKey) (slice)
-	if len(t.SigningKey) > 2097152 {
+	if len(t.SigningKey) > 48 {
 		return xerrors.Errorf("Byte array in field t.SigningKey was too long")
 	}
 
@@ -113,7 +113,7 @@ func (t *PowerTableDelta) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 48 {
 		return fmt.Errorf("t.SigningKey: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -20,7 +20,7 @@ type PowerTableDelta struct {
 	// Change in power from base (signed).
 	PowerDelta gpbft.StoragePower
 	// New signing key if relevant (else empty)
-	SigningKey gpbft.PubKey
+	SigningKey gpbft.PubKey `cborgen:"maxlen=48"`
 }
 
 func (d *PowerTableDelta) IsZero() bool {

--- a/gpbft/cbor_gen.go
+++ b/gpbft/cbor_gen.go
@@ -781,7 +781,7 @@ func (t *PowerEntry) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PubKey (gpbft.PubKey) (slice)
-	if len(t.PubKey) > 2097152 {
+	if len(t.PubKey) > 48 {
 		return xerrors.Errorf("Byte array in field t.PubKey was too long")
 	}
 
@@ -849,7 +849,7 @@ func (t *PowerEntry) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 48 {
 		return fmt.Errorf("t.PubKey: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {

--- a/gpbft/powertable.go
+++ b/gpbft/powertable.go
@@ -18,7 +18,7 @@ var _ sort.Interface = (PowerEntries)(nil)
 type PowerEntry struct {
 	ID     ActorID
 	Power  StoragePower
-	PubKey PubKey
+	PubKey PubKey `cborgen:"maxlen=48"`
 }
 
 type PowerEntries []PowerEntry


### PR DESCRIPTION
The maximum size of public key is 48 bytes. Enforce it in cbor-gen as struct tags.

Fixes #547