### PR TITLE
Add chain exchange and partial message metrics

### DIFF
--- a/chainexchange/metrics.go
+++ b/chainexchange/metrics.go
@@ -1,0 +1,44 @@
+package chainexchange
+
+import (
+	"github.com/filecoin-project/go-f3/internal/measurements"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	meter = otel.Meter("f3/chainexchange")
+
+	attrKindWanted     = attribute.String("kind", "wanted")
+	attrKindDiscovered = attribute.String("kind", "discovered")
+
+	metrics = struct {
+		chains            metric.Int64Counter
+		broadcasts        metric.Int64Counter
+		broadcastChainLen metric.Int64Gauge
+		notifications     metric.Int64Counter
+		instances         metric.Int64UpDownCounter
+		validatedMessages metric.Int64Counter
+		validationTime    metric.Float64Histogram
+	}{
+		chains:            measurements.Must(meter.Int64Counter("f3_chainexchange_chains", metric.WithDescription("Number of chains engaged in chainexhange by status."))),
+		broadcasts:        measurements.Must(meter.Int64Counter("f3_chainexchange_broadcasts", metric.WithDescription("Number of chains broadcasts made by chainexchange."))),
+		broadcastChainLen: measurements.Must(meter.Int64Gauge("f3_chainexchange_broadcast_chain_length", metric.WithDescription("The latest length of broadcasted chain."))),
+		notifications:     measurements.Must(meter.Int64Counter("f3_chainexchange_notifications", metric.WithDescription("Number of chain discovery notified by chainexchange."))),
+		instances:         measurements.Must(meter.Int64UpDownCounter("f3_chainexchange_instances", metric.WithDescription("Number of instances engaged in chainexchage."))),
+		validatedMessages: measurements.Must(meter.Int64Counter("f3_chainexchange_validated_messages", metric.WithDescription("Number of pubsub messages validated tagged by result."))),
+		validationTime: measurements.Must(meter.Float64Histogram("f3_chainexchange_validation_time",
+			metric.WithDescription("Histogram of time spent validating chainexchange messages in seconds."),
+			metric.WithExplicitBucketBoundaries(0.001, 0.002, 0.003, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 10.0),
+			metric.WithUnit("s"),
+		)),
+	}
+)
+
+func attrFromWantedDiscovered(wanted, discovered bool) attribute.Set {
+	return attribute.NewSet(
+		attribute.Bool("wanted", wanted),
+		attribute.Bool("discovered", discovered),
+	)
+}

--- a/host.go
+++ b/host.go
@@ -538,8 +538,9 @@ func (h *gpbftRunner) rebroadcastMessage(msg *gpbft.GMessage) error {
 var _ pubsub.ValidatorEx = (*gpbftRunner)(nil).validatePubsubMessage
 
 func (h *gpbftRunner) validatePubsubMessage(ctx context.Context, _ peer.ID, msg *pubsub.Message) (_result pubsub.ValidationResult) {
+	var partiallyValidated bool
 	defer func(start time.Time) {
-		recordValidationTime(ctx, start, _result)
+		recordValidationTime(ctx, start, _result, partiallyValidated)
 	}(time.Now())
 
 	var pgmsg PartialGMessage
@@ -555,6 +556,7 @@ func (h *gpbftRunner) validatePubsubMessage(ctx context.Context, _ peer.ID, msg 
 		if result == pubsub.ValidationAccept {
 			msg.ValidatorData = partiallyValidatedMessage
 		}
+		partiallyValidated = true
 		return result
 	}
 

--- a/internal/measurements/attributes.go
+++ b/internal/measurements/attributes.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/ipfs/go-datastore"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -36,4 +37,19 @@ func Status(ctx context.Context, err error) attribute.KeyValue {
 	default:
 		return AttrStatusError
 	}
+}
+
+func AttrFromPubSubValidationResult(result pubsub.ValidationResult) attribute.KeyValue {
+	var v string
+	switch result {
+	case pubsub.ValidationAccept:
+		v = "accepted"
+	case pubsub.ValidationReject:
+		v = "rejected"
+	case pubsub.ValidationIgnore:
+		v = "ignored"
+	default:
+		v = "unknown"
+	}
+	return attribute.String("result", v)
 }


### PR DESCRIPTION
Add metrics that measure various aspects of chain exchange and partial messages, including:
 * The number of messages pending partial messages.
 * The total number instances with a partial message.
 * The chain exchange broadcast count.
 * The length of broadcast chain.
 * The time spent on chain exchange validation.
 * Qualify existing GPBFT validation metrics with partial message attribute.
 * The number of duplicate partial messages qualified with equivocation attribute.

Fixes: #812