### PR TITLE
Drop messages that are no longer useful for GPBFT progression

### DIFF
--- a/gpbft/errors.go
+++ b/gpbft/errors.go
@@ -25,6 +25,9 @@ var (
 	//
 	// See SupplementalData.
 	ErrValidationWrongSupplement = newValidationError("unexpected supplemental data")
+	// ErrValidationNotRelevant signals that a message is not relevant at the current
+	// instance, and is not worth propagating to others.
+	ErrValidationNotRelevant = newValidationError("message is valid but not relevant")
 
 	// ErrReceivedWrongInstance signals that a message is received with mismatching instance ID.
 	ErrReceivedWrongInstance = errors.New("received message for wrong instance")

--- a/gpbft/errors_test.go
+++ b/gpbft/errors_test.go
@@ -17,6 +17,7 @@ func TestValidationError_SentinelValues(t *testing.T) {
 		{name: "ErrValidationInvalid", subject: ErrValidationInvalid},
 		{name: "ErrValidationWrongBase", subject: ErrValidationWrongBase},
 		{name: "ErrValidationWrongSupplement", subject: ErrValidationWrongSupplement},
+		{name: "ErrValidationNotRelevant", subject: ErrValidationNotRelevant},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/gpbft/gpbft_test.go
+++ b/gpbft/gpbft_test.go
@@ -1609,7 +1609,8 @@ func TestGPBFT_DropOld(t *testing.T) {
 	}
 	driver.RequireDeliverMessage(newQuality)
 	driver.RequireDeliverMessage(newDecide0)
-	driver.RequireDeliverMessage(newCommit0) // no quorum of decides, should still accept it
+	// No quorum of decides, should still accept it but be considered not relevant
+	driver.RequireErrOnDeliverMessage(newCommit0, gpbft.ErrValidationNotRelevant, "not relevant")
 	driver.RequireDeliverMessage(newDecide1)
 
 	// Once we've received two decides, we should reject messages from the "new" instance.

--- a/gpbft/participant.go
+++ b/gpbft/participant.go
@@ -30,7 +30,7 @@ type Participant struct {
 	// if both are to be taken.
 	apiMutex sync.Mutex
 	// Mutex protecting currentInstance and committees cache for concurrent validation.
-	// Note that not every access need be protected:
+	// Note that not every access needs to be protected:
 	// - writes to currentInstance, and reads from it during validation,
 	// - reads from or writes to committees (which is written during validation).
 	instanceMutex sync.Mutex

--- a/host.go
+++ b/host.go
@@ -335,6 +335,10 @@ func (h *gpbftRunner) validatePubsubMessage(ctx context.Context, _ peer.ID, msg 
 	case errors.Is(err, gpbft.ErrValidationTooOld):
 		// we got the message too late
 		return pubsub.ValidationIgnore
+	case errors.Is(err, gpbft.ErrValidationNotRelevant):
+		// The message is valid but will not effectively aid progress of GPBFT. Ignore it
+		// to stop its further propagation across the network.
+		return pubsub.ValidationIgnore
 	case errors.Is(err, gpbft.ErrValidationNoCommittee):
 		log.Debugf("commitee error during validation: %+v", err)
 		return pubsub.ValidationIgnore

--- a/test/withhold_test.go
+++ b/test/withhold_test.go
@@ -73,9 +73,11 @@ func TestWitholdCommitAdversary(t *testing.T) {
 			}
 			// The adversary could convince the victim to decide a, so all must decide a.
 			require.NoError(t, err)
-			decision := sm.GetInstance(0).GetDecision(0)
-			require.NotNil(t, decision)
-			require.Equal(t, &a, decision)
+			for _, victim := range victims {
+				decision := sm.GetInstance(0).GetDecision(victim)
+				require.NotNil(t, decision)
+				require.Equal(t, &a, decision)
+			}
 		})
 	}
 }


### PR DESCRIPTION
As a GPBFT instance progresses some messages become irrelevant, in that they do not effectively aid the progress of the instance for participants. Instead, GPBFT offers other built-in mechanisms to aid progress of lagging participants such as selective rebroadcast, propagation of DECIDE messages from the previous instance and finality certificate exchange.

The changes here introduce a dedicated error type returned as part of message validation to signal that although a message is valid it is no longer relevant. This error type is then checked by pubsub to avoid further propagation of those messages.

This reduces the redundant pubsub traffic for the network participants.

Fixes #583