### PR TITLE
Reduce exit sleep in tests run with race detector to zero

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -3,7 +3,7 @@ name: Go Test
 on:
   pull_request:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   workflow_dispatch:
   merge_group:
 
@@ -13,6 +13,11 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
+
+env:
+  # Speed-up tests run with race detector by reducing default exit sleep of 1 s to 0.
+  # See: https://go.dev/doc/articles/race_detector#Options
+  GORACE: atexit_sleep_ms=0
 
 jobs:
   go-test:


### PR DESCRIPTION
Reduce exit sleep in tests run with race detector to zero to make the tests run faster.