### PR TITLE
Remove redundant loop variable redeclaration in light of Go 1.22

### DIFF
--- a/gpbft/errors_test.go
+++ b/gpbft/errors_test.go
@@ -19,7 +19,6 @@ func TestValidationError_SentinelValues(t *testing.T) {
 		{name: "ErrValidationWrongSupplement", subject: ErrValidationWrongSupplement},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require.True(t, errors.As(test.subject, &ValidationError{}))
 			require.True(t, errors.As(test.subject, &ValidationError{message: "fish"}))

--- a/gpbft/gpbft_test.go
+++ b/gpbft/gpbft_test.go
@@ -1053,7 +1053,6 @@ func TestGPBFT_Validation(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			driver := emulator.NewDriver(t)

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -438,7 +438,6 @@ func TestParticipant(t *testing.T) {
 				},
 			}
 			for _, test := range tests {
-				test := test
 				t.Run(test.name, func(t *testing.T) {
 					subject := newParticipantTestSubject(t, seed, initialInstance)
 					subject.requireStart()
@@ -951,7 +950,6 @@ func TestParticipant_ValidateMessage(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			subject := newParticipantTestSubject(t, seed, initialInstanceNumber)
 			require.NoError(t, subject.powerTable.Add(somePowerEntry))

--- a/gpbft/payload_test.go
+++ b/gpbft/payload_test.go
@@ -76,7 +76,6 @@ func TestPayload_Eq(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.wantEqual, test.one.Eq(test.other))
 		})
@@ -140,7 +139,6 @@ func TestPayload_MarshalForSigning(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			got := test.subject.MarshalForSigning(test.networkName)
 			require.NotEmpty(t, got)

--- a/gpbft/powertable_test.go
+++ b/gpbft/powertable_test.go
@@ -151,7 +151,6 @@ func TestPowerTable(t *testing.T) {
 			},
 		}
 		for _, test := range tests {
-			test := test
 			t.Run(test.name, func(t *testing.T) {
 				subject := test.subject()
 				gotErr := subject.Validate()
@@ -186,7 +185,6 @@ func TestPowerTable(t *testing.T) {
 			},
 		}
 		for _, test := range tests {
-			test := test
 			t.Run(test.name, func(t *testing.T) {
 				subject := test.subject()
 				gotCopy := subject.Copy()

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -80,7 +80,6 @@ func TestManifest_Serialization(t *testing.T) {
 			want:  &base,
 		},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			got, err := manifest.Unmarshal(bytes.NewReader(test.given))
 			require.NoError(t, err)
@@ -104,7 +103,6 @@ func TestManifest_NetworkName(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			m := manifest.Manifest{NetworkName: test.subject}
 			gotDsPrefix := m.DatastorePrefix().String()

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestHashTree(t *testing.T) {
 	for i := 1; i < 256; i++ {
-		i := i
 		t.Run(fmt.Sprintf("Length/%d", i), func(t *testing.T) {
 			t.Parallel()
 

--- a/sim/message_queue_test.go
+++ b/sim/message_queue_test.go
@@ -120,7 +120,6 @@ func TestMessageQueue_UpsertFirstWhere(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			subject := newMessagePriorityQueue()
 			for _, insertion := range test.givenInsertions {

--- a/test/deny_test.go
+++ b/test/deny_test.go
@@ -46,8 +46,6 @@ func TestDenyPhase(t *testing.T) {
 
 	for _, phase := range []gpbft.Phase{gpbft.QUALITY_PHASE, gpbft.PREPARE_PHASE, gpbft.CONVERGE_PHASE, gpbft.COMMIT_PHASE} {
 		for _, denyMode := range []adversary.DenyTargetMode{adversary.DenyToOrFrom, adversary.DenyFrom, adversary.DenyTo} {
-			phase := phase
-			denyMode := denyMode
 			t.Run(fmt.Sprintf("%s/%s", denyMode, phase), func(t *testing.T) {
 				t.Parallel()
 				ecGen := sim.NewUniformECChainGenerator(4332432, 1, 5)

--- a/test/drop_test.go
+++ b/test/drop_test.go
@@ -34,9 +34,7 @@ func TestDrop_ReachesConsensusDespiteMessageLoss(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		for _, lossProbability := range messageLossProbabilities {
-			lossProbability := lossProbability
 			name := fmt.Sprintf("%s %.0f%% loss", test.name, lossProbability*100)
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()

--- a/test/ec_divergence_test.go
+++ b/test/ec_divergence_test.go
@@ -30,7 +30,6 @@ func TestEcDivergence_AbsoluteDivergenceConvergesOnBase(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			seedFuzzer := uint64(985623)
@@ -121,7 +120,6 @@ func TestEcDivergence_PartitionedNetworkConvergesOnChainWithMostPower(t *testing
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			seedFuzzer := uint64(784523)

--- a/test/honest_test.go
+++ b/test/honest_test.go
@@ -66,9 +66,7 @@ func TestHonest_Agreement(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		for _, participantCount := range test.participantCounts {
-			participantCount := participantCount
 			name := fmt.Sprintf("%s %d", test.name, participantCount)
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
@@ -139,9 +137,7 @@ func TestHonest_Disagreement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		for _, participantCount := range test.participantCounts {
-			participantCount := participantCount
 			name := fmt.Sprintf("%s %d", test.name, participantCount)
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()

--- a/test/multi_instance_test.go
+++ b/test/multi_instance_test.go
@@ -33,11 +33,9 @@ func TestHonestMultiInstance_Agreement(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			for hc := 1; hc <= maxHonestCount; hc++ {
-				hc := hc
 				t.Run(fmt.Sprintf("%d", hc), func(t *testing.T) {
 					multiAgreementTest(t, testRNGSeed, hc, instanceCount, maxRounds, test.options...)
 				})

--- a/test/repeat_test.go
+++ b/test/repeat_test.go
@@ -90,9 +90,7 @@ func FuzzRepeatAdversary(f *testing.F) {
 	f.Fuzz(func(t *testing.T, seed int) {
 		t.Parallel()
 		for _, hc := range repeatAdversaryTestHonestCounts {
-			hc := hc
 			for _, test := range tests {
-				test := test
 				t.Run(test.name, func(t *testing.T) {
 					t.Parallel()
 					rng := rand.New(rand.NewSource(int64(seed)))

--- a/test/spam_test.go
+++ b/test/spam_test.go
@@ -40,9 +40,7 @@ func TestSpamAdversary(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		for _, hc := range honestCounts {
-			hc := hc
 			lessThanOneThirdAdversaryStoragePower := gpbft.NewStoragePower(int64(max(hc/3-1, 1)))
 			name := fmt.Sprintf("%s honest count %d", test.name, hc)
 			t.Run(name, func(t *testing.T) {

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -37,7 +37,6 @@ func TestWitholdCommitAdversary(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			nearSynchrony := func() (latency.Model, error) {


### PR DESCRIPTION
Now that we are using Go 1.22 remove redundant re-declarations of for loop variables.