### PR TITLE
Strictly enforce the Commitments max size in CBOR

### DIFF
--- a/gpbft/cbor_gen.go
+++ b/gpbft/cbor_gen.go
@@ -63,7 +63,7 @@ func (t *TipSet) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Commitments ([32]uint8) (array)
-	if len(t.Commitments) > 2097152 {
+	if len(t.Commitments) > 32 {
 		return xerrors.Errorf("Byte array in field t.Commitments was too long")
 	}
 
@@ -166,7 +166,7 @@ func (t *TipSet) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 32 {
 		return fmt.Errorf("t.Commitments: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {
@@ -368,7 +368,7 @@ func (t *SupplementalData) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Commitments ([32]uint8) (array)
-	if len(t.Commitments) > 2097152 {
+	if len(t.Commitments) > 32 {
 		return xerrors.Errorf("Byte array in field t.Commitments was too long")
 	}
 
@@ -419,7 +419,7 @@ func (t *SupplementalData) UnmarshalCBOR(r io.Reader) (err error) {
 		return err
 	}
 
-	if extra > 2097152 {
+	if extra > 32 {
 		return fmt.Errorf("t.Commitments: byte array too large (%d)", extra)
 	}
 	if maj != cbg.MajByteString {

--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -56,7 +56,7 @@ type TipSet struct {
 	// Blake2b256-32 CID of the CBOR-encoded power table.
 	PowerTable cid.Cid
 	// Keccak256 root hash of the commitments merkle tree.
-	Commitments [32]byte
+	Commitments [32]byte `cborgen:"maxlen=32"`
 }
 
 // Validates a tipset.

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -85,7 +85,7 @@ type Justification struct {
 type SupplementalData struct {
 	// Merkle-tree of instance-specific commitments. Currently empty but this will eventually
 	// include things like snark-friendly power-table commitments.
-	Commitments [32]byte
+	Commitments [32]byte `cborgen:"maxlen=32"`
 	// The DagCBOR-blake2b256 CID of the power table used to validate the next instance, taking
 	// lookback into account.
 	PowerTable cid.Cid // []PowerEntry


### PR DESCRIPTION
The cbor-gen does not seem to implicitly enforce the length specified in the underlying Golang array type. Instead, it uses the maximum number of allowed bytes if no `maxlen` struct tag is specified (2MiB).

Strictly enforce the max allowed size to avoid potential attack vector.

Relates to:
 * https://github.com/whyrusleeping/cbor-gen/pull/106