### PR TITLE
chore: add more logs on manifest and initial power table

### DIFF
--- a/f3.go
+++ b/f3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/filecoin-project/go-f3/internal/writeaheadlog"
 	"github.com/filecoin-project/go-f3/manifest"
 
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -187,11 +188,18 @@ func (m *F3) Start(startCtx context.Context) (_err error) {
 	}
 	{
 		var maybeNetworkName gpbft.NetworkName
+		var bootstrapEpoch int64
+		var finality int64
+		var initialPowerTable *cid.Cid
 		if m := m.manifest.Load(); m != nil {
 			maybeNetworkName = m.NetworkName
+			bootstrapEpoch = m.BootstrapEpoch
+			finality = m.EC.Finality
+			initialPowerTable = &m.InitialPowerTable
 		}
-		log.Infow("F3 is starting", "initialDelay", initialDelay,
-			"hasPendingManifest", hasPendingManifest, "NetworkName", maybeNetworkName)
+		log.Infow("F3 is starting", "initialDelay", initialDelay, "hasPendingManifest", hasPendingManifest,
+			"NetworkName", maybeNetworkName, "bootstrapEpoch", bootstrapEpoch, "finality", finality,
+			"initialPowerTable", initialPowerTable)
 	}
 
 	m.errgrp.Go(func() (_err error) {

--- a/f3.go
+++ b/f3.go
@@ -20,7 +20,6 @@ import (
 	"github.com/filecoin-project/go-f3/internal/writeaheadlog"
 	"github.com/filecoin-project/go-f3/manifest"
 
-	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -186,20 +185,13 @@ func (m *F3) Start(startCtx context.Context) (_err error) {
 		}
 		hasPendingManifest = false
 	}
-	{
-		var maybeNetworkName gpbft.NetworkName
-		var bootstrapEpoch int64
-		var finality int64
-		var initialPowerTable *cid.Cid
-		if m := m.manifest.Load(); m != nil {
-			maybeNetworkName = m.NetworkName
-			bootstrapEpoch = m.BootstrapEpoch
-			finality = m.EC.Finality
-			initialPowerTable = &m.InitialPowerTable
-		}
+
+	if m := m.manifest.Load(); m != nil {
 		log.Infow("F3 is starting", "initialDelay", initialDelay, "hasPendingManifest", hasPendingManifest,
-			"NetworkName", maybeNetworkName, "bootstrapEpoch", bootstrapEpoch, "finality", finality,
-			"initialPowerTable", initialPowerTable)
+			"NetworkName", m.NetworkName, "BootstrapEpoch", m.BootstrapEpoch, "Finality", m.EC.Finality,
+			"InitialPowerTable", m.InitialPowerTable, "CommitteeLookback", m.CommitteeLookback)
+	} else {
+		log.Infow("F3 is starting", "initialDelay", initialDelay, "hasPendingManifest", hasPendingManifest)
 	}
 
 	m.errgrp.Go(func() (_err error) {

--- a/store.go
+++ b/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/filecoin-project/go-f3/certexchange"
+	"github.com/filecoin-project/go-f3/certs"
 	"github.com/filecoin-project/go-f3/certstore"
 	"github.com/filecoin-project/go-f3/ec"
 	"github.com/filecoin-project/go-f3/gpbft"
@@ -45,6 +46,9 @@ func loadInitialPowerTable(ctx context.Context, ec ec.Backend, m *manifest.Manif
 	} else if pt, err := ec.GetPowerTable(ctx, ts.Key()); err != nil {
 		log.Debugw("failed to load the bootstrap power table for F3 from state", "error", err)
 	} else {
+		if ptCid, err := certs.MakePowerTableCID(pt); err == nil {
+			log.Infof("loaded initial power table at epoch %d: %s", epoch, ptCid)
+		}
 		return pt, nil
 	}
 	if !m.InitialPowerTable.Defined() {

--- a/store.go
+++ b/store.go
@@ -48,6 +48,9 @@ func loadInitialPowerTable(ctx context.Context, ec ec.Backend, m *manifest.Manif
 	} else {
 		if ptCid, err := certs.MakePowerTableCID(pt); err == nil {
 			log.Infof("loaded initial power table at epoch %d: %s", epoch, ptCid)
+			if m.InitialPowerTable.Defined() && m.InitialPowerTable != ptCid {
+				log.Warnf("initial power table mismatch, loaded from EC: %s, from manifest: %s", ptCid, m.InitialPowerTable)
+			}
 		}
 		return pt, nil
 	}


### PR DESCRIPTION
This PR adds more F3 startup logs for easier troubleshooting.

After the change:
```
...
2024-10-15T13:15:14.693+0800    INFO    f3      go-f3/store.go:50       loaded initial power table at epoch 1860: bafy2bzaced6vgp6agebcyymrmh3q2r6gmiz3owb2b7kz5h744u7frlkdpg3qy
...
2024-10-15T13:15:14.704+0800    INFO    f3      go-f3/f3.go:200 F3 is starting  {"initialDelay": 0, "hasPendingManifest": false, "NetworkName": "butterflynet", "bootstrapEpoch": 2760, "finality": 900, "initialPowerTable": "b"}
```