### PR TITLE
Determine the manifest CID and log it for better debugging

### DIFF
--- a/cmd/f3/manifest.go
+++ b/cmd/f3/manifest.go
@@ -247,9 +247,13 @@ var manifestServeCmd = cli.Command{
 					if nextManifest, err := loadManifest(manifestPath); err != nil {
 						_, _ = fmt.Fprintf(c.App.ErrWriter, "Failed reload manifest: %v\n", err)
 					} else if !nextManifest.Equal(currentManifest) {
-						_, _ = fmt.Fprintf(c.App.Writer, "Loaded changed manifest with network name: %q\n", nextManifest.NetworkName)
-						sender.UpdateManifest(nextManifest)
-						currentManifest = nextManifest
+						if mcid, err := nextManifest.Cid(); err != nil {
+							_, _ = fmt.Fprintf(c.App.ErrWriter, "Failed determine manifest CID: %v\n", err)
+						} else {
+							_, _ = fmt.Fprintf(c.App.Writer, "Loaded changed manifest with network name: %q, and CID %s\n", nextManifest.NetworkName, mcid)
+							sender.UpdateManifest(nextManifest)
+							currentManifest = nextManifest
+						}
 					}
 
 					// Periodically reconnect to bootstrappers; this would reload any changes to

--- a/manifest/dynamic_provider.go
+++ b/manifest/dynamic_provider.go
@@ -224,6 +224,12 @@ func (m *DynamicManifestProvider) Start(startCtx context.Context) error {
 				continue
 			}
 
+			mcid, err := update.Manifest.Cid()
+			if err != nil {
+				log.Errorw("Failed to determine manifest CID", "error", err)
+				continue
+			}
+
 			if err := m.filter(&update.Manifest); err != nil {
 				log.Errorw("received filtered manifest, discarded", "error", err)
 				continue
@@ -236,7 +242,7 @@ func (m *DynamicManifestProvider) Start(startCtx context.Context) error {
 				}
 			}
 
-			log.Infow("received manifest update", "seqNo", update.MessageSequence)
+			log.Infow("received manifest update", "seqNo", update.MessageSequence, "cid", mcid)
 
 			oldManifest := currentManifest
 			manifestCopy := update.Manifest

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
+	"github.com/multiformats/go-multihash"
 )
 
 // ErrNoManifest is returned when no manifest is known.
@@ -408,6 +409,21 @@ func (m *Manifest) DatastorePrefix() datastore.Key {
 
 func (m *Manifest) PubSubTopic() string {
 	return PubSubTopicFromNetworkName(m.NetworkName)
+}
+
+var cidPrefix = cid.Prefix{
+	Version:  1,
+	Codec:    cid.DagJSON,
+	MhType:   multihash.BLAKE2B_MIN + 31,
+	MhLength: 32,
+}
+
+func (m *Manifest) Cid() (cid.Cid, error) {
+	marshalled, err := m.Marshal()
+	if err != nil {
+		return cid.Cid{}, err
+	}
+	return cidPrefix.Sum(marshalled)
 }
 
 func PubSubTopicFromNetworkName(nn gpbft.NetworkName) string {

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -118,3 +118,27 @@ func TestManifest_NetworkName(t *testing.T) {
 		})
 	}
 }
+
+func TestManifest_CID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantLocalDevnetCid = "baguqfiheaiqptjzqkzqyu2hskn7ac5fexvjwuxmjec7hjrjug27jkucvmrrtmji"
+		wantAfterUpdateCid = "baguqfiheaiqjxj6otbtvdoitpqtfmjbslqc2o5cnjuipjxxduxiaezomoa44cey"
+	)
+	subject := manifest.LocalDevnetManifest()
+	// Use a fixed network name for deterministic CID calculation.
+	subject.NetworkName = "fish"
+
+	got, err := subject.Cid()
+	require.NoError(t, err)
+	require.Equal(t, wantLocalDevnetCid, got.String())
+
+	changedSubject := *subject
+	changedSubject.CommitteeLookback = changedSubject.CommitteeLookback + 1
+	gotAfterUpdate, err := changedSubject.Cid()
+	require.NoError(t, err)
+	require.NotEqual(t, subject, changedSubject)
+	require.NotEqual(t, wantLocalDevnetCid, gotAfterUpdate.String())
+	require.Equal(t, wantAfterUpdateCid, gotAfterUpdate.String())
+}


### PR DESCRIPTION
Introduce Manifest CID calculation and log it both at manifest publisher and manifest receiver for better debugging.