### PR TITLE
Atomically return manifest + instant

### DIFF
--- a/f3.go
+++ b/f3.go
@@ -88,10 +88,6 @@ func (m *F3) MessagesToSign() <-chan *gpbft.MessageBuilder {
 	return m.outboundMessages
 }
 
-func (m *F3) Manifest() *manifest.Manifest {
-	return m.manifest.Load()
-}
-
 func (m *F3) Broadcast(ctx context.Context, signatureBuilder *gpbft.SignatureBuilder, msgSig []byte, vrf []byte) {
 	state := m.state.Load()
 	if state == nil {
@@ -402,9 +398,13 @@ func (m *F3) GetPowerTable(ctx context.Context, ts gpbft.TipSetKey) (gpbft.Power
 	return nil, fmt.Errorf("no known network manifest")
 }
 
-func (m *F3) Progress() (instant gpbft.Instant) {
-	if st := m.state.Load(); st != nil && st.runner != nil {
+// Status (atomically) returns the current network manifest and instant in that network.
+func (m *F3) Status() (manifest *manifest.Manifest, instant gpbft.Instant) {
+	if st := m.state.Load(); st != nil {
+		manifest = st.manifest
 		instant = st.runner.Progress()
+	} else {
+		manifest = m.manifest.Load()
 	}
 	return
 }


### PR DESCRIPTION
Otherwise, there's no (nice) atomic way to get both the current progress and the current network.

- I'm renaming this to `Status` because it does more than return the current instant. It also means we have the trifecta: start/stop/status.
- I've removed the separate `Manifest` method because there really wasn't any need for it. Maybe I'm being over-eager to break things but... this gives us a single-atomic way to inspect the state (well, except "is running").

Feel free to tell me this too much...