### PR TITLE
Capture broadcasted messages for re-broadcasting even at panic

### DIFF
--- a/emulator/driver_assertions.go
+++ b/emulator/driver_assertions.go
@@ -19,8 +19,14 @@ func (d *Driver) RequireErrOnDeliverMessage(message *gpbft.GMessage, err error, 
 	}
 }
 
+// RequireStartInstance asserts that instance with the given ID is started. See
+// StartInstance.
+func (d *Driver) RequireStartInstance(id uint64) {
+	d.require.NoError(d.StartInstance(id))
+}
+
 func (d *Driver) RequireDeliverAlarm() {
-	delivered, err := d.deliverAlarm()
+	delivered, err := d.DeliverAlarm()
 	d.require.NoError(err)
 	d.require.True(delivered)
 }

--- a/emulator/host.go
+++ b/emulator/host.go
@@ -15,7 +15,7 @@ const networkName = "emulator-net"
 var _ gpbft.Host = (*driverHost)(nil)
 
 type driverHost struct {
-	adhocSigning
+	Signing
 
 	t                  *testing.T
 	id                 gpbft.ActorID
@@ -25,10 +25,11 @@ type driverHost struct {
 	chain              map[uint64]*Instance
 }
 
-func newHost(t *testing.T) *driverHost {
+func newHost(t *testing.T, signing Signing) *driverHost {
 	return &driverHost{
-		t:     t,
-		chain: make(map[uint64]*Instance),
+		Signing: signing,
+		t:       t,
+		chain:   make(map[uint64]*Instance),
 	}
 }
 

--- a/gpbft/gpbft_test.go
+++ b/gpbft/gpbft_test.go
@@ -45,7 +45,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 
 	t.Run("Decides proposal on strong quorum", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -80,7 +80,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 
 	t.Run("Decides base on lack of quorum", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -118,7 +118,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 
 	t.Run("Converges on base when quorum not possible", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -190,7 +190,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			Vote:   instance.NewPrepare(0, instance.Proposal()),
 		})
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequirePrepare(instance.Proposal())
 		evidenceOfPrepare := instance.NewJustification(0, gpbft.PREPARE_PHASE, instance.Proposal(), 0, 1)
@@ -214,7 +214,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 			tipSet3, tipSet4,
 		)
 		driver.AddInstance(futureInstance)
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireDeliverMessage(&gpbft.GMessage{
 			Sender: 1,
 			Vote:   instance.NewQuality(instance.Proposal()),
@@ -256,7 +256,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 
 		// Start the future instance and expect progress to commit without any timeouts
 		// based on previously queued messages.
-		driver.StartInstance(futureInstance.ID())
+		driver.RequireStartInstance(futureInstance.ID())
 		driver.RequireQuality()
 		driver.RequirePrepare(futureInstance.Proposal())
 		driver.RequireCommit(0, futureInstance.Proposal(), instance.NewJustification(0, gpbft.PREPARE_PHASE, futureInstance.Proposal(), 0, 1))
@@ -264,7 +264,7 @@ func TestGPBFT_WithEvenPowerDistribution(t *testing.T) {
 
 	t.Run("Rebroadcasts selected messages on timeout", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 		driver.RequireDeliverAlarm()
@@ -469,7 +469,7 @@ func TestGPBFT_SkipsToDecide(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
 		wantDecision := instance.Proposal().Extend(tipSet4.Key)
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -494,7 +494,7 @@ func TestGPBFT_SkipsToDecide(t *testing.T) {
 			Justification: instance.NewJustification(0, gpbft.COMMIT_PHASE, wantDecision, 1),
 		})
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		// Expect immediate decision.
 		driver.RequireDecision(instance.ID(), wantDecision)
 	})
@@ -520,7 +520,7 @@ func TestGPBFT_SoloParticipant(t *testing.T) {
 
 	t.Run("Decides proposal with no timeout", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequirePrepare(instance.Proposal())
 		driver.RequireCommit(
@@ -538,7 +538,7 @@ func TestGPBFT_SoloParticipant(t *testing.T) {
 	t.Run("Decides base on QUALITY timeout", func(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
 		baseChain := instance.Proposal().BaseChain()
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireDeliverAlarm()
 		driver.RequireQuality()
 		driver.RequirePrepare(baseChain)
@@ -581,7 +581,7 @@ func TestGPBFT_SkipsToRound(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
 		futureRoundProposal := instance.Proposal().Extend(tipSet4.Key)
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -619,7 +619,7 @@ func TestGPBFT_SkipsToRound(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
 		futureRoundProposal := instance.Proposal().Extend(tipSet4.Key)
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -643,7 +643,7 @@ func TestGPBFT_SkipsToRound(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
 		futureRoundProposal := instance.Proposal().Extend(tipSet4.Key)
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 
@@ -687,7 +687,7 @@ func TestGPBFT_SkipsToRound(t *testing.T) {
 			Ticket:        emulator.ValidTicket,
 		})
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 
 		// Expect skip to round.
@@ -726,7 +726,7 @@ func TestGPBFT_Equivocations(t *testing.T) {
 			instance.Proposal().Extend(tipSet4.Key),
 		}
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 
 		// Send the first Quality message for instance proposal
 		driver.RequireDeliverMessage(&gpbft.GMessage{
@@ -858,7 +858,7 @@ func TestGPBFT_Equivocations(t *testing.T) {
 		}
 
 		// Start the instance before sending decide messages to avoid skip to decide.
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequirePrepare(instance.Proposal())
 		driver.RequireCommit(0, instance.Proposal(), evidenceOfPrepare)
@@ -913,7 +913,7 @@ func TestGPBFT_ImpossibleQuorum(t *testing.T) {
 		instance, driver := newInstanceAndDriver(t)
 		alternativeProposal := instance.Proposal().BaseChain().Extend([]byte("barreleye"))
 
-		driver.StartInstance(instance.ID())
+		driver.RequireStartInstance(instance.ID())
 		driver.RequireQuality()
 		driver.RequireNoBroadcast()
 		driver.RequireDeliverAlarm()
@@ -1342,7 +1342,7 @@ func TestGPBFT_DropOld(t *testing.T) {
 	driver.AddInstance(newInstance)
 
 	// We immediately skip to the "new" instance.
-	driver.StartInstance(2)
+	driver.RequireStartInstance(2)
 
 	// All messages from the old instance should be dropped.
 


### PR DESCRIPTION
Fix a bug where if `Host.RequestBroadcast` panics the requested message is never added to the re-broadcast state.

Fix an inconsistent behaviour where error at requested broadcasts via re-broadcast are returned instead of being silently logged.

Enhance emulator to allow pluggable signign logic with two additional signing implementation: erroneous and panic.

Implement tests that assert expected behaviour at signing error or panic.

Fixes #236