### PR TITLE
Specify whether or not to finalize tipsets in the manifest itself

### DIFF
--- a/host.go
+++ b/host.go
@@ -216,8 +216,14 @@ func (h *gpbftRunner) Start(ctx context.Context) (_err error) {
 						// There is not much we can do here other than logging. The next instance start
 						// will effectively retry checkpointing the latest finalized tipset. This error
 						// will not impact the selection of next instance chain.
-						log.Error(fmt.Errorf("error while finalizing decision at EC: %w", err))
+						log.Errorf("error while finalizing decision at EC: %+v", err)
 					}
+				} else {
+					ts := cert.ECChain.Head()
+					log.Infow("not finalizing a new head because Finalize the manifest specifies that tipsets should not be finalized",
+						"tsk", ts.Key,
+						"epoch", ts.Epoch,
+					)
 				}
 				const keepInstancesInWAL = 5
 				if cert.GPBFTInstance > keepInstancesInWAL {

--- a/host.go
+++ b/host.go
@@ -210,12 +210,14 @@ func (h *gpbftRunner) Start(ctx context.Context) (_err error) {
 					// does, error loudly since the chances are the cause is a programmer error.
 					return errors.New("cert store subscription to finalize tipsets was closed unexpectedly")
 				}
-				key := cert.ECChain.Head().Key
-				if err := h.ec.Finalize(h.runningCtx, key); err != nil {
-					// There is not much we can do here other than logging. The next instance start
-					// will effectively retry checkpointing the latest finalized tipset. This error
-					// will not impact the selection of next instance chain.
-					log.Error(fmt.Errorf("error while finalizing decision at EC: %w", err))
+				if h.manifest.EC.Finalize {
+					key := cert.ECChain.Head().Key
+					if err := h.ec.Finalize(h.runningCtx, key); err != nil {
+						// There is not much we can do here other than logging. The next instance start
+						// will effectively retry checkpointing the latest finalized tipset. This error
+						// will not impact the selection of next instance chain.
+						log.Error(fmt.Errorf("error while finalizing decision at EC: %w", err))
+					}
 				}
 				const keepInstancesInWAL = 5
 				if cert.GPBFTInstance > keepInstancesInWAL {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -27,6 +27,7 @@ var (
 		// MaxBackoff is 15min given default params
 		BaseDecisionBackoffTable: []float64{1.3, 1.69, 2.2, 2.86, 3.71, 4.83, 6.27, 7.5},
 		HeadLookback:             0,
+		Finalize:                 true,
 	}
 
 	DefaultGpbftConfig = GpbftConfig{
@@ -152,6 +153,8 @@ type EcConfig struct {
 	BaseDecisionBackoffTable []float64
 	// HeadLookback number of unfinalized tipsets to remove from the head
 	HeadLookback int
+	// Finalize indicates whether or not F3 should finalize tipsets as F3 agrees on them.
+	Finalize bool
 }
 
 func (e *EcConfig) Equal(o *EcConfig) bool {


### PR DESCRIPTION
This'll make it easier to wire up the bootstrap logic.