### PR TITLE
Fix GPBFT Trace log logging by pointer

### DIFF
--- a/chainexchange/pubsub_test.go
+++ b/chainexchange/pubsub_test.go
@@ -36,6 +36,7 @@ func TestPubSubChainExchange_Broadcast(t *testing.T) {
 		chainexchange.WithPubSub(ps),
 		chainexchange.WithTopicName(topicName),
 		chainexchange.WithTopicScoreParams(nil),
+		chainexchange.WithMaxTimestampAge(time.Minute),
 		chainexchange.WithListener(&testListener),
 	)
 	require.NoError(t, err)
@@ -61,7 +62,7 @@ func TestPubSubChainExchange_Broadcast(t *testing.T) {
 	require.NoError(t, subject.Broadcast(ctx, chainexchange.Message{
 		Instance:  instance,
 		Chain:     ecChain,
-		Timestamp: time.Now().Unix(),
+		Timestamp: time.Now().Add(-2 * time.Second).Unix(),
 	}))
 
 	require.Eventually(t, func() bool {

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -1039,7 +1039,7 @@ func (i *instance) log(format string, args ...any) {
 	if i.tracer != nil {
 		msg := fmt.Sprintf(format, args...)
 		i.tracer.Log("{%d}: %s (round %d, phase %s, proposal %s, value %s)", i.current.ID, msg,
-			i.current.Round, i.current.Phase, &i.proposal, &i.value)
+			i.current.Round, i.current.Phase, i.proposal, i.value)
 	}
 }
 


### PR DESCRIPTION
Since ECChain is changed to pointer at struct level log the proposal and vale directly. Otherwise, we get memory address to pointer in logs.