### PR TITLE
Add the ability to publish container for specific commit sha

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -11,6 +11,11 @@ on:
       types:
         - completed
   pull_request:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA to publish'
+        required: true
 
 jobs:
   prepare-checkout:
@@ -18,7 +23,7 @@ jobs:
     name: Prepare ref
     runs-on: ubuntu-latest
     outputs:
-      ref: ${{ github.event_name != 'workflow_run' && github.ref || steps.releaser.outputs.version }}
+      ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sha || github.event_name != 'workflow_run' && github.ref || steps.releaser.outputs.version }}
     steps:
       - name: Get version tag from releaser
         id: releaser


### PR DESCRIPTION
For debugging purposes we need to be able to deploy a specific commit as observer or manifest server without having to cut a release or even merge to `main`.