### PR TITLE
Expose access to progress on f3 runner

### DIFF
--- a/f3.go
+++ b/f3.go
@@ -414,3 +414,10 @@ func (m *F3) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.Power
 	}
 	return nil, fmt.Errorf("no known network manifest")
 }
+
+func (m *F3) Progress() (instance, round uint64, phase gpbft.Phase) {
+	if st := m.state.Load(); st != nil && st.runner != nil {
+		instance, round, phase = st.runner.Progress()
+	}
+	return
+}

--- a/host.go
+++ b/host.go
@@ -452,7 +452,7 @@ func (h *gpbftRunner) startPubsub() (<-chan gpbft.ValidatedMessage, error) {
 
 var (
 	_ gpbft.Host     = (*gpbftHost)(nil)
-	_ gpbft.Progress = (*gpbftHost)(nil).Progress
+	_ gpbft.Progress = (*gpbftRunner)(nil).Progress
 )
 
 // gpbftHost is a newtype of gpbftRunner exposing APIs required by the gpbft.Participant
@@ -489,6 +489,14 @@ func (h *gpbftRunner) Stop(context.Context) error {
 		h.errgrp.Wait(),
 		h.teardownPubsub(),
 	)
+}
+
+// Progress returns the latest progress of GPBFT consensus in terms of instance
+// ID, round and phase.
+//
+// This API is safe for concurrent use.
+func (h *gpbftRunner) Progress() (instance, round uint64, phase gpbft.Phase) {
+	return h.participant.Progress()
 }
 
 // Returns inputs to the next GPBFT instance.
@@ -774,12 +782,4 @@ func (h *gpbftHost) Verify(pubKey gpbft.PubKey, msg []byte, sig []byte) error {
 
 func (h *gpbftHost) Aggregate(pubKeys []gpbft.PubKey) (gpbft.Aggregate, error) {
 	return h.verifier.Aggregate(pubKeys)
-}
-
-// Progress returns the latest progress of GPBFT concensus in terms of instance
-// ID, round and phase.
-//
-// This API is safe for concurrent use.
-func (h *gpbftHost) Progress() (instance, round uint64, phase gpbft.Phase) {
-	return h.participant.Progress()
 }


### PR DESCRIPTION
The root F3 instance holds reference to the `gpbftRunner`, not `gpbftHost`. To allow access to current progress from Lotus, move the `Progress` implementation to runner and expose at root `F3` type.

Part of #599