### PR TITLE
Pick an optimal zstd encoding buffer based on uncompressed data size

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -110,7 +110,8 @@ func (c *ZSTD[T]) Encode(t T) (_ []byte, _err error) {
 	if err != nil {
 		return nil, err
 	}
-	compressed := c.compressor.EncodeAll(decompressed, make([]byte, 0, len(decompressed)))
+	maxCompressedSize := c.compressor.MaxEncodedSize(len(decompressed))
+	compressed := c.compressor.EncodeAll(decompressed, make([]byte, 0, maxCompressedSize))
 	c.meterCompressionRatio(len(decompressed), len(compressed))
 	return compressed, nil
 }


### PR DESCRIPTION
Calculate the max encoded size based on the uncompressed data size and use it as the capacity of the buffer to which data is encoded.

Benchmark comparison (10 repetitions):

```
$ benchstat before.txt after.txt
                 │ before.txt  │              after.txt              │
                 │   sec/op    │   sec/op     vs base                │
 ZstdEncoding-12   3.949µ ± 6%   3.375µ ± 2%  -14.55% (p=0.000 n=10)
 ZstdDecoding-12   10.60µ ± 1%   10.56µ ± 2%        ~ (p=0.143 n=10)
 geomean           6.470µ        5.970µ        -7.72%

                 │  before.txt  │              after.txt               │
                 │     B/op     │     B/op      vs base                │
 ZstdEncoding-12   45.84Ki ± 0%   27.83Ki ± 0%  -39.29% (p=0.000 n=10)
 ZstdDecoding-12   17.96Ki ± 1%   18.01Ki ± 1%        ~ (p=0.315 n=10)
 geomean           28.69Ki        22.39Ki       -21.97%

                 │ before.txt │              after.txt              │
                 │ allocs/op  │ allocs/op   vs base                 │
 ZstdEncoding-12   18.00 ± 0%   17.00 ± 0%  -5.56% (p=0.000 n=10)
 ZstdDecoding-12   31.00 ± 0%   31.00 ± 0%       ~ (p=1.000 n=10) ¹
 geomean           23.62        22.96       -2.82%
```