### PR TITLE
Refactor `Chain` interface into separate do-er interfaces

### DIFF
--- a/emulator/host.go
+++ b/emulator/host.go
@@ -68,7 +68,7 @@ func (h *driverHost) maybeReceiveDecision(decision *gpbft.Justification) error {
 	}
 }
 
-func (h *driverHost) GetProposalForInstance(id uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
+func (h *driverHost) GetProposal(id uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
 	instance := h.chain[id]
 	if instance == nil {
 		return nil, nil, fmt.Errorf("instance ID %d not found", id)
@@ -76,12 +76,15 @@ func (h *driverHost) GetProposalForInstance(id uint64) (*gpbft.SupplementalData,
 	return &instance.supplementalData, instance.Proposal(), nil
 }
 
-func (h *driverHost) GetCommitteeForInstance(id uint64) (power *gpbft.PowerTable, beacon []byte, err error) {
+func (h *driverHost) GetCommittee(id uint64) (*gpbft.Committee, error) {
 	instance := h.chain[id]
 	if instance == nil {
-		return nil, nil, fmt.Errorf("instance ID %d not found", id)
+		return nil, fmt.Errorf("instance ID %d not found", id)
 	}
-	return instance.powerTable, instance.beacon, nil
+	return &gpbft.Committee{
+		PowerTable: instance.powerTable,
+		Beacon:     instance.beacon,
+	}, nil
 }
 
 func (h *driverHost) addInstance(instance *Instance) error {

--- a/gpbft/committee.go
+++ b/gpbft/committee.go
@@ -1,0 +1,52 @@
+package gpbft
+
+import (
+	"fmt"
+	"sync"
+)
+
+var _ CommitteeProvider = (*cachedCommitteeProvider)(nil)
+
+type cachedCommitteeProvider struct {
+	delegate CommitteeProvider
+
+	// mu guards access to committees.
+	mu         sync.Mutex
+	committees map[uint64]*Committee
+}
+
+func newCachedCommitteeProvider(delegate CommitteeProvider) *cachedCommitteeProvider {
+	return &cachedCommitteeProvider{
+		delegate:   delegate,
+		committees: make(map[uint64]*Committee),
+	}
+}
+
+func (c *cachedCommitteeProvider) GetCommittee(instance uint64) (*Committee, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if committee, found := c.committees[instance]; found {
+		return committee, nil
+	}
+	switch committee, err := c.delegate.GetCommittee(instance); {
+	case err != nil:
+		return nil, fmt.Errorf("instance %d: %w: %w", instance, ErrValidationNoCommittee, err)
+	case committee == nil:
+		return nil, fmt.Errorf("unexpected nil committee for instance %d", instance)
+	default:
+		c.committees[instance] = committee
+		return committee, nil
+	}
+}
+
+// EvictCommitteesBefore evicts any cached committees that correspond to
+// instances prior to the given instance.
+func (c *cachedCommitteeProvider) EvictCommitteesBefore(instance uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range c.committees {
+		if i < instance {
+			delete(c.committees, i)
+		}
+	}
+}

--- a/gpbft/committee_test.go
+++ b/gpbft/committee_test.go
@@ -1,0 +1,141 @@
+package gpbft
+
+import (
+	"errors"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ CommitteeProvider = (*mockCommitteeProvider)(nil)
+)
+
+type mockCommitteeProvider struct {
+	mock.Mock
+}
+
+func (m *mockCommitteeProvider) GetCommittee(instance uint64) (*Committee, error) {
+	args := m.Called(instance)
+	if committee, ok := args.Get(0).(*Committee); ok {
+		return committee, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func TestCachedCommitteeProvider_GetCommittee(t *testing.T) {
+	var (
+		instance1                    = uint64(1)
+		instance2                    = uint64(2)
+		instance3                    = uint64(3)
+		instance5                    = uint64(5)
+		instance6                    = uint64(6)
+		instance7                    = uint64(7)
+		committeeWithValidPowerTable = &Committee{
+			PowerTable: generateValidPowerTable(t),
+			Beacon:     []byte("fish")}
+		committee5 = &Committee{
+			PowerTable: generateValidPowerTable(t),
+			Beacon:     []byte("fish"),
+		}
+		committee6 = &Committee{
+			PowerTable: generateValidPowerTable(t),
+			Beacon:     []byte("fish"),
+		}
+		committee7 = &Committee{
+			PowerTable: generateValidPowerTable(t),
+			Beacon:     []byte("fish"),
+		}
+
+		mockDelegate = new(mockCommitteeProvider)
+		subject      = newCachedCommitteeProvider(mockDelegate)
+	)
+
+	mockDelegate.On("GetCommittee", instance1).Return(committeeWithValidPowerTable, nil)
+	t.Run("delegates cache miss", func(t *testing.T) {
+		result, err := subject.GetCommittee(1)
+		require.NoError(t, err)
+		require.Equal(t, committeeWithValidPowerTable, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance1)
+	})
+	t.Run("caches", func(t *testing.T) {
+		result, err := subject.GetCommittee(1)
+		require.NoError(t, err)
+		require.Equal(t, committeeWithValidPowerTable, result)
+		mockDelegate.AssertNotCalled(t, "GetCommittee")
+	})
+	t.Run("delegates error", func(t *testing.T) {
+		wantErr := errors.New("undadasea")
+		mockDelegate.On("GetCommittee", instance2).Return(nil, wantErr)
+		result, err := subject.GetCommittee(instance2)
+		require.ErrorIs(t, err, ErrValidationNoCommittee)
+		require.ErrorIs(t, err, wantErr)
+		require.Nil(t, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance2)
+	})
+	t.Run("checks nil committee", func(t *testing.T) {
+		mockDelegate.On("GetCommittee", instance3).Return(nil, nil)
+		result, err := subject.GetCommittee(instance3)
+		require.ErrorContains(t, err, "unexpected")
+		require.Nil(t, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance3)
+	})
+	t.Run("evicts instances before given", func(t *testing.T) {
+		mockDelegate.On("GetCommittee", instance5).Return(committee5, nil)
+		mockDelegate.On("GetCommittee", instance6).Return(committee6, nil)
+		mockDelegate.On("GetCommittee", instance7).Return(committee7, nil)
+
+		// Populate
+		result, err := subject.GetCommittee(instance5)
+		require.NoError(t, err)
+		require.Equal(t, committee5, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance5)
+		result, err = subject.GetCommittee(instance6)
+		require.NoError(t, err)
+		require.Equal(t, committee6, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance6)
+		result, err = subject.GetCommittee(instance7)
+		require.NoError(t, err)
+		require.Equal(t, committee7, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance7)
+
+		// Assert cache hit.
+		result, err = subject.GetCommittee(instance5)
+		require.NoError(t, err)
+		require.Equal(t, committee5, result)
+		mockDelegate.AssertNotCalled(t, "GetCommittee")
+		result, err = subject.GetCommittee(instance6)
+		require.NoError(t, err)
+		require.Equal(t, committee6, result)
+		mockDelegate.AssertNotCalled(t, "GetCommittee")
+		result, err = subject.GetCommittee(instance7)
+		require.NoError(t, err)
+		require.Equal(t, committee7, result)
+		mockDelegate.AssertNotCalled(t, "GetCommittee")
+
+		// Evict committees prior to 6.
+		subject.EvictCommitteesBefore(instance6)
+
+		// Assert cache miss.
+		result, err = subject.GetCommittee(instance5)
+		require.NoError(t, err)
+		require.Equal(t, committee5, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance5)
+		result, err = subject.GetCommittee(instance1)
+		require.NoError(t, err)
+		require.Equal(t, committeeWithValidPowerTable, result)
+		mockDelegate.AssertCalled(t, "GetCommittee", instance1)
+	})
+}
+
+func generateValidPowerTable(t *testing.T) *PowerTable {
+	pt := NewPowerTable()
+	require.NoError(t, pt.Add(PowerEntry{
+		ID:     ActorID(rand.Uint64N(100)),
+		Power:  NewStoragePower(int64(rand.Uint64N(100))),
+		PubKey: []byte("lobster"),
+	}))
+	return pt
+}

--- a/gpbft/errors.go
+++ b/gpbft/errors.go
@@ -11,7 +11,7 @@ var (
 	// ErrValidationNoCommittee signals that a message is invalid because there is no
 	// committee for the instance to which it belongs.
 	//
-	// See: Chain.GetCommitteeForInstance.
+	// See: CommitteeProvider.
 	ErrValidationNoCommittee = newValidationError("no committee for instance")
 	// ErrValidationInvalid signals that a message violates the validity rules of
 	// gpbft protocol.

--- a/gpbft/mock_host_test.go
+++ b/gpbft/mock_host_test.go
@@ -80,79 +80,70 @@ func (_c *MockHost_Aggregate_Call) RunAndReturn(run func([]PubKey, [][]byte) ([]
 	return _c
 }
 
-// GetCommitteeForInstance provides a mock function with given fields: instance
-func (_m *MockHost) GetCommitteeForInstance(instance uint64) (*PowerTable, []byte, error) {
+// GetCommittee provides a mock function with given fields: instance
+func (_m *MockHost) GetCommittee(instance uint64) (*Committee, error) {
 	ret := _m.Called(instance)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetCommitteeForInstance")
+		panic("no return value specified for GetCommittee")
 	}
 
-	var r0 *PowerTable
-	var r1 []byte
-	var r2 error
-	if rf, ok := ret.Get(0).(func(uint64) (*PowerTable, []byte, error)); ok {
+	var r0 *Committee
+	var r1 error
+	if rf, ok := ret.Get(0).(func(uint64) (*Committee, error)); ok {
 		return rf(instance)
 	}
-	if rf, ok := ret.Get(0).(func(uint64) *PowerTable); ok {
+	if rf, ok := ret.Get(0).(func(uint64) *Committee); ok {
 		r0 = rf(instance)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*PowerTable)
+			r0 = ret.Get(0).(*Committee)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(uint64) []byte); ok {
+	if rf, ok := ret.Get(1).(func(uint64) error); ok {
 		r1 = rf(instance)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]byte)
-		}
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(uint64) error); ok {
-		r2 = rf(instance)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
-// MockHost_GetCommitteeForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCommitteeForInstance'
-type MockHost_GetCommitteeForInstance_Call struct {
+// MockHost_GetCommittee_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCommittee'
+type MockHost_GetCommittee_Call struct {
 	*mock.Call
 }
 
-// GetCommitteeForInstance is a helper method to define mock.On call
+// GetCommittee is a helper method to define mock.On call
 //   - instance uint64
-func (_e *MockHost_Expecter) GetCommitteeForInstance(instance interface{}) *MockHost_GetCommitteeForInstance_Call {
-	return &MockHost_GetCommitteeForInstance_Call{Call: _e.mock.On("GetCommitteeForInstance", instance)}
+func (_e *MockHost_Expecter) GetCommittee(instance interface{}) *MockHost_GetCommittee_Call {
+	return &MockHost_GetCommittee_Call{Call: _e.mock.On("GetCommittee", instance)}
 }
 
-func (_c *MockHost_GetCommitteeForInstance_Call) Run(run func(instance uint64)) *MockHost_GetCommitteeForInstance_Call {
+func (_c *MockHost_GetCommittee_Call) Run(run func(instance uint64)) *MockHost_GetCommittee_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(uint64))
 	})
 	return _c
 }
 
-func (_c *MockHost_GetCommitteeForInstance_Call) Return(power *PowerTable, beacon []byte, err error) *MockHost_GetCommitteeForInstance_Call {
-	_c.Call.Return(power, beacon, err)
+func (_c *MockHost_GetCommittee_Call) Return(_a0 *Committee, _a1 error) *MockHost_GetCommittee_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockHost_GetCommitteeForInstance_Call) RunAndReturn(run func(uint64) (*PowerTable, []byte, error)) *MockHost_GetCommitteeForInstance_Call {
+func (_c *MockHost_GetCommittee_Call) RunAndReturn(run func(uint64) (*Committee, error)) *MockHost_GetCommittee_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetProposalForInstance provides a mock function with given fields: instance
-func (_m *MockHost) GetProposalForInstance(instance uint64) (*SupplementalData, ECChain, error) {
+// GetProposal provides a mock function with given fields: instance
+func (_m *MockHost) GetProposal(instance uint64) (*SupplementalData, ECChain, error) {
 	ret := _m.Called(instance)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetProposalForInstance")
+		panic("no return value specified for GetProposal")
 	}
 
 	var r0 *SupplementalData
@@ -186,30 +177,30 @@ func (_m *MockHost) GetProposalForInstance(instance uint64) (*SupplementalData, 
 	return r0, r1, r2
 }
 
-// MockHost_GetProposalForInstance_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetProposalForInstance'
-type MockHost_GetProposalForInstance_Call struct {
+// MockHost_GetProposal_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetProposal'
+type MockHost_GetProposal_Call struct {
 	*mock.Call
 }
 
-// GetProposalForInstance is a helper method to define mock.On call
+// GetProposal is a helper method to define mock.On call
 //   - instance uint64
-func (_e *MockHost_Expecter) GetProposalForInstance(instance interface{}) *MockHost_GetProposalForInstance_Call {
-	return &MockHost_GetProposalForInstance_Call{Call: _e.mock.On("GetProposalForInstance", instance)}
+func (_e *MockHost_Expecter) GetProposal(instance interface{}) *MockHost_GetProposal_Call {
+	return &MockHost_GetProposal_Call{Call: _e.mock.On("GetProposal", instance)}
 }
 
-func (_c *MockHost_GetProposalForInstance_Call) Run(run func(instance uint64)) *MockHost_GetProposalForInstance_Call {
+func (_c *MockHost_GetProposal_Call) Run(run func(instance uint64)) *MockHost_GetProposal_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(uint64))
 	})
 	return _c
 }
 
-func (_c *MockHost_GetProposalForInstance_Call) Return(data *SupplementalData, chain ECChain, err error) *MockHost_GetProposalForInstance_Call {
+func (_c *MockHost_GetProposal_Call) Return(data *SupplementalData, chain ECChain, err error) *MockHost_GetProposal_Call {
 	_c.Call.Return(data, chain, err)
 	return _c
 }
 
-func (_c *MockHost_GetProposalForInstance_Call) RunAndReturn(run func(uint64) (*SupplementalData, ECChain, error)) *MockHost_GetProposalForInstance_Call {
+func (_c *MockHost_GetProposal_Call) RunAndReturn(run func(uint64) (*SupplementalData, ECChain, error)) *MockHost_GetProposal_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sim/adversary/repeat.go
+++ b/sim/adversary/repeat.go
@@ -82,11 +82,11 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 		return nil
 	}
 	instance := msg.Vote.Instance
-	supplementalData, _, err := r.host.GetProposalForInstance(instance)
+	supplementalData, _, err := r.host.GetProposal(instance)
 	if err != nil {
 		panic(err)
 	}
-	power, beacon, _ := r.host.GetCommitteeForInstance(instance)
+	committee, _ := r.host.GetCommittee(instance)
 	p := gpbft.Payload{
 		Instance:         instance,
 		Round:            msg.Vote.Round,
@@ -96,13 +96,13 @@ func (r *Repeat) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 	}
 	mt := &gpbft.MessageBuilder{
 		NetworkName:      r.host.NetworkName(),
-		PowerTable:       power,
+		PowerTable:       committee.PowerTable,
 		Payload:          p,
 		Justification:    msg.Justification,
 		SigningMarshaler: r.host,
 	}
 	if len(msg.Ticket) > 0 {
-		mt.BeaconForTicket = beacon
+		mt.BeaconForTicket = committee.Beacon
 	}
 	for i := 0; i < echoCount; i++ {
 		if msg.Sender != r.ID() {

--- a/sim/adversary/spam.go
+++ b/sim/adversary/spam.go
@@ -63,11 +63,11 @@ func (s *Spam) ReceiveMessage(vmsg gpbft.ValidatedMessage) error {
 func (s *Spam) spamAtInstance(instance uint64) {
 	// Spam the network with COMMIT messages by incrementing rounds up to
 	// roundsAhead.
-	supplementalData, _, err := s.host.GetProposalForInstance(instance)
+	supplementalData, _, err := s.host.GetProposal(instance)
 	if err != nil {
 		panic(err)
 	}
-	power, _, err := s.host.GetCommitteeForInstance(instance)
+	committee, err := s.host.GetCommittee(instance)
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +80,7 @@ func (s *Spam) spamAtInstance(instance uint64) {
 		}
 		mt := &gpbft.MessageBuilder{
 			NetworkName:      s.host.NetworkName(),
-			PowerTable:       power,
+			PowerTable:       committee.PowerTable,
 			Payload:          p,
 			SigningMarshaler: s.host,
 		}

--- a/sim/host.go
+++ b/sim/host.go
@@ -59,7 +59,7 @@ func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg Storag
 	}
 }
 
-func (v *simHost) GetProposalForInstance(instance uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
+func (v *simHost) GetProposal(instance uint64) (*gpbft.SupplementalData, gpbft.ECChain, error) {
 	// Use the head of latest agreement chain as the base of next.
 	// TODO: use lookback to return the correct next power table commitment and commitments hash.
 	chain := v.ecg.GenerateECChain(instance, *v.ecChain.Head(), v.id)
@@ -84,12 +84,14 @@ func (v *simHost) GetProposalForInstance(instance uint64) (*gpbft.SupplementalDa
 	return i.SupplementalData, chain, nil
 }
 
-func (v *simHost) GetCommitteeForInstance(instance uint64) (power *gpbft.PowerTable, beacon []byte, err error) {
+func (v *simHost) GetCommittee(instance uint64) (*gpbft.Committee, error) {
 	i := v.sim.ec.GetInstance(instance)
 	if i == nil {
-		return nil, nil, ErrInstanceUnavailable
+		return nil, ErrInstanceUnavailable
 	}
-	return i.PowerTable, i.Beacon, nil
+	return &gpbft.Committee{
+		PowerTable: i.PowerTable, Beacon: i.Beacon,
+	}, nil
 }
 
 func (v *simHost) SetAlarm(at time.Time) {

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -111,7 +111,7 @@ func (s *Simulation) Run(instanceCount uint64, maxRounds uint64) error {
 			//  * the simulation stabilisation delay is not long enough to halt the start of
 			//    next instance for those nodes before others have caught up.
 			//
-			// See simHost.GetProposalForInstance.
+			// See gpbft.ProposalProvider.
 			currentInstance = s.ec.GetInstance(currentInstance.Instance + 1)
 			if currentInstance == nil {
 				// Instantiate the next instance even if it goes beyond finalInstance.


### PR DESCRIPTION
Refactor the `Chain` interface into two separate smaller interfaces for a more pluggable committee caching.

Refactor committee cache out of participant.

This work is part of a larger refactor of validation mechanism and is separated into its own commit for easier review.

Part of #561