### PR TITLE
Publish containers tagged with version created by uci releaser

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -6,11 +6,29 @@ on:
       - 'main'
     tags:
       - 'v*'
+    workflow_run:
+      workflows: [ Releaser ]
+      types:
+        - completed
   pull_request:
 
 jobs:
+  prepare-checkout:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    name: Prepare ref
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ github.event_name != 'workflow_run' && github.ref || steps.releaser.outputs.version }}
+    steps:
+      - name: Get version tag from releaser
+        id: releaser
+        if: github.event_name == 'workflow_run'
+        uses: ipdxco/unified-github-workflows/.github/actions/inspect-releaser@v1.0
+        with:
+          artifacts-url: ${{ github.event.workflow_run.artifacts_url }}
   publish:
-    name: publish
+    name: Publish
+    needs: [ prepare-checkout ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-checkout.outputs.ref }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
@@ -34,7 +54,8 @@ jobs:
           tags: |
             type=semver,pattern={{raw}}
             type=ref,event=branch
-            type=raw,value=${{ github.ref }}
+            type=sha,format=long
+            type=raw,value=${{ needs.prepare-checkout.outputs.ref }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
This repository started using unified CI (uci) a while back to make tagged releases. This release mechanism is triggered by editing the `version.json` which in turn triggers a CI workflow to make a tagged release along with ghithub release etc.

The issue with this approach is that because the tag is created by CI it does not trigger other CI jobs that listen to `tags: ['v*']` events. Therefore, since the switch we have only been publishing containers tagged with `main`.

The changes here resolve this issue by triggering the GHCR publish workflow whenever releaser wrokflow succeeds. It then fishes out the ref produced by the releaser workflow to use as tagging. This will then give us containers tagged by whatever release we make using uci releaser workflow.

Additionally, it adds `type=sha,format=long` tagging to containers for easier debugging and deployment of an explicit commit to `main`.