### PR TITLE
Reduce GOGC in fuzz tests

### DIFF
--- a/.github/workflows/go-fuzz.yml
+++ b/.github/workflows/go-fuzz.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Fuzz
         env:
           FUZZTIME: 30s
+          GOGC: '100'
         run: make fuzz
       - name: Upload fuzz failure seed corpus as run artifact
         if: failure()


### PR DESCRIPTION
Investigate false negative fuzz test failures due to hitting memory limit by reverting GOGC back to default 100.

Fixes #666