### PR TITLE
Consistently use cert pointer in verification

### DIFF
--- a/certexchange/polling/poller.go
+++ b/certexchange/polling/poller.go
@@ -135,7 +135,7 @@ func (p *Poller) Poll(ctx context.Context, peer peer.ID) (*PollResult, error) {
 			// TODO: consider batching verification, it's slightly faster.
 			next, _, pt, err := certs.ValidateFinalityCertificates(
 				p.SignatureVerifier, p.NetworkName, p.PowerTable, p.NextInstance, nil,
-				*cert,
+				cert,
 			)
 			if err != nil {
 				res.Status = PollIllegal

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -89,7 +89,7 @@ func NewFinalityCertificate(powerDelta PowerTableDiff, justification *gpbft.Just
 // finalized, the instance of the first invalid finality certificate, and the power table that
 // should be used to validate that finality certificate, along with the error encountered.
 func ValidateFinalityCertificates(verifier gpbft.Verifier, network gpbft.NetworkName, prevPowerTable gpbft.PowerEntries, nextInstance uint64, base *gpbft.TipSet,
-	certs ...FinalityCertificate) (_nextInstance uint64, chain gpbft.ECChain, newPowerTable gpbft.PowerEntries, err error) {
+	certs ...*FinalityCertificate) (_nextInstance uint64, chain gpbft.ECChain, newPowerTable gpbft.PowerEntries, err error) {
 	for _, cert := range certs {
 		if cert.GPBFTInstance != nextInstance {
 			return nextInstance, chain, prevPowerTable, fmt.Errorf("expected instance %d, found instance %d", nextInstance, cert.GPBFTInstance)
@@ -144,7 +144,7 @@ func ValidateFinalityCertificates(verifier gpbft.Verifier, network gpbft.Network
 // Verify the signature of the given finality certificate. This doesn't validate the power delta, or
 // any other parts of the certificate, just that the _value_ has been signed by a majority of the
 // power.
-func verifyFinalityCertificateSignature(verifier gpbft.Verifier, powerTable gpbft.PowerEntries, nn gpbft.NetworkName, cert FinalityCertificate) error {
+func verifyFinalityCertificateSignature(verifier gpbft.Verifier, powerTable gpbft.PowerEntries, nn gpbft.NetworkName, cert *FinalityCertificate) error {
 	scaled, totalScaled, err := powerTable.Scaled()
 	if err != nil {
 		return fmt.Errorf("failed to scale power table: %w", err)

--- a/host.go
+++ b/host.go
@@ -909,7 +909,7 @@ func (h *gpbftHost) saveDecision(decision *gpbft.Justification) (*certs.Finality
 	if err != nil {
 		return nil, fmt.Errorf("forming certificate out of decision: %w", err)
 	}
-	_, _, _, err = certs.ValidateFinalityCertificates(h, h.NetworkName(), current.PowerTable.Entries, decision.Vote.Instance, nil, *cert)
+	_, _, _, err = certs.ValidateFinalityCertificates(h, h.NetworkName(), current.PowerTable.Entries, decision.Vote.Instance, nil, cert)
 	if err != nil {
 		return nil, fmt.Errorf("certificate is invalid: %w", err)
 	}


### PR DESCRIPTION
The finality certificate APIs at times switch between pointer and values. This introduces the need for extra gymnastics when validating certs, where a slice of cert pointers need to be converted to values to use the cert verification APIs.

Instead, consistently accept pointers to certs.