### PR TITLE
Fix potential panic when subscribing to topic fails

### DIFF
--- a/host.go
+++ b/host.go
@@ -640,7 +640,7 @@ func (h *gpbftRunner) startPubsub() (<-chan gpbft.ValidatedMessage, error) {
 	)
 	sub, err := h.topic.Subscribe(pubsub.WithBufferSize(subBufferSize))
 	if err != nil {
-		return nil, fmt.Errorf("could not subscribe to pubsub topic: %s: %w", sub.Topic(), err)
+		return nil, fmt.Errorf("could not subscribe to pubsub topic: %s: %w", h.topic, err)
 	}
 
 	messageQueue := make(chan gpbft.ValidatedMessage, msgQueueBufferSize)


### PR DESCRIPTION
Avoid referencing subscription when constructing an error message as it may be nil when subscription fails.
