### PR TITLE
Consistently use lower case for errors with no ending punctuation

### DIFF
--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -18,7 +18,7 @@ import (
 )
 
 var ErrCertNotFound = errors.New("certificate not found")
-var ErrNotInitialized = errors.New("CertStore is not initialized")
+var ErrNotInitialized = errors.New("certstore is not initialized")
 
 const defaultPowerTableFrequency = 60 * 24 // expected twice a day for Filecoin
 

--- a/f3.go
+++ b/f3.go
@@ -116,14 +116,14 @@ func (m *F3) GetLatestCert(ctx context.Context) (*certs.FinalityCertificate, err
 	if state := m.state.Load(); state != nil {
 		return state.cs.Latest(), nil
 	}
-	return nil, fmt.Errorf("F3 is not running")
+	return nil, fmt.Errorf("f3 is not running")
 }
 
 func (m *F3) GetCert(ctx context.Context, instance uint64) (*certs.FinalityCertificate, error) {
 	if state := m.state.Load(); state != nil {
 		return state.cs.Get(ctx, instance)
 	}
-	return nil, fmt.Errorf("F3 is not running")
+	return nil, fmt.Errorf("f3 is not running")
 }
 
 // Returns the time at which the F3 instance specified by the passed manifest should be started, or

--- a/f3_test.go
+++ b/f3_test.go
@@ -134,7 +134,7 @@ func TestF3FailRecover(t *testing.T) {
 			switch op {
 			case "put", "batch-put":
 				failDsWrite.Store(false)
-				return fmt.Errorf("Intentional error for testing, please ignore!")
+				return fmt.Errorf("intentional error for testing, please ignore")
 			}
 		}
 		return nil

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -1355,7 +1355,7 @@ func (c *convergeState) Receive(sender ActorID, table *PowerTable, value ECChain
 		return fmt.Errorf("bottom cannot be justified for CONVERGE")
 	}
 	if justification == nil {
-		return fmt.Errorf("CONVERGE message cannot carry nil-justification")
+		return fmt.Errorf("converge message cannot carry nil-justification")
 	}
 
 	if _, ok := c.senders[sender]; ok {

--- a/internal/powerstore/powerstore.go
+++ b/internal/powerstore/powerstore.go
@@ -64,7 +64,7 @@ func (ps *Store) Start(ctx context.Context) error {
 	ps.errgrp.Go(func() (_err error) {
 		defer func() {
 			if err := recover(); err != nil {
-				_err = fmt.Errorf("PANIC in power store: %+v", err)
+				_err = fmt.Errorf("panic in power store: %+v", err)
 				log.Errorw("PANIC in power store", "error", _err)
 			} else if _err != nil && ps.runningCtx.Err() == nil {
 				log.Errorw("power store exited early", "error", _err)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -104,27 +104,27 @@ type GpbftConfig struct {
 
 func (g *GpbftConfig) Validate() error {
 	if g.Delta <= 0 {
-		return fmt.Errorf("GPBFT delta must be positive, was %s", g.Delta)
+		return fmt.Errorf("gpbft delta must be positive, was %s", g.Delta)
 	}
 	if g.DeltaBackOffExponent < 1.0 {
-		return fmt.Errorf("GPBFT backoff exponent must be at least 1.0, was %f", g.DeltaBackOffExponent)
+		return fmt.Errorf("gpbft backoff exponent must be at least 1.0, was %f", g.DeltaBackOffExponent)
 	}
 
 	if g.ChainProposedLength < 1 {
-		return fmt.Errorf("GPBFT proposed chain length cannot be less than 1")
+		return fmt.Errorf("gpbft proposed chain length cannot be less than 1")
 	}
 	// not checking against gpbft.ChainMaxLen, it is handled gracefully
 
 	if g.RebroadcastBackoffBase <= 0 {
-		return fmt.Errorf("GPBFT rebroadcast backoff base must be greater than 0, was %s",
+		return fmt.Errorf("gpbft rebroadcast backoff base must be greater than 0, was %s",
 			g.RebroadcastBackoffBase)
 	}
 	if g.RebroadcastBackoffExponent < 1.0 {
-		return fmt.Errorf("GPBFT rebroadcast backoff exponent must be at least 1.0, was %f",
+		return fmt.Errorf("gpbft rebroadcast backoff exponent must be at least 1.0, was %f",
 			g.RebroadcastBackoffExponent)
 	}
 	if g.RebroadcastBackoffMax < g.RebroadcastBackoffBase {
-		return fmt.Errorf("GPBFT rebroadcast backoff max (%s) must be at least the backoff base (%s)",
+		return fmt.Errorf("gpbft rebroadcast backoff max (%s) must be at least the backoff base (%s)",
 			g.RebroadcastBackoffMax, g.RebroadcastBackoffBase)
 	}
 	return nil
@@ -171,20 +171,20 @@ func (e *EcConfig) Equal(o *EcConfig) bool {
 func (e *EcConfig) Validate() error {
 	switch {
 	case e.HeadLookback < 0:
-		return fmt.Errorf("EC head lookback must be non-negative, was %d", e.HeadLookback)
+		return fmt.Errorf("ec head lookback must be non-negative, was %d", e.HeadLookback)
 	case e.Period <= 0:
-		return fmt.Errorf("EC period must be positive, was %s", e.Period)
+		return fmt.Errorf("ec period must be positive, was %s", e.Period)
 	case e.Finality < 0:
-		return fmt.Errorf("EC finality must be non-negative, was %d", e.Finality)
+		return fmt.Errorf("ec finality must be non-negative, was %d", e.Finality)
 	case e.DelayMultiplier <= 0.0:
-		return fmt.Errorf("EC delay multiplier must positive, was %f", e.DelayMultiplier)
+		return fmt.Errorf("ec delay multiplier must positive, was %f", e.DelayMultiplier)
 	case len(e.BaseDecisionBackoffTable) == 0:
-		return fmt.Errorf("EC backoff table must have at least one element")
+		return fmt.Errorf("ec backoff table must have at least one element")
 	}
 
 	for i, b := range e.BaseDecisionBackoffTable {
 		if b < 0.0 {
-			return fmt.Errorf("EC backoff table element %d is negative (%f)", i, b)
+			return fmt.Errorf("ec backoff table element %d is negative (%f)", i, b)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #795