### PR TITLE
Reduce log level of skipping finalization message to DEBUG

### DIFF
--- a/host.go
+++ b/host.go
@@ -296,7 +296,7 @@ func (h *gpbftRunner) Start(ctx context.Context) (_err error) {
 					}
 				} else {
 					ts := cert.ECChain.Head()
-					log.Infow("skipping finalization of a new head because the current manifest specifies that tipsets should not be finalized",
+					log.Debugw("skipping finalization of a new head because the current manifest specifies that tipsets should not be finalized",
 						"tsk", ts.Key,
 						"epoch", ts.Epoch,
 					)


### PR DESCRIPTION
It is printed per finalised instance, which is too verbose during passive testing.