### PR TITLE
ci: allow custom runners usage in the Go Test workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   go-test:
-    uses: ipdxco/unified-github-workflows/.github/workflows/go-test.yml@v1.0
+    uses: filecoin-project/unified-github-workflows/.github/workflows/go-test.yml@v1.0
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This is a follow-up to the discussions we've been having at https://ipdx-workspace.slack.com/archives/C03KLC57LKB/p1730963666791569

I forgot about this limitation before. In this PR I pointed the go-test at the fork of https://github.com/ipdxco/unified-github-workflows that lives in filecoin-project org https://github.com/filecoin-project/unified-github-workflows. By doing that, we'll be able to set up custom runners for the workflow via the repo config vars.

What's also worth noting is that https://github.com/filecoin-project/unified-github-workflows is kept up-to-date automatically by https://github.com/ipdxco/unified-github-workflows/actions/workflows/sync-forks.yml (so it doesn't introduce any additional manual maintenance burden whatsoever).