### PR TITLE
Custom JSON serialization of TipSetKey for array-of-CIDs

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -46,7 +46,7 @@ type FinalityCertificate struct {
 	Signature []byte
 	// Changes between the power table used to validate this finality certificate and the power
 	// used to validate the next finality certificate. Sorted by ParticipantID, ascending.
-	PowerTableDelta PowerTableDiff `json:"omitempty"`
+	PowerTableDelta PowerTableDiff `json:"PowerTableDelta,omitempty"`
 }
 
 // NewFinalityCertificate constructs a new finality certificate from the given power delta (from

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -46,7 +46,7 @@ type FinalityCertificate struct {
 	Signature []byte
 	// Changes between the power table used to validate this finality certificate and the power
 	// used to validate the next finality certificate. Sorted by ParticipantID, ascending.
-	PowerTableDelta PowerTableDiff
+	PowerTableDelta PowerTableDiff `json:"omitempty"`
 }
 
 // NewFinalityCertificate constructs a new finality certificate from the given power delta (from

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -188,7 +188,7 @@ func TestECChain_Eq(t *testing.T) {
 	}
 }
 
-func TestTipSetKeySerialization(t *testing.T) {
+func TestTipSetSerialization(t *testing.T) {
 	t.Parallel()
 	var (
 		c1        = gpbft.MakeCid([]byte("barreleye1"))
@@ -268,6 +268,11 @@ func TestTipSetKeySerialization(t *testing.T) {
 			for j, c := range []cid.Cid{c1, c2, c3}[:len(ts.Key)/38] {
 				req.Equal(map[string]any{"/": c.String()}, keyField[j])
 			}
+
+			// check that the supplemental data is a base64 string
+			commitField, ok := bareMap["Commitments"].(string)
+			req.True(ok)
+			req.Len(commitField, 44)
 		}
 	})
 


### PR DESCRIPTION
🤷 is this OK to do here?

Basically: the byte form of a TipSetKey isn't very useful as a consumer of the Lotus API, we don't give it like that anywhere. So a user would have to decoded the base64 bytes, extract the CIDs from it using one of the CID libraries, then re-form it back into the array-of-CIDs dag-json form to post it back to a Lotus API to do anything with it (like calling `ChainGetTipSet`).

Before:

```
$ curl -s -X POST -H "Content-Type: application/json" --data '{"method":"Filecoin.F3GetLatestCertificate","params":[],"id":2,"jsonrpc":"2.0"}' http://127.0.0.1:1235/rpc/v1
{"id":2,"jsonrpc":"2.0","result":{"GPBFTInstance":42292,"ECChain":[{"Epoch":2175657,"Key":"AXGg5AIgSRY8LQrdggB5IOtuEPM7t3QVCZsQd6X6w6ZGM6e0AE4BcaDkAiA3gbWY6IFo8bRTc+9TKGlmCEU+bgNQzpoNVhhEr/ySswFxoOQCICxs2tKsVpIAiqdqZXLp4aIOQBFyBOW+XElIC0NFkVZ5","PowerTable":{"/":"bafy2bzaceabae7y7mjaib2z4obmvicmqbbpuhihnhdomzjwcghwal536y3oeg"},"Commitments":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},{"Epoch":2175658,"Key":"AXGg5AIgG52GGH6mEskkX8woDYC2ddur/wak+PurcR9q2E3d6a8=","PowerTable":{"/":"bafy2bzaceabae7y7mjaib2z4obmvicmqbbpuhihnhdomzjwcghwal536y3oeg"},"Commitments":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}],"SupplementalData":{"Commitments":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"PowerTable":{"/":"bafy2bzaceabae7y7mjaib2z4obmvicmqbbpuhihnhdomzjwcghwal536y3oeg"}},"Signers":[0,2,1,1,1,1],"Signature":"kEmVhxBHXh8kE77j58KtOgMzC0srFf1TPULigMCy3ipMcPHycHpWX0ANsYEVKmpiEyxmGRge79XQiFHb9rMiXU44i8Ts/VFZ2vQuHkXXExrDt0PnejnJ8Oh95niq+GYz","PowerTableDelta":null}}
```

After:

```
$ curl -s -X POST -H "Content-Type: application/json" --data '{"method":"Filecoin.F3GetLatestCertificate","params":[],"id":2,"jsonrpc":"2.0
"}' http://127.0.0.1:1235/rpc/v1
{"id":2,"jsonrpc":"2.0","result":{"GPBFTInstance":42376,"ECChain":[{"Key":[{"/":"bafy2bzaceco7323ltaq3efz3godq5gfzpdnt664hx32brfzpk2bxhnioywoyi"},{"/":"bafy2bzacedjaquoof5sj5zgqa5zwnd2u5rbrcxu4xgl62diti2u3n7opq4ozk"},{"/":"bafy2bzacebhdoylimje4ep4ymf5k6vy7taaexe65n4cvm4gcml6my65pby634"},{"/":"bafy2bzacecgv6xsvnnhvhbucarhocdbwtjzlnrdcqilz2tvwz2ad2tygfk44w"},{"/":"bafy2bzacebfiituy7hzuwc43czd35eal4q2wp75fm6uoyp2dkr2vcmq4j7yrs"}],"Epoch":2175744,"PowerTable":{"/":"bafy2bzaceabae7y7mjaib2z4obmvicmqbbpuhihnhdomzjwcghwal536y3oeg"},"Commitments":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},{"Key":[{"/":"bafy2bzacednxacmhjsthqhd4y42pvy3wyow5ai32xlhgg5kn6cm6wqc7dkfx4"},{"/":"bafy2bzaced65livizlohxbwgzk5r2zxtuofj2v2yzzpfmut7cibcj7quwxmbq"},{"/":"bafy2bzaceatetc6pat6535o5sqguvf3izbdoajilsslibfv67su3ywpg2odhw"}],"Epoch":2175745,"PowerTable":{"/":"bafy2bzaceabae7y7mjaib2z4obmvicmqbbpuhihnhdomzjwcghwal536y3oeg"},"Commitments":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}],"SupplementalData":{"Commitments":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"PowerTable":{"/":"bafy2bzaceabae7y7mjaib2z4obmvicmqbbpuhihnhdomzjwcghwal536y3oeg"}},"Signers":[0,2,1,1,1,1],"Signature":"gbyZNJBy4bkuDJDcYqDw0woZI0FK748w1f4nC6LmTyCadwAZRKzV2gTevWzHS7YcB6VytkOQQE5RKlPxTOm/B7bF0xIN5gR/uHXrHCWTOX6ganIgqYog8g5n0c1df4ya","PowerTableDelta":null}}
```

(different epoch but you get the idea)

But now I can at least feed that tsk back into lotus:

```
$ curl -s -X POST -H "Content-Type: application/json" --data '{"method":"Filecoin.ChainGetTipSet","params":[[{"/":"bafy2bzacednxacmhjsthqhd4y42pvy3wyow5ai32xlhgg5kn6cm6wqc7dkfx4"},{"/":"bafy2bzaced65livizlohxbwgzk5r2zxtuofj2v2yzzpfmut7cibcj7quwxmbq"},{"/":"bafy2bzaceatetc6pat6535o5sqguvf3izbdoajilsslibfv67su3ywpg2odhw"}]],"id":2,"jsonrpc":"2.0"}' http://127.0.0.1:1235/rpc/v1
```

An alternative would be to not expose `certs.FinalityCertificate` directly in Lotus but to wrap it in a new struct that uses the native Lotus `TipSetKey`: https://github.com/filecoin-project/lotus/blob/5791b4a9786bc259df2c1cc2775fd9aaf62d25fb/api/api_full.go#L984-L987