### PR TITLE
Don't abort if we fail to deliver an alarm and/or start an instance

### DIFF
--- a/emulator/driver.go
+++ b/emulator/driver.go
@@ -42,9 +42,7 @@ func (d *Driver) SetSigning(signing Signing) { d.host.Signing = signing }
 //
 // See NewInstance.
 func (d *Driver) StartInstance(id uint64) error {
-	if err := d.subject.StartInstanceAt(id, d.host.Time()); err != nil {
-		return err
-	}
+	d.subject.StartInstanceAt(id, d.host.Time())
 	// Trigger alarm once based on the implicit assumption that go-f3 uses alarm to
 	// kickstart an instance internally.
 	if triggered, err := d.DeliverAlarm(); err != nil {

--- a/gpbft/participant_test.go
+++ b/gpbft/participant_test.go
@@ -160,7 +160,7 @@ func (pt *participantTestSubject) requireStart() {
 // See [participant.go:Start()] for reference
 func (pt *participantTestSubject) Start() error {
 	pt.host.EXPECT().SetAlarm(pt.time)
-	require.NoError(pt.t, pt.Participant.StartInstanceAt(pt.instance, pt.time))
+	pt.Participant.StartInstanceAt(pt.instance, pt.time)
 	return pt.ReceiveAlarm()
 }
 
@@ -305,7 +305,7 @@ func TestParticipant(t *testing.T) {
 				subject.instance = fInstance
 				subject.expectBeginInstance()
 				// Receiving the certificate should skip directly to the finality instance.
-				require.NoError(t, subject.StartInstanceAt(fInstance, subject.time))
+				subject.StartInstanceAt(fInstance, subject.time)
 				// set subject to the finality instance to see if participant
 				// has begun the right instance.
 				require.NoError(t, subject.ReceiveAlarm())

--- a/sim/sim.go
+++ b/sim/sim.go
@@ -98,9 +98,7 @@ func (s *Simulation) Run(instanceCount uint64, maxRounds uint64) error {
 				if instance, _, _ := p.Progress(); instance < currentInstance.Instance {
 					// TODO: enhance control over propagation of finality certificates
 					//       See: https://github.com/filecoin-project/go-f3/issues/327
-					if err := p.StartInstanceAt(currentInstance.Instance, s.network.Time()); err != nil {
-						return fmt.Errorf("participant %d failed to skip to instace %d: %w", p.ID(), currentInstance.Instance, err)
-					}
+					p.StartInstanceAt(currentInstance.Instance, s.network.Time())
 				}
 			}
 
@@ -148,15 +146,11 @@ func (s *Simulation) startParticipants(instance uint64) {
 	when := s.network.Time()
 	// Start participants.
 	for _, p := range s.participants {
-		if err := p.StartInstanceAt(instance, when); err != nil {
-			panic(fmt.Errorf("participant %d failed starting: %w", p.ID(), err))
-		}
+		p.StartInstanceAt(instance, when)
 	}
 	// Start adversary
 	if s.adversary != nil {
-		if err := s.adversary.StartInstanceAt(instance, when); err != nil {
-			panic(fmt.Errorf("adversary %d failed starting: %w", s.adversary.ID(), err))
-		}
+		s.adversary.StartInstanceAt(instance, when)
 	}
 }
 


### PR DESCRIPTION
We may fail to deliver an alarm if we, e.g., don't have a power table we need to participate in that instance. In that case, we should just wait until we get a finality certificate that'll let us advance to an instance we can participate in.

Also, start the first instance at the correct time (which may be in the future if we're rebooting).