### PR TITLE
Simplify participant locking and expose current GPBFT progress

### DIFF
--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -135,7 +135,10 @@ func (pt *participantTestSubject) expectBeginInstance() {
 
 func (pt *participantTestSubject) requireNotStarted() {
 	pt.t.Helper()
-	require.Zero(pt.t, pt.CurrentRound())
+	instance, round, phase := pt.Progress()
+	require.Zero(pt.t, instance)
+	require.Zero(pt.t, round)
+	require.Equal(pt.t, gpbft.INITIAL_PHASE, phase)
 	require.Equal(pt.t, "nil", pt.Describe())
 }
 

--- a/gpbft/progress.go
+++ b/gpbft/progress.go
@@ -1,0 +1,49 @@
+package gpbft
+
+import "sync/atomic"
+
+var (
+	_ ProgressObserver = (*atomicProgression)(nil)
+	_ Progress         = (*atomicProgression)(nil).Get
+)
+
+// Progress gets the latest GPBFT instance progress.
+type Progress func() (instance, round uint64, phase Phase)
+
+// ProgressObserver defines an interface for observing and being notified about
+// the progress of a GPBFT instance as it advances through different instance,
+// rounds or phases.
+type ProgressObserver interface {
+	// NotifyProgress is called to notify the observer about the progress of GPBFT
+	// instance, round or phase.
+	NotifyProgress(instance, round uint64, phase Phase)
+}
+
+type atomicProgression struct {
+	progression atomic.Pointer[progress]
+}
+
+type progress struct {
+	instance uint64
+	round    uint64
+	phase    Phase
+}
+
+func newAtomicProgression() *atomicProgression {
+	return &atomicProgression{}
+}
+
+func (a *atomicProgression) NotifyProgress(instance, round uint64, phase Phase) {
+	a.progression.Store(&progress{
+		instance: instance,
+		round:    round,
+		phase:    phase,
+	})
+}
+
+func (a *atomicProgression) Get() (instance, round uint64, phase Phase) {
+	if latest := a.progression.Load(); latest != nil {
+		instance, round, phase = latest.instance, latest.round, latest.phase
+	}
+	return
+}

--- a/gpbft/progress_test.go
+++ b/gpbft/progress_test.go
@@ -1,0 +1,48 @@
+package gpbft
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAtomicProgression(t *testing.T) {
+	subject := newAtomicProgression()
+	t.Run("zero value", func(t *testing.T) {
+		instance, round, phase := subject.Get()
+		require.Equal(t, uint64(0), instance, "Expected initial instance to be 0")
+		require.Equal(t, uint64(0), round, "Expected initial round to be 0")
+		require.Equal(t, INITIAL_PHASE, phase, "Expected initial phase to be INITIAL_PHASE")
+	})
+	t.Run("notify and get", func(t *testing.T) {
+		subject.NotifyProgress(1, 10, PREPARE_PHASE)
+		instance, round, phase := subject.Get()
+		require.Equal(t, uint64(1), instance, "Expected instance to be 1")
+		require.Equal(t, uint64(10), round, "Expected round to be 10")
+		require.Equal(t, PREPARE_PHASE, phase, "Expected phase to be PREPARE_PHASE")
+	})
+	t.Run("notify and get progresses", func(t *testing.T) {
+		subject.NotifyProgress(2, 20, COMMIT_PHASE)
+		instance, round, phase := subject.Get()
+		require.Equal(t, uint64(2), instance, "Expected instance to be updated to 2")
+		require.Equal(t, uint64(20), round, "Expected round to be updated to 20")
+		require.Equal(t, COMMIT_PHASE, phase, "Expected phase to be updated to COMMIT_PHASE")
+	})
+	t.Run("concurrent update", func(t *testing.T) {
+		var wg sync.WaitGroup
+		update := func(inst, rnd uint64, ph Phase) {
+			defer wg.Done()
+			subject.NotifyProgress(inst, rnd, ph)
+		}
+		wg.Add(2)
+		go update(3, 30, COMMIT_PHASE)
+		go update(4, 40, DECIDE_PHASE)
+		wg.Wait()
+
+		instance, round, phase := subject.Get()
+		require.True(t, instance == 3 || instance == 4, "Instance should match one of the updates")
+		require.True(t, round == 30 || round == 40, "Round should match one of the updates")
+		require.True(t, phase == COMMIT_PHASE || phase == DECIDE_PHASE, "Phase should match one of the updates")
+	})
+}

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -95,7 +95,7 @@ func (s *Simulation) Run(instanceCount uint64, maxRounds uint64) error {
 			// certificates from future rounds, i.e. the instance that just completed in
 			// simulation, it signals the participant to skip ahead.
 			for _, p := range s.participants {
-				if p.CurrentInstance() < currentInstance.Instance {
+				if instance, _, _ := p.Progress(); instance < currentInstance.Instance {
 					// TODO: enhance control over propagation of finality certificates
 					//       See: https://github.com/filecoin-project/go-f3/issues/327
 					if err := p.StartInstanceAt(currentInstance.Instance, s.network.Time()); err != nil {
@@ -236,7 +236,7 @@ func (s *Simulation) GetInstance(i uint64) *ECInstance {
 func (s *Simulation) getMaxRound() uint64 {
 	var maxRound uint64
 	for _, participant := range s.participants {
-		currentRound := participant.CurrentRound()
+		_, currentRound, _ := participant.Progress()
 		if currentRound > maxRound {
 			maxRound = currentRound
 		}


### PR DESCRIPTION
The host implementation needs to know the progress of the current instance for certificate storage and catch up purposes. As a result the current instance must be safe to read from multiple goroutines. This was achieved by a dedicated mutex that synchronised all access to the current instanceID.

Separately, validation logic requires to know how far the current instance has progressed in order to effectively validate incoming messages.

The changes here simplify the locking by unifying the logic for checking the progress of an instance: both validator and host can now get the latest progress from the participant that is safe for concurrent use. This is achieved by moving the progress observer mechanism out of validator and into the participant, while introducing the concept of `gpbft.Progress` a function that returns the current instance, round and phase.

As part of this change, Lotus integration can now get the current round and phase as well as current instance, which is useful for self equivocation checking as well as debugging purposes.

Fixes #658
Relates to #599