### PR TITLE
Add the ability to listen for discovered chains

### DIFF
--- a/chainexchange/chainexchange.go
+++ b/chainexchange/chainexchange.go
@@ -24,4 +24,8 @@ type ChainExchange interface {
 	RemoveChainsByInstance(context.Context, uint64) error
 }
 
+type Listener interface {
+	NotifyChainDiscovered(ctx context.Context, key Key, instance uint64, chain gpbft.ECChain)
+}
+
 func (k Key) IsZero() bool { return len(k) == 0 }

--- a/chainexchange/options.go
+++ b/chainexchange/options.go
@@ -21,6 +21,7 @@ type options struct {
 	maxInstanceLookahead           uint64
 	maxDiscoveredChainsPerInstance int
 	maxWantedChainsPerInstance     int
+	listener                       Listener
 }
 
 func newOptions(o ...Option) (*options, error) {
@@ -129,6 +130,16 @@ func WithMaxWantedChainsPerInstance(max int) Option {
 			return errors.New("max wanted chains per instance must be at least 1")
 		}
 		o.maxWantedChainsPerInstance = max
+		return nil
+	}
+}
+
+func WithListener(listener Listener) Option {
+	return func(o *options) error {
+		if listener == nil {
+			return errors.New("listener cannot be nil")
+		}
+		o.listener = listener
 		return nil
 	}
 }


### PR DESCRIPTION
Expand chain exchange to accept a listener which is notified whenever a new chain is discovered. This mechanism is intended to be integrated into F3 host pubsub, whereupon receiving a partial message the host looks up its chain. When known, the chain is returned immediately. Otherwise, the host would buffer the partial message and await notification of its discovering from chain exchange.

Part of #792
