### PR TITLE
Bump the protocol version compatibility

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ipfs/go-datastore"
 )
 
-const VersionCapability = 3
+const VersionCapability = 4
 
 var (
 	DefaultCommitteeLookback uint64 = 10


### PR DESCRIPTION
I can't recall if we've made any major breaking changes, but I want to bump this one more time before the final release just to be safe.