### PR TITLE
Move redundant top-level singer-marshaller interface

### DIFF
--- a/gpbft/message_builder.go
+++ b/gpbft/message_builder.go
@@ -22,11 +22,6 @@ type powerTableAccessor interface {
 	Get(ActorID) (int64, PubKey)
 }
 
-type SignerWithMarshaler interface {
-	Signer
-	SigningMarshaler
-}
-
 // Build uses the builder and a signer interface to build GMessage
 // It is a shortcut for when separated flow is not required
 func (mt *MessageBuilder) Build(ctx context.Context, signer Signer, id ActorID) (*GMessage, error) {

--- a/sim/host.go
+++ b/sim/host.go
@@ -46,7 +46,7 @@ type SimNetwork interface {
 func newHost(id gpbft.ActorID, sim *Simulation, ecg ECChainGenerator, spg StoragePowerGenerator) *simHost {
 	pubKey, _ := sim.signingBacked.GenerateKey()
 	return &simHost{
-		SimNetwork:       sim.network.NetworkFor(sim.signingBacked, id),
+		SimNetwork:       sim.network.networkFor(sim.signingBacked, id),
 		Verifier:         sim.signingBacked,
 		Signer:           sim.signingBacked,
 		SigningMarshaler: sim.signingBacked,

--- a/sim/network.go
+++ b/sim/network.go
@@ -65,7 +65,12 @@ func (n *Network) AddParticipant(id gpbft.ActorID, p gpbft.Receiver) {
 
 ////// Network interface
 
-func (n *Network) NetworkFor(signer gpbft.SignerWithMarshaler, id gpbft.ActorID) *networkFor {
+type signerWithMarshaler interface {
+	gpbft.Signer
+	gpbft.SigningMarshaler
+}
+
+func (n *Network) networkFor(signer signerWithMarshaler, id gpbft.ActorID) *networkFor {
 	return &networkFor{
 		ParticipantID: id,
 		Signer:        signer,
@@ -75,7 +80,7 @@ func (n *Network) NetworkFor(signer gpbft.SignerWithMarshaler, id gpbft.ActorID)
 
 type networkFor struct {
 	ParticipantID gpbft.ActorID
-	Signer        gpbft.SignerWithMarshaler
+	Signer        signerWithMarshaler
 	*Network
 }
 


### PR DESCRIPTION
The interface`SignerWithMarshaler` is only used by `sim` package. Remove it from top level `gpbft` package into unexported `sim` network implementation.

Unexport simulation `NetworkFor` since it is returning an unexported type.