### PR TITLE
Use real CIDs

### DIFF
--- a/certexchange/client.go
+++ b/certexchange/client.go
@@ -2,7 +2,6 @@ package certexchange
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -221,8 +220,8 @@ func FindInitialPowerTable(ctx context.Context, c Client, powerTableCID cid.Cid,
 			log.Infow("computing initial power table CID", "error", err)
 			return nil, false
 		}
-		if !bytes.Equal(ptCID, powerTableCID.Bytes()) {
-			log.Infow("peer returned mismatching power table", "peer", p)
+		if ptCID != powerTableCID {
+			log.Infow("peer returned mismatching power table", "peer", p, "expected", powerTableCID, "got", ptCID)
 			return nil, false
 		}
 		return rh.PowerTable, true

--- a/certexchange/protocol_test.go
+++ b/certexchange/protocol_test.go
@@ -19,7 +19,7 @@ import (
 
 const testNetworkName gpbft.NetworkName = "testnet"
 
-func testPowerTable(entries int64) (gpbft.PowerEntries, gpbft.CID) {
+func testPowerTable(entries int64) (gpbft.PowerEntries, cid.Cid) {
 	powerTable := make(gpbft.PowerEntries, entries)
 
 	for i := range powerTable {
@@ -176,10 +176,8 @@ func TestClientServer(t *testing.T) {
 	{
 		ptCid, err := certs.MakePowerTableCID(pt)
 		require.NoError(t, err)
-		ptCid2, err := cid.Cast(ptCid)
-		require.NoError(t, err)
 
-		pt2, err := certexchange.FindInitialPowerTable(ctx, client, ptCid2, 1*time.Second)
+		pt2, err := certexchange.FindInitialPowerTable(ctx, client, ptCid, 1*time.Second)
 		require.NoError(t, err)
 		require.EqualValues(t, pt, pt2)
 	}

--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -380,8 +380,8 @@ func (cs *Store) Put(ctx context.Context, cert *certs.FinalityCertificate) error
 	// later.
 	if ptCid, err := certs.MakePowerTableCID(newPowerTable); err != nil {
 		return err
-	} else if !bytes.Equal(ptCid, cert.SupplementalData.PowerTable) {
-		return fmt.Errorf("new power table differs from expected power table")
+	} else if ptCid != cert.SupplementalData.PowerTable {
+		return fmt.Errorf("new power table differs from expected power table: %s != %s", ptCid, cert.SupplementalData.PowerTable)
 	}
 
 	// Double check that we're not killing the network.

--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/ipfs/go-cid"
 	datastore "github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
 	ds_sync "github.com/ipfs/go-datastore/sync"
@@ -22,7 +23,7 @@ func makeCert(instance uint64, supp gpbft.SupplementalData) *certs.FinalityCerti
 	}
 }
 
-func testPowerTable(entries int64) (gpbft.PowerEntries, gpbft.CID) {
+func testPowerTable(entries int64) (gpbft.PowerEntries, cid.Cid) {
 	powerTable := make(gpbft.PowerEntries, entries)
 
 	for i := range powerTable {

--- a/ec/fake_ec.go
+++ b/ec/fake_ec.go
@@ -75,6 +75,8 @@ func NewFakeEC(ctx context.Context, seed uint64, bootstrapEpoch int64, ecPeriod 
 	}
 }
 
+var cidPrefixBytes = gpbft.CidPrefix.Bytes()
+
 func (ec *FakeEC) genTipset(epoch int64) *Tipset {
 	h, err := blake2b.New256(ec.seed)
 	if err != nil {
@@ -102,7 +104,8 @@ func (ec *FakeEC) genTipset(epoch int64) *Tipset {
 			//encode epoch in the first block hash
 			binary.BigEndian.PutUint64(digest[32-8:], uint64(epoch))
 		}
-		tsk = append(tsk, gpbft.DigestToCid(digest)...)
+		tsk = append(tsk, cidPrefixBytes...)
+		tsk = append(tsk, digest...)
 	}
 	return &Tipset{
 		tsk:       tsk,

--- a/emulator/instance.go
+++ b/emulator/instance.go
@@ -46,7 +46,7 @@ func NewInstance(t *testing.T, id uint64, powerEntries gpbft.PowerEntries, propo
 	pt := gpbft.NewPowerTable()
 	require.NoError(t, pt.Add(powerEntries...))
 	for i, tipset := range proposal {
-		if len(tipset.PowerTable) == 0 {
+		if !tipset.PowerTable.Defined() {
 			// Populate missing power table CIDs to avoid validation error when constructing
 			// ECChain.
 			proposal[i].PowerTable = ptCid
@@ -63,6 +63,10 @@ func NewInstance(t *testing.T, id uint64, powerEntries gpbft.PowerEntries, propo
 		powerTable: pt,
 		beacon:     []byte(fmt.Sprintf("🥓%d", id)),
 		proposal:   proposalChain,
+		supplementalData: gpbft.SupplementalData{
+			Commitments: [32]byte{},
+			PowerTable:  ptCid,
+		},
 	}
 }
 
@@ -102,7 +106,7 @@ func (i *Instance) NewPayload(round uint64, step gpbft.Phase, value gpbft.ECChai
 }
 
 func (i *Instance) NewMessageBuilder(payload gpbft.Payload, justification *gpbft.Justification, withTicket bool) *gpbft.MessageBuilder {
-	if len(payload.SupplementalData.PowerTable) == 0 {
+	if !payload.SupplementalData.PowerTable.Defined() {
 		// Only fill in the power table cid if empty to allow emulation of invalid supplemental data.
 		payload.SupplementalData.PowerTable = i.supplementalData.PowerTable
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/libp2p/go-libp2p v0.35.0
 	github.com/libp2p/go-libp2p-pubsub v0.11.0
 	github.com/multiformats/go-multibase v0.2.0
+	github.com/multiformats/go-multihash v0.2.3
 	github.com/parquet-go/parquet-go v0.23.0
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.25.5
@@ -25,6 +26,7 @@ require (
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.24.0
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/sync v0.7.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 )
@@ -87,7 +89,6 @@ require (
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect
 	github.com/multiformats/go-multiaddr-fmt v0.1.0 // indirect
 	github.com/multiformats/go-multicodec v0.9.0 // indirect
-	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-multistream v0.5.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -133,7 +134,6 @@ require (
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/fx v1.21.1 // indirect
 	go.uber.org/mock v0.4.0 // indirect
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect

--- a/gpbft/cbor_gen.go
+++ b/gpbft/cbor_gen.go
@@ -56,17 +56,10 @@ func (t *TipSet) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.PowerTable ([]uint8) (slice)
-	if len(t.PowerTable) > 38 {
-		return xerrors.Errorf("Byte array in field t.PowerTable was too long")
-	}
+	// t.PowerTable (cid.Cid) (struct)
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.PowerTable))); err != nil {
-		return err
-	}
-
-	if _, err := cw.Write(t.PowerTable); err != nil {
-		return err
+	if err := cbg.WriteCid(cw, t.PowerTable); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PowerTable: %w", err)
 	}
 
 	// t.Commitments ([32]uint8) (array)
@@ -154,28 +147,18 @@ func (t *TipSet) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	// t.PowerTable ([]uint8) (slice)
+	// t.PowerTable (cid.Cid) (struct)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 38 {
-		return fmt.Errorf("t.PowerTable: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
+		c, err := cbg.ReadCid(cr)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.PowerTable: %w", err)
+		}
 
-	if extra > 0 {
-		t.PowerTable = make([]uint8, extra)
-	}
+		t.PowerTable = c
 
-	if _, err := io.ReadFull(cr, t.PowerTable); err != nil {
-		return err
 	}
-
 	// t.Commitments ([32]uint8) (array)
 
 	maj, extra, err = cr.ReadHeader()
@@ -397,17 +380,10 @@ func (t *SupplementalData) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.PowerTable ([]uint8) (slice)
-	if len(t.PowerTable) > 38 {
-		return xerrors.Errorf("Byte array in field t.PowerTable was too long")
-	}
+	// t.PowerTable (cid.Cid) (struct)
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.PowerTable))); err != nil {
-		return err
-	}
-
-	if _, err := cw.Write(t.PowerTable); err != nil {
-		return err
+	if err := cbg.WriteCid(cw, t.PowerTable); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PowerTable: %w", err)
 	}
 
 	return nil
@@ -457,28 +433,18 @@ func (t *SupplementalData) UnmarshalCBOR(r io.Reader) (err error) {
 	if _, err := io.ReadFull(cr, t.Commitments[:]); err != nil {
 		return err
 	}
-	// t.PowerTable ([]uint8) (slice)
+	// t.PowerTable (cid.Cid) (struct)
 
-	maj, extra, err = cr.ReadHeader()
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > 38 {
-		return fmt.Errorf("t.PowerTable: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
+		c, err := cbg.ReadCid(cr)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.PowerTable: %w", err)
+		}
 
-	if extra > 0 {
-		t.PowerTable = make([]uint8, extra)
-	}
+		t.PowerTable = c
 
-	if _, err := io.ReadFull(cr, t.PowerTable); err != nil {
-		return err
 	}
-
 	return nil
 }
 

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -10,8 +10,9 @@ import (
 func TestECChain(t *testing.T) {
 	t.Parallel()
 
+	ptCid := gpbft.MakeCid([]byte("pt"))
 	zeroTipSet := gpbft.TipSet{}
-	oneTipSet := gpbft.TipSet{Epoch: 0, Key: []byte{1}, PowerTable: []byte("pt")}
+	oneTipSet := gpbft.TipSet{Epoch: 0, Key: []byte{1}, PowerTable: ptCid}
 	t.Run("zero-value is zero", func(t *testing.T) {
 		var subject gpbft.ECChain
 		require.True(t, subject.IsZero())
@@ -33,7 +34,7 @@ func TestECChain(t *testing.T) {
 		require.Nil(t, subject)
 	})
 	t.Run("extended chain is as expected", func(t *testing.T) {
-		wantBase := gpbft.TipSet{Epoch: 0, Key: []byte("fish"), PowerTable: []byte("pt")}
+		wantBase := gpbft.TipSet{Epoch: 0, Key: []byte("fish"), PowerTable: ptCid}
 		subject, err := gpbft.NewChain(wantBase)
 		require.NoError(t, err)
 		require.Len(t, subject, 1)
@@ -42,7 +43,7 @@ func TestECChain(t *testing.T) {
 		require.False(t, subject.HasSuffix())
 		require.NoError(t, subject.Validate())
 
-		wantNext := gpbft.TipSet{Epoch: 1, Key: []byte("lobster"), PowerTable: []byte("pt")}
+		wantNext := gpbft.TipSet{Epoch: 1, Key: []byte("lobster"), PowerTable: ptCid}
 		subjectExtended := subject.Extend(wantNext.Key)
 		require.Len(t, subjectExtended, 2)
 		require.NoError(t, subjectExtended.Validate())
@@ -84,15 +85,15 @@ func TestECChain(t *testing.T) {
 
 	t.Run("prefix and extend don't mutate", func(t *testing.T) {
 		subject := gpbft.ECChain{
-			gpbft.TipSet{Epoch: 0, Key: []byte{0}, PowerTable: []byte("pt")},
-			gpbft.TipSet{Epoch: 1, Key: []byte{1}, PowerTable: []byte("pt1")},
+			gpbft.TipSet{Epoch: 0, Key: []byte{0}, PowerTable: ptCid},
+			gpbft.TipSet{Epoch: 1, Key: []byte{1}, PowerTable: ptCid},
 		}
 		dup := append(gpbft.ECChain{}, subject...)
 		after := subject.Prefix(0).Extend([]byte{2})
 		require.True(t, subject.Eq(dup))
 		require.True(t, after.Eq(gpbft.ECChain{
-			gpbft.TipSet{Epoch: 0, Key: []byte{0}, PowerTable: []byte("pt")},
-			gpbft.TipSet{Epoch: 1, Key: []byte{2}, PowerTable: []byte("p2")},
+			gpbft.TipSet{Epoch: 0, Key: []byte{0}, PowerTable: ptCid},
+			gpbft.TipSet{Epoch: 1, Key: []byte{2}, PowerTable: ptCid},
 		}))
 	})
 

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -14,6 +14,7 @@ import (
 	"github.com/filecoin-project/go-bitfield"
 	rlepluslazy "github.com/filecoin-project/go-bitfield/rle"
 	"github.com/filecoin-project/go-f3/merkle"
+	"github.com/ipfs/go-cid"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -86,12 +87,11 @@ type SupplementalData struct {
 	Commitments [32]byte
 	// The DagCBOR-blake2b256 CID of the power table used to validate the next instance, taking
 	// lookback into account.
-	PowerTable CID `cborgen:"maxlen=38"` // []PowerEntry
+	PowerTable cid.Cid // []PowerEntry
 }
 
 func (d *SupplementalData) Eq(other *SupplementalData) bool {
-	return d.Commitments == other.Commitments &&
-		bytes.Equal(d.PowerTable, other.PowerTable)
+	return d.Commitments == other.Commitments && d.PowerTable == other.PowerTable
 }
 
 // Fields of the message that make up the signature payload.
@@ -140,7 +140,7 @@ func (p *Payload) MarshalForSigning(nn NetworkName) []byte {
 	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
 	_, _ = buf.Write(p.SupplementalData.Commitments[:])
 	_, _ = buf.Write(root[:])
-	_, _ = buf.Write(p.SupplementalData.PowerTable)
+	_, _ = buf.Write(p.SupplementalData.PowerTable.Bytes())
 	return buf.Bytes()
 }
 

--- a/gpbft/gpbft_test.go
+++ b/gpbft/gpbft_test.go
@@ -972,7 +972,8 @@ func TestGPBFT_Validation(t *testing.T) {
 				return &gpbft.GMessage{
 					Sender: 1,
 					Vote: instance.NewQuality(gpbft.ECChain{gpbft.TipSet{
-						Epoch: -1,
+						Epoch:      -1,
+						PowerTable: instance.SupplementalData().PowerTable,
 					}}),
 				}
 			},
@@ -986,7 +987,7 @@ func TestGPBFT_Validation(t *testing.T) {
 					Vote: gpbft.Payload{
 						Step: gpbft.DECIDE_PHASE,
 						SupplementalData: gpbft.SupplementalData{
-							PowerTable: []byte("fish"),
+							PowerTable: gpbft.MakeCid([]byte("fish")),
 						},
 						Value: instance.Proposal(),
 					},
@@ -1001,8 +1002,9 @@ func TestGPBFT_Validation(t *testing.T) {
 				return &gpbft.GMessage{
 					Sender: 1,
 					Vote: gpbft.Payload{
-						Step:  gpbft.DECIDE_PHASE,
-						Value: instance.Proposal(),
+						Step:             gpbft.DECIDE_PHASE,
+						Value:            instance.Proposal(),
+						SupplementalData: instance.SupplementalData(),
 					},
 					Justification: instance.NewJustification(55, gpbft.COMMIT_PHASE, instance.Proposal().Extend([]byte("lobster")), 0, 1),
 				}
@@ -1015,11 +1017,13 @@ func TestGPBFT_Validation(t *testing.T) {
 				return &gpbft.GMessage{
 					Sender: 1,
 					Vote: gpbft.Payload{
-						Step:  gpbft.DECIDE_PHASE,
-						Value: instance.Proposal(),
+						Step:             gpbft.DECIDE_PHASE,
+						Value:            instance.Proposal(),
+						SupplementalData: instance.SupplementalData(),
 					},
 					Justification: instance.NewJustification(55, gpbft.COMMIT_PHASE, gpbft.ECChain{gpbft.TipSet{
-						Epoch: -2,
+						Epoch:      -2,
+						PowerTable: instance.SupplementalData().PowerTable,
 					}}, 0, 1),
 				}
 			},
@@ -1032,8 +1036,9 @@ func TestGPBFT_Validation(t *testing.T) {
 				return &gpbft.GMessage{
 					Sender: 1,
 					Vote: gpbft.Payload{
-						Step:  gpbft.DECIDE_PHASE,
-						Value: instance.Proposal(),
+						Step:             gpbft.DECIDE_PHASE,
+						Value:            instance.Proposal(),
+						SupplementalData: instance.SupplementalData(),
 					},
 					Justification: newInstance.NewJustification(55, gpbft.COMMIT_PHASE, instance.Proposal().Extend([]byte("lobster")), 0, 1),
 				}

--- a/gpbft/payload_test.go
+++ b/gpbft/payload_test.go
@@ -37,7 +37,7 @@ func TestPayload_Eq(t *testing.T) {
 				Step:     gpbft.TERMINATED_PHASE,
 				SupplementalData: gpbft.SupplementalData{
 					Commitments: [32]byte{1, 2, 3, 4},
-					PowerTable:  []byte("fish"),
+					PowerTable:  ptCid,
 				},
 				Value: someChain,
 			},
@@ -47,7 +47,7 @@ func TestPayload_Eq(t *testing.T) {
 				Step:     gpbft.TERMINATED_PHASE,
 				SupplementalData: gpbft.SupplementalData{
 					Commitments: [32]byte{1, 2, 3, 4},
-					PowerTable:  []byte("fish"),
+					PowerTable:  ptCid,
 				},
 				Value: someChain,
 			},
@@ -60,7 +60,7 @@ func TestPayload_Eq(t *testing.T) {
 				Step:     gpbft.TERMINATED_PHASE,
 				SupplementalData: gpbft.SupplementalData{
 					Commitments: [32]byte{1, 2, 3, 4},
-					PowerTable:  []byte("fish"),
+					PowerTable:  ptCid,
 				},
 			},
 			other: &gpbft.Payload{
@@ -69,7 +69,7 @@ func TestPayload_Eq(t *testing.T) {
 				Step:     gpbft.TERMINATED_PHASE,
 				SupplementalData: gpbft.SupplementalData{
 					Commitments: [32]byte{1, 2, 3, 4},
-					PowerTable:  []byte("fish"),
+					PowerTable:  ptCid,
 				},
 				Value: someChain,
 			},
@@ -118,7 +118,7 @@ func TestPayload_MarshalForSigning(t *testing.T) {
 				Step:     gpbft.TERMINATED_PHASE,
 				SupplementalData: gpbft.SupplementalData{
 					Commitments: [32]byte([]byte("🐡 fish unda da sea 🪼  🌊")),
-					PowerTable:  []byte("barreleye"),
+					PowerTable:  ptCid,
 				},
 				Value: someChain,
 			},
@@ -135,8 +135,12 @@ func TestPayload_MarshalForSigning(t *testing.T) {
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
 				0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-				0x0, 0x0, 0x0, 0x0, 0x62, 0x61, 0x72, 0x72,
-				0x65, 0x6c, 0x65, 0x79, 0x65},
+				0x0, 0x0, 0x0, 0x0, 0x1, 0x71, 0xa0, 0xe4,
+				0x2, 0x20, 0xfb, 0x3e, 0x4d, 0x51, 0x32,
+				0x34, 0xf9, 0x4f, 0x10, 0x67, 0xbd, 0x4a,
+				0x49, 0x6b, 0xb8, 0x48, 0xf0, 0x73, 0xd,
+				0x9b, 0x7c, 0x7f, 0xfa, 0x5a, 0xc5, 0x4e,
+				0xec, 0xab, 0xb6, 0xac, 0xd3, 0xc7},
 		},
 	}
 	for _, test := range tests {

--- a/gpbft/powertable.go
+++ b/gpbft/powertable.go
@@ -34,7 +34,7 @@ type PowerTable struct {
 }
 
 func (p *PowerEntry) Equal(o *PowerEntry) bool {
-	return p.ID == o.ID && p.Power.Equals(o.Power) && bytes.Equal(p.PubKey, o.PubKey)
+	return p.ID == o.ID && p.Power == o.Power && bytes.Equal(p.PubKey, o.PubKey)
 }
 
 func (p PowerEntries) Equal(o PowerEntries) bool {

--- a/sim/ec.go
+++ b/sim/ec.go
@@ -70,7 +70,7 @@ func (ec *simEC) BeginInstance(baseChain gpbft.ECChain, pt *gpbft.PowerTable) *E
 		PowerTable: pt,
 		Beacon:     beacon,
 		SupplementalData: &gpbft.SupplementalData{
-			PowerTable: gpbft.CID(fmt.Sprintf("supp-data-pt@%d", nextInstanceID)),
+			PowerTable: gpbft.MakeCid([]byte(fmt.Sprintf("supp-data-pt@%d", nextInstanceID))),
 		},
 		ec:        ec,
 		decisions: make(map[gpbft.ActorID]*gpbft.Justification),

--- a/sim/options.go
+++ b/sim/options.go
@@ -24,7 +24,7 @@ func init() {
 	defaultBaseChain, err = gpbft.NewChain(gpbft.TipSet{
 		Epoch:       0,
 		Key:         []byte("genesis"),
-		PowerTable:  []byte("genesis-powertable"),
+		PowerTable:  gpbft.MakeCid([]byte("genesis-powertable")),
 		Commitments: [32]byte{},
 	})
 	if err != nil {

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -116,7 +116,7 @@ func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Pa
 		length += 8 // epoch
 		length += len(ts.Key)
 		length += len(ts.Commitments)
-		length += len(ts.PowerTable)
+		length += ts.PowerTable.ByteLen()
 	}
 
 	var buf bytes.Buffer
@@ -130,14 +130,14 @@ func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Pa
 	_ = binary.Write(&buf, binary.BigEndian, p.Round)
 	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
 	_, _ = buf.Write(p.SupplementalData.Commitments[:])
-	_, _ = buf.Write(p.SupplementalData.PowerTable)
+	_, _ = buf.Write(p.SupplementalData.PowerTable.Bytes())
 	_ = binary.Write(&buf, binary.BigEndian, uint32(len(p.Value)))
 	for i := range p.Value {
 		ts := &p.Value[i]
 
 		_ = binary.Write(&buf, binary.BigEndian, ts.Epoch)
 		_, _ = buf.Write(ts.Commitments[:])
-		_, _ = buf.Write(ts.PowerTable)
+		_, _ = buf.Write(ts.PowerTable.Bytes())
 		_, _ = buf.Write(ts.Key)
 	}
 	return buf.Bytes()

--- a/test/decide_test.go
+++ b/test/decide_test.go
@@ -147,7 +147,9 @@ func TestIllegalCommittee_WrongSupplementalData(t *testing.T) {
 				adversaryValue,
 				gpbft.NewStoragePower(3),
 				// Justify the base-chain, but attempt to decide on something else.
-				adversary.ImmediateDecideWithJustifiedSupplementalData(gpbft.SupplementalData{}))))...)
+				adversary.ImmediateDecideWithJustifiedSupplementalData(gpbft.SupplementalData{
+					PowerTable: gpbft.MakeCid([]byte("wrong")),
+				}))))...)
 	require.NoError(t, err)
 
 	err = sm.Run(1, maxRounds)

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -30,7 +30,11 @@ func requireConsensusAtInstance(t *testing.T, sm *sim.Simulation, instance uint6
 func generateECChain(t *testing.T, tsg *sim.TipSetGenerator) gpbft.ECChain {
 	t.Helper()
 	// TODO: add stochastic chain generation.
-	chain, err := gpbft.NewChain(gpbft.TipSet{Epoch: 0, Key: tsg.Sample(), PowerTable: []byte("pt")})
+	chain, err := gpbft.NewChain(gpbft.TipSet{
+		Epoch:      0,
+		Key:        tsg.Sample(),
+		PowerTable: gpbft.MakeCid([]byte("pt")),
+	})
 	require.NoError(t, err)
 	return chain
 }


### PR DESCRIPTION
1. Encode CIDs with the correct CBOR tags.
2. Use the upstream go-cid library.

We were already depending on the CBOR library and, at a minimum, I want to use the correct DagCBOR CID encoding in certificates. We might as well use them everywhere.

fixes #18