### PR TITLE
Clear out old instances from partial message management

### DIFF
--- a/chainexchange/pubsub.go
+++ b/chainexchange/pubsub.go
@@ -321,8 +321,16 @@ func (p *PubSubChainExchange) cacheAsWantedChain(ctx context.Context, cmsg Messa
 func (p *PubSubChainExchange) RemoveChainsByInstance(_ context.Context, instance uint64) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	delete(p.chainsWanted, instance)
-	delete(p.chainsDiscovered, instance)
+	for i := range p.chainsWanted {
+		if i < instance {
+			delete(p.chainsWanted, i)
+		}
+	}
+	for i := range p.chainsDiscovered {
+		if i < instance {
+			delete(p.chainsDiscovered, i)
+		}
+	}
 	return nil
 }
 

--- a/f3_test.go
+++ b/f3_test.go
@@ -541,7 +541,6 @@ func (e *testEnv) waitForEpochFinalized(epoch int64) {
 				//       here and reduce the clock advance to give messages a chance of being
 				//       delivered in time. See:
 				//         - https://github.com/filecoin-project/go-f3/issues/818
-				time.Sleep(20 * time.Millisecond)
 				for _, nd := range e.nodes {
 					if nd.f3 == nil || !nd.f3.IsRunning() {
 						continue

--- a/host.go
+++ b/host.go
@@ -788,7 +788,9 @@ func (h *gpbftHost) ReceiveDecision(decision *gpbft.Justification) (time.Time, e
 	log.Infow("reached a decision", "instance", decision.Vote.Instance,
 		"ecHeadEpoch", decision.Vote.Value.Head().Epoch)
 	if decision.Vote.Instance > 0 {
-		h.pmCache.RemoveGroupsLessThan(decision.Vote.Instance - 1)
+		oldInstance := decision.Vote.Instance - 1
+		h.pmCache.RemoveGroupsLessThan(oldInstance)
+		h.pmm.RemoveMessagesBeforeInstance(context.Background(), oldInstance)
 	}
 	cert, err := h.saveDecision(decision)
 	if err != nil {


### PR DESCRIPTION
Once a decision about an instance is received, remove all states related to the older instances from partial message manager and chain exchange.

Part of #792