### PR TITLE
Handle late arriving QUALITY messages in every round

### DIFF
--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -288,7 +288,7 @@ func (c ECChain) Validate() error {
 // Returns an identifier for the chain suitable for use as a map key.
 // This must completely determine the sequence of tipsets in the chain.
 func (c ECChain) Key() ChainKey {
-	ln := len(c) * (8 + 32 + 4) // epoch + commitement + ts length
+	ln := len(c) * (8 + 32 + 4) // epoch + commitment + ts length
 	for i := range c {
 		ln += len(c[i].Key) + len(c[i].PowerTable)
 	}


### PR DESCRIPTION
Change the core GPBFT protocol to:
 1) accept QUALITY messages in ant phase or round.
 2) update candidate chains at any round or phase based on the initial proposal.

This would permit participants with late-arriving/partially delivered QUALITY messages to affect the candidates chains in CONVERGE phase to sway for the initial proposal or any of its prefixes should there be a strong quorum. No that the changes here do not update the current proposal based on late arriving QUALITY messages.

The changes above, in conjunction with rebroadcast of QUALITY messages introduced in #597 should significantly reduce the likelihood of lack of progress due to partially seen QUALITY messages. See:
 - https://github.com/filecoin-project/FIPs/discussions/809
 #discussioncomment-10409902

As part of the changes introduced by this commit, the data structure used by the instance to store candidate chains is changed to a map of chain keys for a faster candidate set update (O(1)), and a more concise way to assure uniqueness of the set of candidates.

Fixes #591