### PR TITLE
Replace cache set maps instead of clearing them

### DIFF
--- a/internal/caching/set.go
+++ b/internal/caching/set.go
@@ -100,6 +100,6 @@ func (ss *Set) newKey(namespace, v []byte) ([32]byte, error) {
 func (ss *Set) Clear() {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
-	clear(ss.flip)
-	clear(ss.flop)
+	ss.flip = make(map[[32]byte]struct{})
+	ss.flop = make(map[[32]byte]struct{})
 }


### PR DESCRIPTION
Clearing seems to be very slow, it's making
`FuzzHonestMultiInstance_SyncAgreement` take 2x longer. This is probably
because the keys are large and by-value? I'm not sure, but the cost of
re-allocating these maps shouldn't be huge anyways...