### PR TITLE
Make the FakeEC more configurable

### DIFF
--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -113,7 +113,11 @@ var runCmd = cli.Command{
 		id := c.Uint64("id")
 		signingBackend.Allow(int(id))
 
-		ec := consensus.NewFakeEC(ctx, 1, m.BootstrapEpoch, m.EC.Period, initialPowerTable)
+		ec := consensus.NewFakeEC(ctx,
+			consensus.WithBootstrapEpoch(m.BootstrapEpoch),
+			consensus.WithECPeriod(m.EC.Period),
+			consensus.WithInitialPowerTable(initialPowerTable),
+		)
 
 		module, err := f3.New(ctx, mprovider, ds, h, ps, signingBackend, ec, filepath.Join(tmpdir, "f3"))
 		if err != nil {

--- a/ec/powerdelta_test.go
+++ b/ec/powerdelta_test.go
@@ -30,7 +30,7 @@ var powerTableC = gpbft.PowerEntries{
 }
 
 func TestReplacePowerTable(t *testing.T) {
-	backend := consensus.NewFakeEC(context.Background(), 0, 0, 30, powerTableA)
+	backend := consensus.NewFakeEC(context.Background(), consensus.WithInitialPowerTable(powerTableA))
 	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, true)
 
 	head, err := modifiedBackend.GetHead(context.Background())
@@ -43,7 +43,7 @@ func TestReplacePowerTable(t *testing.T) {
 }
 
 func TestModifyPowerTable(t *testing.T) {
-	backend := consensus.NewFakeEC(context.Background(), 0, 0, 30, powerTableA)
+	backend := consensus.NewFakeEC(context.Background(), consensus.WithInitialPowerTable(powerTableA))
 	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, false)
 
 	head, err := modifiedBackend.GetHead(context.Background())
@@ -55,7 +55,7 @@ func TestModifyPowerTable(t *testing.T) {
 }
 
 func TestBypassModifiedPowerTable(t *testing.T) {
-	backend := consensus.NewFakeEC(context.Background(), 0, 0, 30, powerTableA)
+	backend := consensus.NewFakeEC(context.Background(), consensus.WithInitialPowerTable(powerTableA))
 	modifiedBackend := ec.WithModifiedPower(backend, nil, false)
 	require.Equal(t, backend, modifiedBackend)
 }

--- a/f3_test.go
+++ b/f3_test.go
@@ -528,10 +528,11 @@ func (e *testEnv) initialize() *testEnv {
 			})
 		}
 
-		e.ec = consensus.NewFakeEC(e.testCtx, 1,
-			e.manifest.BootstrapEpoch+e.manifest.EC.Finality,
-			e.manifest.EC.Period,
-			initialPowerTable)
+		e.ec = consensus.NewFakeEC(e.testCtx,
+			consensus.WithBootstrapEpoch(e.manifest.BootstrapEpoch+e.manifest.EC.Finality),
+			consensus.WithECPeriod(e.manifest.EC.Period),
+			consensus.WithInitialPowerTable(initialPowerTable),
+		)
 	}
 
 	for _, n := range e.nodes {


### PR DESCRIPTION
I need to be able to configure the fake EC to "forget" power tables after some time (and would like to be able to better test power table evolution as well).

Changes:

1. Use functional options (so we can add more later).
2. Make it possible to "forget" power tables after some time.
3. Make it possible to evolve the power-table over time.