### PR TITLE
Fail fast in equivocation tests and fix typos

### DIFF
--- a/equivocation.go
+++ b/equivocation.go
@@ -139,5 +139,4 @@ func (ef *equivocationFilter) ProcessReceive(peerID peer.ID, m *gpbft.GMessage) 
 		// add the message
 		ef.seenMessages[key] = equivMessage{signature: m.Signature, origin: peerID}
 	}
-
 }

--- a/equivocation_test.go
+++ b/equivocation_test.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var localGoodPID = peer.ID("1local")
 var remotePID0 = peer.ID("0remote")
 var remotePID5 = peer.ID("5remote")
 
-func TestEquivactionFilter_ProcessBroadcast(t *testing.T) {
+func TestEquivocationFilter_ProcessBroadcast(t *testing.T) {
 	localPID := localGoodPID
 	ef := newEquivocationFilter(localPID)
 
@@ -22,7 +22,7 @@ func TestEquivactionFilter_ProcessBroadcast(t *testing.T) {
 		Vote:      gpbft.Payload{Instance: 1, Round: 1, Phase: gpbft.Phase(1)},
 		Signature: []byte("signature1"),
 	}
-	assert.True(t, ef.ProcessBroadcast(msg1), "First message should be processed")
+	require.True(t, ef.ProcessBroadcast(msg1), "First message should be processed")
 
 	// Test case 2: Duplicate message with same signature should be processed
 	msg2 := &gpbft.GMessage{
@@ -30,7 +30,7 @@ func TestEquivactionFilter_ProcessBroadcast(t *testing.T) {
 		Vote:      gpbft.Payload{Instance: 1, Round: 1, Phase: gpbft.Phase(1)},
 		Signature: []byte("signature1"),
 	}
-	assert.True(t, ef.ProcessBroadcast(msg2), "Duplicate message with same signature should be processed")
+	require.True(t, ef.ProcessBroadcast(msg2), "Duplicate message with same signature should be processed")
 
 	// Test case 3 Message with same key but different signature should not be processed
 	msg3 := &gpbft.GMessage{
@@ -38,7 +38,7 @@ func TestEquivactionFilter_ProcessBroadcast(t *testing.T) {
 		Vote:      gpbft.Payload{Instance: 1, Round: 1, Phase: gpbft.Phase(1)},
 		Signature: []byte("signature2"),
 	}
-	assert.False(t, ef.ProcessBroadcast(msg3), "Message with same key but different signature should not be processed")
+	require.False(t, ef.ProcessBroadcast(msg3), "Message with same key but different signature should not be processed")
 
 	// Test case 4: Message with new instance should be processed
 	msg4 := &gpbft.GMessage{
@@ -46,7 +46,7 @@ func TestEquivactionFilter_ProcessBroadcast(t *testing.T) {
 		Vote:      gpbft.Payload{Instance: 2, Round: 1, Phase: gpbft.Phase(1)},
 		Signature: []byte("signature3"),
 	}
-	assert.True(t, ef.ProcessBroadcast(msg4), "Message with new instance should be processed")
+	require.True(t, ef.ProcessBroadcast(msg4), "Message with new instance should be processed")
 
 	// Test case 5: Message with past instance should not be processed
 	msg5 := &gpbft.GMessage{
@@ -54,10 +54,10 @@ func TestEquivactionFilter_ProcessBroadcast(t *testing.T) {
 		Vote:      gpbft.Payload{Instance: 1, Round: 1, Phase: gpbft.Phase(1)},
 		Signature: []byte("signature4"),
 	}
-	assert.False(t, ef.ProcessBroadcast(msg5), "Message with past instance should not be processed")
+	require.False(t, ef.ProcessBroadcast(msg5), "Message with past instance should not be processed")
 }
 
-func TestEquivactionFilter_formKey(t *testing.T) {
+func TestEquivocationFilter_formKey(t *testing.T) {
 	ef := newEquivocationFilter(localGoodPID)
 
 	msg := &gpbft.GMessage{
@@ -71,10 +71,10 @@ func TestEquivactionFilter_formKey(t *testing.T) {
 		Phase:  gpbft.Phase(1),
 	}
 
-	assert.Equal(t, expectedKey, ef.formKey(msg), "Keys should match")
+	require.Equal(t, expectedKey, ef.formKey(msg), "Keys should match")
 }
 
-func TestEquivactionFilter_remoteEquivocationResolution(t *testing.T) {
+func TestEquivocationFilter_remoteEquivocationResolution(t *testing.T) {
 	localPID := localGoodPID
 	ef := newEquivocationFilter(localPID)
 
@@ -83,7 +83,7 @@ func TestEquivactionFilter_remoteEquivocationResolution(t *testing.T) {
 		Vote:      gpbft.Payload{Instance: 1, Round: 1, Phase: gpbft.Phase(1)},
 		Signature: []byte("signature1"),
 	}
-	assert.True(t, ef.ProcessBroadcast(msg1), "First message should be processed")
+	require.True(t, ef.ProcessBroadcast(msg1), "First message should be processed")
 	ef.ProcessReceive(localPID, msg1)
 
 	msg2 := &gpbft.GMessage{
@@ -92,7 +92,7 @@ func TestEquivactionFilter_remoteEquivocationResolution(t *testing.T) {
 		Signature: []byte("signature2"),
 	}
 	ef.ProcessReceive(remotePID5, msg2)
-	assert.Contains(t, ef.activeSenders[msg2.Sender].origins, remotePID5)
+	require.Contains(t, ef.activeSenders[msg2.Sender].origins, remotePID5)
 
 	msg3 := &gpbft.GMessage{
 		Sender:    gpbft.ActorID(1),
@@ -100,7 +100,7 @@ func TestEquivactionFilter_remoteEquivocationResolution(t *testing.T) {
 		Signature: []byte("signature3"),
 	}
 
-	assert.True(t, ef.ProcessBroadcast(msg3), "local sender should still be able to broadcast")
+	require.True(t, ef.ProcessBroadcast(msg3), "local sender should still be able to broadcast")
 	ef.ProcessReceive(localPID, msg1)
 
 	// lower PeerID sender comes along
@@ -110,7 +110,7 @@ func TestEquivactionFilter_remoteEquivocationResolution(t *testing.T) {
 		Signature: []byte("signature4"),
 	}
 	ef.ProcessReceive(remotePID0, msg4)
-	assert.Contains(t, ef.activeSenders[msg2.Sender].origins, remotePID0)
+	require.Contains(t, ef.activeSenders[msg2.Sender].origins, remotePID0)
 
 	msg5 := &gpbft.GMessage{
 		Sender:    gpbft.ActorID(1),
@@ -118,9 +118,9 @@ func TestEquivactionFilter_remoteEquivocationResolution(t *testing.T) {
 		Signature: []byte("signature5"),
 	}
 
-	assert.False(t, ef.ProcessBroadcast(msg5), "we should have backed off")
+	require.False(t, ef.ProcessBroadcast(msg5), "we should have backed off")
 
-	assert.False(t, ef.ProcessBroadcast(msg3), "trying to re-broadcast is now not allowed")
+	require.False(t, ef.ProcessBroadcast(msg3), "trying to re-broadcast is now not allowed")
 }
 
 func TestEquivocationFilter_PeerIDBasedEquivocationHandling(t *testing.T) {
@@ -133,7 +133,7 @@ func TestEquivocationFilter_PeerIDBasedEquivocationHandling(t *testing.T) {
 		Vote:      gpbft.Payload{Instance: 1, Round: 1, Phase: gpbft.Phase(1)},
 		Signature: []byte("signature1"),
 	}
-	assert.True(t, ef.ProcessBroadcast(msg1), "Local message should be processed")
+	require.True(t, ef.ProcessBroadcast(msg1), "Local message should be processed")
 
 	// Remote equivocation with higher PeerID
 	msg2 := &gpbft.GMessage{
@@ -142,10 +142,10 @@ func TestEquivocationFilter_PeerIDBasedEquivocationHandling(t *testing.T) {
 		Signature: []byte("signature2"),
 	}
 	ef.ProcessReceive(remotePID5, msg2)
-	assert.Contains(t, ef.activeSenders[msg2.Sender].origins, remotePID5, "Higher PeerID should be recorded")
+	require.Contains(t, ef.activeSenders[msg2.Sender].origins, remotePID5, "Higher PeerID should be recorded")
 
 	// Local broadcast after higher PeerID equivocation
-	assert.True(t, ef.ProcessBroadcast(msg1), "Local message should still be processed after higher PeerID equivocation")
+	require.True(t, ef.ProcessBroadcast(msg1), "Local message should still be processed after higher PeerID equivocation")
 
 	// Remote equivocation with lower PeerID
 	msg3 := &gpbft.GMessage{
@@ -154,8 +154,8 @@ func TestEquivocationFilter_PeerIDBasedEquivocationHandling(t *testing.T) {
 		Signature: []byte("signature3"),
 	}
 	ef.ProcessReceive(remotePID0, msg3)
-	assert.Contains(t, ef.activeSenders[msg3.Sender].origins, remotePID0, "Lower PeerID should be recorded")
+	require.Contains(t, ef.activeSenders[msg3.Sender].origins, remotePID0, "Lower PeerID should be recorded")
 
 	// Local broadcast after lower PeerID equivocation
-	assert.False(t, ef.ProcessBroadcast(msg1), "Local message should not be processed after lower PeerID equivocation")
+	require.False(t, ef.ProcessBroadcast(msg1), "Local message should not be processed after lower PeerID equivocation")
 }


### PR DESCRIPTION
We want to fail fast in equivocation tests as there is not much point proceeding with the tests if a test case fails.

While at it, fix typos in tests.