### PR TITLE
Support filtering received dynamic manifest

### DIFF
--- a/cmd/f3/observer.go
+++ b/cmd/f3/observer.go
@@ -166,7 +166,10 @@ var observerCmd = cli.Command{
 		if err != nil {
 			return fmt.Errorf("decoding manifestServerID: %w", err)
 		}
-		manifestProvider, err := manifest.NewDynamicManifestProvider(nil, ds, pubSub, manifestServerID)
+		manifestProvider, err := manifest.NewDynamicManifestProvider(
+			pubSub, manifestServerID,
+			manifest.DynamicManifestProviderWithDatastore(ds),
+		)
 		if err != nil {
 			return fmt.Errorf("initialzing manifest sender: %w", err)
 		}

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -104,7 +104,10 @@ var runCmd = cli.Command{
 			if err != nil {
 				return fmt.Errorf("parsing manifest server ID: %w", err)
 			}
-			mprovider, err = manifest.NewDynamicManifestProvider(m, ds, ps, manifestServer)
+			mprovider, err = manifest.NewDynamicManifestProvider(ps, manifestServer,
+				manifest.DynamicManifestProviderWithDatastore(ds),
+				manifest.DynamicManifestProviderWithInitialManifest(m),
+			)
 		} else {
 			mprovider, err = manifest.NewStaticManifestProvider(m)
 		}

--- a/f3_test.go
+++ b/f3_test.go
@@ -342,7 +342,9 @@ func (n *testNode) init() *f3.F3 {
 	var mprovider manifest.ManifestProvider
 	if manifestServerID != "" {
 		mprovider, err = manifest.NewDynamicManifestProvider(
-			n.e.currentManifest(), ds, ps, manifestServerID)
+			ps, manifestServerID,
+			manifest.DynamicManifestProviderWithInitialManifest(n.e.currentManifest()),
+		)
 	} else {
 		mprovider, err = manifest.NewStaticManifestProvider(n.e.currentManifest())
 	}


### PR DESCRIPTION
That way we can, e.g., prevent the manifest server from sending manifests that apply to the mainnet network name, actually finalize tipsets, etc.

See #688.