### PR TITLE
Introduce sentinel errors for F3 not running and unknown manifest

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -13,6 +14,9 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 )
+
+// ErrNoManifest is returned when no manifest is known.
+var ErrNoManifest = errors.New("no known manifest")
 
 const VersionCapability = 4
 


### PR DESCRIPTION
For better upstream logic flow introduce sentinel errors to signal:
* when F3 is not running,
* when manifest is not known.

Fixes #797