### PR TITLE
Randomize rebroadcast backoff

### DIFF
--- a/gpbft/options.go
+++ b/gpbft/options.go
@@ -144,6 +144,6 @@ func exponentialBackoffer(exponent float64, base, maxBackoff time.Duration) func
 		if nextBackoff > float64(maxBackoff) {
 			return maxBackoff
 		}
-		return maxBackoff
+		return time.Duration(nextBackoff)
 	}
 }

--- a/gpbft/options_test.go
+++ b/gpbft/options_test.go
@@ -7,12 +7,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_exponentialBackoffer(t *testing.T) {
+func Test_exponentialBackofferMax(t *testing.T) {
 	maxBackoff := 30 * time.Second
-	backoffer := exponentialBackoffer(1.3, 3*time.Second, maxBackoff)
+	backoffer := exponentialBackoffer(1.3, 0, 3*time.Second, maxBackoff)
+	var lastBackoff time.Duration
 	for i := 0; i < 10_000; i++ {
 		backoff := backoffer(i)
 		require.Positivef(t, backoff, "at %d", i)
-		require.LessOrEqualf(t, backoff, maxBackoff, "at %d", i)
+		if backoff != maxBackoff {
+			require.Less(t, backoff, maxBackoff, "at %d", i)
+			require.Greater(t, backoff, lastBackoff, "at %d", i)
+		}
+	}
+}
+
+func Test_exponentialBackofferSpread(t *testing.T) {
+	maxBackoff := 30 * time.Second
+	backoffer1 := exponentialBackoffer(1.3, 0.1, 3*time.Second, maxBackoff)
+	backoffer2 := exponentialBackoffer(1.3, 0.1, 3*time.Second, maxBackoff)
+
+	for i := 0; i < 8; i++ {
+		backoff1 := backoffer1(i)
+		backoff2 := backoffer2(i)
+		require.NotEqual(t, backoff1, backoff2, "backoffs were not randomized")
 	}
 }

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -34,6 +34,7 @@ var (
 		DeltaBackOffExponent:       2.0,
 		MaxLookaheadRounds:         5,
 		RebroadcastBackoffBase:     3 * time.Second,
+		RebroadcastBackoffSpread:   0.1,
 		RebroadcastBackoffExponent: 1.3,
 		RebroadcastBackoffMax:      30 * time.Second,
 	}
@@ -98,6 +99,7 @@ type GpbftConfig struct {
 
 	RebroadcastBackoffBase     time.Duration
 	RebroadcastBackoffExponent float64
+	RebroadcastBackoffSpread   float64
 	RebroadcastBackoffMax      time.Duration
 }
 
@@ -131,6 +133,7 @@ func (g *GpbftConfig) ToOptions() []gpbft.Option {
 		gpbft.WithMaxLookaheadRounds(g.MaxLookaheadRounds),
 		gpbft.WithRebroadcastBackoff(
 			DefaultGpbftConfig.RebroadcastBackoffExponent,
+			DefaultGpbftConfig.RebroadcastBackoffSpread,
 			DefaultGpbftConfig.RebroadcastBackoffBase,
 			DefaultGpbftConfig.RebroadcastBackoffMax,
 		),

--- a/test/constants_test.go
+++ b/test/constants_test.go
@@ -29,7 +29,7 @@ var (
 	testGpbftOptions = []gpbft.Option{
 		gpbft.WithDelta(200 * time.Millisecond),
 		gpbft.WithDeltaBackOffExponent(1.300),
-		gpbft.WithRebroadcastBackoff(1.3, time.Second, 5*time.Second),
+		gpbft.WithRebroadcastBackoff(1.3, 0, time.Second, 5*time.Second),
 	}
 )
 


### PR DESCRIPTION
This fixes part of https://github.com/filecoin-project/go-f3/issues/549 to avoid having the entire network slam pubsub at the same time, although we should still optimize what we rebroadcast.

This also fixes the backoff calculator to return the actual backoff instead of always returning the max (oops).