### PR TITLE
Use go 1.23 in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bullseye AS build
+FROM golang:1.23-bullseye AS build
 
 WORKDIR /go/src/f3
 


### PR DESCRIPTION
There is no reason not to use a more recent version of go to build the binary in docker images.

This should also reduce the chances of random segmentation fault when building for arm64 platform.

Fixes #846