### PR TITLE
Apply manifest update immediately after receipt

### DIFF
--- a/f3_helpers_test.go
+++ b/f3_helpers_test.go
@@ -1,0 +1,16 @@
+package f3
+
+import "context"
+
+// These methods are restricted to tests only because they can interfere with the manifest sender
+// logic in strange ways (and aren't something we want to support long-term anyways).
+
+// Resume the F3 runner. Internal method for testing only.
+func (m *F3) Resume(ctx context.Context) error {
+	return m.startInternal(ctx)
+}
+
+// Pause the F3 runner. Internal method for testing only.
+func (m *F3) Pause(ctx context.Context) error {
+	return m.stopInternal(ctx)
+}

--- a/f3_test.go
+++ b/f3_test.go
@@ -195,12 +195,13 @@ func TestF3DynamicManifest_WithRebootstrap(t *testing.T) {
 	// check that it rebootstrapped and has a new base epoch.
 	targetBaseEpoch := env.manifest.BootstrapEpoch - env.manifest.EC.Finality
 	env.waitForCondition(func() bool {
+		env.clock.Add(env.manifest.EC.Period)
 		c, err := env.nodes[0].f3.GetCert(env.testCtx, 0)
 		if err != nil || c == nil {
 			return false
 		}
 		return c.ECChain.Base().Epoch == targetBaseEpoch
-	}, 10*time.Second)
+	}, 20*time.Second)
 	env.waitForInstanceNumber(3, 15*time.Second, false)
 	require.NotEqual(t, prev, env.nodes[0].f3.Manifest())
 	env.requireEqualManifests(false)


### PR DESCRIPTION
That way we:

1. Stop immediately.
2. Expose the manifest to the user immediately so they can see which network we're going to participate in (important for the miner participation API).