### PR TITLE
Remove unused/duplicate rebroadcast metric

### DIFF
--- a/gpbft/metrics.go
+++ b/gpbft/metrics.go
@@ -42,30 +42,28 @@ var (
 	attrCacheKindJustification = attribute.String("kind", "justification")
 
 	metrics = struct {
-		phaseCounter              metric.Int64Counter
-		roundHistogram            metric.Int64Histogram
-		broadcastCounter          metric.Int64Counter
-		reBroadcastCounter        metric.Int64Counter
-		reBroadcastAttemptCounter metric.Int64Counter
-		errorCounter              metric.Int64Counter
-		currentInstance           metric.Int64Gauge
-		currentRound              metric.Int64Gauge
-		currentPhase              metric.Int64Gauge
-		skipCounter               metric.Int64Counter
-		epochsPerInstance         metric.Int64Gauge
-		validationCache           metric.Int64Counter
+		phaseCounter       metric.Int64Counter
+		roundHistogram     metric.Int64Histogram
+		broadcastCounter   metric.Int64Counter
+		reBroadcastCounter metric.Int64Counter
+		errorCounter       metric.Int64Counter
+		currentInstance    metric.Int64Gauge
+		currentRound       metric.Int64Gauge
+		currentPhase       metric.Int64Gauge
+		skipCounter        metric.Int64Counter
+		epochsPerInstance  metric.Int64Gauge
+		validationCache    metric.Int64Counter
 	}{
 		phaseCounter: measurements.Must(meter.Int64Counter("f3_gpbft_phase_counter", metric.WithDescription("Number of times phases change"))),
 		roundHistogram: measurements.Must(meter.Int64Histogram("f3_gpbft_round_histogram",
 			metric.WithDescription("Histogram of rounds per instance"),
 			metric.WithExplicitBucketBoundaries(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 20.0, 50.0, 100.0, 1000.0),
 		)),
-		broadcastCounter:          measurements.Must(meter.Int64Counter("f3_gpbft_broadcast_counter", metric.WithDescription("Number of broadcasted messages"))),
-		reBroadcastCounter:        measurements.Must(meter.Int64Counter("f3_gpbft_rebroadcast_counter", metric.WithDescription("Number of rebroadcasted messages"))),
-		reBroadcastAttemptCounter: measurements.Must(meter.Int64Counter("f3_gpbft_rebroadcast_attempt_counter", metric.WithDescription("Number of rebroadcast attempts"))),
-		errorCounter:              measurements.Must(meter.Int64Counter("f3_gpbft_error_counter", metric.WithDescription("Number of errors"))),
-		currentInstance:           measurements.Must(meter.Int64Gauge("f3_gpbft_current_instance", metric.WithDescription("The ID of the current instance"))),
-		currentRound:              measurements.Must(meter.Int64Gauge("f3_gpbft_current_round", metric.WithDescription("The current round number"))),
+		broadcastCounter:   measurements.Must(meter.Int64Counter("f3_gpbft_broadcast_counter", metric.WithDescription("Number of broadcasted messages"))),
+		reBroadcastCounter: measurements.Must(meter.Int64Counter("f3_gpbft_rebroadcast_counter", metric.WithDescription("Number of rebroadcasted messages"))),
+		errorCounter:       measurements.Must(meter.Int64Counter("f3_gpbft_error_counter", metric.WithDescription("Number of errors"))),
+		currentInstance:    measurements.Must(meter.Int64Gauge("f3_gpbft_current_instance", metric.WithDescription("The ID of the current instance"))),
+		currentRound:       measurements.Must(meter.Int64Gauge("f3_gpbft_current_round", metric.WithDescription("The current round number"))),
 		currentPhase: measurements.Must(meter.Int64Gauge("f3_gpbft_current_phase",
 			metric.WithDescription("The current phase represented as numeric value of gpbft.Phase: "+
 				"0=INITIAL, 1=QUALITY, 2=CONVERGE, 3=PREPARE, 4=COMMIT, 5=DECIDE, and 6=TERMINATED"))),


### PR DESCRIPTION
The rebroadcast attempt metric seem to be never used. Remove it.