### PR TITLE
Remove panic cases from TipSet methods and simplify nil handling

### DIFF
--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -23,9 +23,9 @@ func TestECChain(t *testing.T) {
 		require.True(t, subject.Eq(subject))
 		require.True(t, subject.Eq(*new(gpbft.ECChain)))
 		require.Nil(t, subject.Suffix())
-		require.Panics(t, func() { subject.Prefix(0) })
-		require.Panics(t, func() { subject.Base() })
-		require.Panics(t, func() { subject.Head() })
+		require.Nil(t, subject.Prefix(0))
+		require.Nil(t, subject.Base())
+		require.Nil(t, subject.Head())
 		require.NoError(t, subject.Validate())
 	})
 	t.Run("NewChain with zero-value base is error", func(t *testing.T) {


### PR DESCRIPTION
Panicing is perfectly fine in these cases, but not necessary and a little inconsistent (e.g., `Suffix` didn't panic).

1. Avoid panicing when TipSet is nil in Validate.
2. Use nil tipsets as zero tipsets, no need to look at the key. Empty tipset keys will fail `Validate` anyways. Remove `TipSet.Zero`.
3. Return a nil base when the chain has no base instead of panicing.
4. Return a nil head when the chain is empty.
5. Return a nil base chain when the chain has no base.
6. Improve some documentation.

fixes https://github.com/filecoin-project/go-f3/issues/643