### PR TITLE
Measure time spent on encoding and the compaction ratio

### DIFF
--- a/internal/encoding/encoding_api_test.go
+++ b/internal/encoding/encoding_api_test.go
@@ -1,0 +1,7 @@
+package encoding
+
+import "go.opentelemetry.io/otel/attribute"
+
+// GetMetricAttribute returns the attribute for metric collection, exported for
+// testing purposes.
+func (c *ZSTD[T]) GetMetricAttribute() attribute.KeyValue { return c.getMetricAttribute() }

--- a/internal/encoding/metrics.go
+++ b/internal/encoding/metrics.go
@@ -1,0 +1,38 @@
+package encoding
+
+import (
+	"github.com/filecoin-project/go-f3/internal/measurements"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+var (
+	attrCodecCbor     = attribute.String("codec", "cbor")
+	attrCodecZstd     = attribute.String("codec", "zstd")
+	attrActionEncode  = attribute.String("action", "encode")
+	attrActionDecode  = attribute.String("action", "decode")
+	attrSetCborEncode = attribute.NewSet(attrCodecCbor, attrActionEncode)
+	attrSetCborDecode = attribute.NewSet(attrCodecCbor, attrActionDecode)
+	attrSetZstdEncode = attribute.NewSet(attrCodecZstd, attrActionEncode)
+	attrSetZstdDecode = attribute.NewSet(attrCodecZstd, attrActionDecode)
+
+	meter = otel.Meter("f3/internal/encoding")
+
+	metrics = struct {
+		encodingTime         metric.Float64Histogram
+		zstdCompressionRatio metric.Float64Histogram
+	}{
+		encodingTime: measurements.Must(meter.Float64Histogram(
+			"f3_internal_encoding_time",
+			metric.WithDescription("The time spent on encoding/decoding in seconds."),
+			metric.WithUnit("s"),
+			metric.WithExplicitBucketBoundaries(0.001, 0.003, 0.005, 0.01, 0.03, 0.05, 0.1, 0.3, 0.5, 1.0, 2.0, 5.0, 10.0),
+		)),
+		zstdCompressionRatio: measurements.Must(meter.Float64Histogram(
+			"f3_internal_encoding_zstd_compression_ratio",
+			metric.WithDescription("The ratio of compressed to uncompressed data size for zstd encoding."),
+			metric.WithExplicitBucketBoundaries(0.0, 0.1, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0),
+		)),
+	}
+)


### PR DESCRIPTION
Add metrics to measure time spent on encoding CBOR+ZSTD, and the compaction ratio achieved by ZSTD.

Fixes #863