### PR TITLE
Disable docker build summary generation and artifact upload

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -63,6 +63,9 @@ jobs:
             type=raw,value=${{ needs.prepare-checkout.outputs.ref }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: 'false'
+          DOCKER_BUILD_RECORD_UPLOAD: 'false'
         with:
           context: .
           cache-from: type=gha


### PR DESCRIPTION
The build summary generator is taking a very long time currently. This is most likely due to upstream issues with pulling necessary docker images.

The capability itself is mostly cosmetic, i.e., we don't care about the summary nor artifacts uploaded to GitHub Actions as long as the container itself is pushed. Hence, the decision to disable them for faster build that does just enough.

Example of post-build summary generation taking too long:
 * https://github.com/filecoin-project/go-f3/actions/runs/12926848944/job/36050762119