### PR TITLE
Bump the manifest version compatibility to 5

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -18,7 +18,7 @@ import (
 // ErrNoManifest is returned when no manifest is known.
 var ErrNoManifest = errors.New("no known manifest")
 
-const VersionCapability = 4
+const VersionCapability = 5
 
 var (
 	DefaultCommitteeLookback uint64 = 10


### PR DESCRIPTION
Bump the manifest version compatibility to 5 to avoid any accidental participation of old lotus versions considering the changes introduced since v4.

Relates to #858