### PR TITLE
Add a periodic chain re-broadcast mechanism

### DIFF
--- a/chainexchange/cbor_gen.go
+++ b/chainexchange/cbor_gen.go
@@ -19,7 +19,7 @@ var _ = cid.Undef
 var _ = math.E
 var _ = sort.Sort
 
-var lengthBufMessage = []byte{130}
+var lengthBufMessage = []byte{131}
 
 func (t *Message) MarshalCBOR(w io.Writer) error {
 	if t == nil {
@@ -53,6 +53,18 @@ func (t *Message) MarshalCBOR(w io.Writer) error {
 		}
 
 	}
+
+	// t.Timestamp (int64) (int64)
+	if t.Timestamp >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Timestamp)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Timestamp-1)); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -75,7 +87,7 @@ func (t *Message) UnmarshalCBOR(r io.Reader) (err error) {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 2 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -130,6 +142,31 @@ func (t *Message) UnmarshalCBOR(r io.Reader) (err error) {
 			}
 
 		}
+	}
+	// t.Timestamp (int64) (int64)
+	{
+		maj, extra, err := cr.ReadHeader()
+		if err != nil {
+			return err
+		}
+		var extraI int64
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative overflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.Timestamp = int64(extraI)
 	}
 	return nil
 }

--- a/chainexchange/chainexchange.go
+++ b/chainexchange/chainexchange.go
@@ -13,8 +13,9 @@ type Keyer interface {
 }
 
 type Message struct {
-	Instance uint64
-	Chain    gpbft.ECChain
+	Instance  uint64
+	Chain     gpbft.ECChain
+	Timestamp int64
 }
 
 type ChainExchange interface {

--- a/chainexchange/options.go
+++ b/chainexchange/options.go
@@ -2,6 +2,7 @@ package chainexchange
 
 import (
 	"errors"
+	"time"
 
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/filecoin-project/go-f3/internal/psutil"
@@ -22,6 +23,7 @@ type options struct {
 	maxDiscoveredChainsPerInstance int
 	maxWantedChainsPerInstance     int
 	listener                       Listener
+	maxTimestampAge                time.Duration
 }
 
 func newOptions(o ...Option) (*options, error) {
@@ -140,6 +142,16 @@ func WithListener(listener Listener) Option {
 			return errors.New("listener cannot be nil")
 		}
 		o.listener = listener
+		return nil
+	}
+}
+
+func WithMaxTimestampAge(max time.Duration) Option {
+	return func(o *options) error {
+		if max < 0 {
+			return errors.New("max timestamp age cannot be negative")
+		}
+		o.maxTimestampAge = max
 		return nil
 	}
 }

--- a/chainexchange/pubsub_test.go
+++ b/chainexchange/pubsub_test.go
@@ -57,8 +57,9 @@ func TestPubSubChainExchange_Broadcast(t *testing.T) {
 	require.Empty(t, testListener.getNotifications())
 
 	require.NoError(t, subject.Broadcast(ctx, chainexchange.Message{
-		Instance: instance,
-		Chain:    ecChain,
+		Instance:  instance,
+		Chain:     ecChain,
+		Timestamp: time.Now().Unix(),
 	}))
 
 	require.Eventually(t, func() bool {

--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -322,6 +322,23 @@ func (c ECChain) Validate() error {
 	return nil
 }
 
+// HasPrefix checks whether a chain has the given chain as a prefix, including
+// base. This function always returns if either chain is zero.
+func (c ECChain) HasPrefix(other ECChain) bool {
+	if c.IsZero() || other.IsZero() {
+		return false
+	}
+	if len(other) > len(c) {
+		return false
+	}
+	for i := range other {
+		if !c[i].Equal(&other[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // Returns an identifier for the chain suitable for use as a map key.
 // This must completely determine the sequence of tipsets in the chain.
 func (c ECChain) Key() ChainKey {

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -53,6 +53,8 @@ func TestECChain(t *testing.T) {
 		require.Equal(t, &wantNext, subjectExtended.Head())
 		require.True(t, subjectExtended.HasSuffix())
 		require.Equal(t, &wantNext, subjectExtended.Prefix(1).Head())
+		require.True(t, subjectExtended.HasPrefix(subject))
+		require.False(t, subject.Extend(wantBase.Key).HasPrefix(subjectExtended.Extend(wantNext.Key)))
 	})
 	t.Run("zero-valued chain is valid", func(t *testing.T) {
 		var zeroChain gpbft.ECChain

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -63,6 +63,8 @@ var (
 		MaxInstanceLookahead:           DefaultCommitteeLookback,
 		MaxDiscoveredChainsPerInstance: 1_000,
 		MaxWantedChainsPerInstance:     1_000,
+		RebroadcastInterval:            2 * time.Second,
+		MaxTimestampAge:                8 * time.Second,
 	}
 
 	// Default instance alignment when catching up.
@@ -225,6 +227,8 @@ type ChainExchangeConfig struct {
 	MaxInstanceLookahead           uint64
 	MaxDiscoveredChainsPerInstance int
 	MaxWantedChainsPerInstance     int
+	RebroadcastInterval            time.Duration
+	MaxTimestampAge                time.Duration
 }
 
 func (cx *ChainExchangeConfig) Validate() error {
@@ -239,6 +243,8 @@ func (cx *ChainExchangeConfig) Validate() error {
 		return fmt.Errorf("chain exchange max discovered chains per instance must be at least 1, got: %d", cx.MaxDiscoveredChainsPerInstance)
 	case cx.MaxWantedChainsPerInstance < 1:
 		return fmt.Errorf("chain exchange max wanted chains per instance must be at least 1, got: %d", cx.MaxWantedChainsPerInstance)
+	case cx.RebroadcastInterval < 1*time.Millisecond: // 1 ms is a made-up minimum to avoid accidental hot-loop of chain rebroadcast.
+		return fmt.Errorf("chain exchange rebroadcast interval cannot be less than 1ms, got: %s", cx.RebroadcastInterval)
 	default:
 		return nil
 	}


### PR DESCRIPTION
Based on a configured rebroadcast interval periodically rebroadcast the longest chain currently being progressed by GPBFT.

Extend the chain exchange broadcast message to include a timestamp rounded down to the rebroadcast interval as a way to work around gossipsub deduplication. This is to help gain better message propagation.

The rebroadcast interval is reset as soon as the first message with a larger instance is observed, signaling the start of the next instance. This helps synchronize the chain rebroadcast intervals relative to the GPBFT instance start.

Fixes #814