### PR TITLE
Reduce the `ECChain` API surface by removing unused capability

### DIFF
--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -288,53 +288,11 @@ func (c ECChain) Eq(other ECChain) bool {
 	return true
 }
 
-// Checks whether two chains have the same base.
-//
-// Always false for a zero value.
-func (c ECChain) SameBase(other ECChain) bool {
-	if c.IsZero() || other.IsZero() {
-		return false
-	}
-	return c.Base().Equal(other.Base())
-}
-
 // Check whether a chain has a specific base tipset.
 //
 // Always false for a zero value.
 func (c ECChain) HasBase(t *TipSet) bool {
 	return t != nil && !c.IsZero() && c.Base().Equal(t)
-}
-
-// Checks whether a chain has some prefix (including the base).
-//
-// Always false for a zero value.
-func (c ECChain) HasPrefix(other ECChain) bool {
-	if c.IsZero() || other.IsZero() {
-		return false
-	}
-	if len(other) > len(c) {
-		return false
-	}
-	for i := range other {
-		if !c[i].Equal(&other[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-// Checks whether a chain has some tipset (including as its base).
-func (c ECChain) HasTipset(t *TipSet) bool {
-	if t == nil {
-		// Chain can never contain zero-valued TipSet.
-		return false
-	}
-	for i := range c {
-		if c[i].Equal(t) {
-			return true
-		}
-	}
-	return false
 }
 
 // Validates a chain value, returning an error if it finds any issues.

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -21,9 +21,6 @@ func TestECChain(t *testing.T) {
 		var subject gpbft.ECChain
 		require.True(t, subject.IsZero())
 		require.False(t, subject.HasBase(&zeroTipSet))
-		require.False(t, subject.HasPrefix(subject))
-		require.False(t, subject.HasTipset(&zeroTipSet))
-		require.False(t, subject.SameBase(subject))
 		require.True(t, subject.Eq(subject))
 		require.True(t, subject.Eq(*new(gpbft.ECChain)))
 		require.Nil(t, subject.Suffix())
@@ -56,27 +53,6 @@ func TestECChain(t *testing.T) {
 		require.Equal(t, &wantNext, subjectExtended.Head())
 		require.True(t, subjectExtended.HasSuffix())
 		require.Equal(t, &wantNext, subjectExtended.Prefix(1).Head())
-		require.True(t, subjectExtended.HasTipset(&wantBase))
-		require.False(t, subject.HasPrefix(subjectExtended))
-		require.True(t, subjectExtended.HasPrefix(subject))
-
-		require.False(t, subject.Extend(wantBase.Key).HasPrefix(subjectExtended.Extend(wantNext.Key)))
-	})
-	t.Run("SameBase is false when either chain is zero", func(t *testing.T) {
-		var zeroChain gpbft.ECChain
-		nonZeroChain, err := gpbft.NewChain(oneTipSet)
-		require.NoError(t, err)
-		require.False(t, nonZeroChain.SameBase(zeroChain))
-		require.False(t, zeroChain.SameBase(nonZeroChain))
-		require.False(t, zeroChain.SameBase(zeroChain))
-	})
-	t.Run("HasPrefix is false when either chain is zero", func(t *testing.T) {
-		var zeroChain gpbft.ECChain
-		nonZeroChain, err := gpbft.NewChain(oneTipSet)
-		require.NoError(t, err)
-		require.False(t, nonZeroChain.HasPrefix(zeroChain))
-		require.False(t, zeroChain.HasPrefix(nonZeroChain))
-		require.False(t, zeroChain.HasPrefix(zeroChain))
 	})
 	t.Run("zero-valued chain is valid", func(t *testing.T) {
 		var zeroChain gpbft.ECChain


### PR DESCRIPTION
The `ECChain` API offers a few functions that seem to only have been used in unit testing the functions themselves.

Remove them to reduce LOC, in favor of adding back later if ever anyone asked for it.