### PR TITLE
Simplify CertStore subscriber

### DIFF
--- a/certstore/certstore_test.go
+++ b/certstore/certstore_test.go
@@ -222,7 +222,7 @@ func TestDeleteAll(t *testing.T) {
 	verifyEmpty()
 }
 
-func TestSubscribeForNewCerts(t *testing.T) {
+func TestSubscribe(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -233,8 +233,7 @@ func TestSubscribeForNewCerts(t *testing.T) {
 	cs, err := CreateStore(ctx, ds, 1, pt)
 	require.NoError(t, err)
 
-	ch := make(chan *certs.FinalityCertificate, 1)
-	_, closer := cs.SubscribeForNewCerts(ch)
+	ch, closer := cs.Subscribe()
 	defer closer()
 
 	cert := makeCert(1, supp)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/filecoin-project/go-f3
 go 1.22
 
 require (
-	github.com/Kubuxu/go-broadcast v0.0.0-20240621161059-1a8c90734cd6
 	github.com/drand/kyber v1.3.1
 	github.com/drand/kyber-bls12381 v0.3.1
 	github.com/filecoin-project/go-bitfield v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Kubuxu/go-broadcast v0.0.0-20240621161059-1a8c90734cd6 h1:yh2/1fz3ajTaeKskSWxtSBNScdRZfQ/A5nyd9+64T6M=
-github.com/Kubuxu/go-broadcast v0.0.0-20240621161059-1a8c90734cd6/go.mod h1:5LOj/fF3Oc/cvJqzDiyfx4XwtBPRWUYEz+V+b13sH5U=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=


### PR DESCRIPTION
I have yet to write any code that cares about intermediate certificates and they can easily be queried with `GetRange`. This change:

1. Makes the certificate subscription system always return the latest certificate, dropping intermediates.
2. Drops the dependency on go-broadcast.
3. Simplifies the code that relies on the certificate subscription logic.