### PR TITLE
Tag status in encoding time metrics

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -44,11 +44,9 @@ func NewCBOR[T CBORMarshalUnmarshaler]() *CBOR[T] {
 
 func (c *CBOR[T]) Encode(m T) (_ []byte, _err error) {
 	defer func(start time.Time) {
-		if _err != nil {
-			metrics.encodingTime.Record(context.Background(),
-				time.Since(start).Seconds(),
-				metric.WithAttributeSet(attrSetCborEncode))
-		}
+		metrics.encodingTime.Record(context.Background(),
+			time.Since(start).Seconds(),
+			metric.WithAttributes(attrCodecCbor, attrActionEncode, attrSuccessFromErr(_err)))
 	}(time.Now())
 	var out bytes.Buffer
 	if err := m.MarshalCBOR(&out); err != nil {
@@ -59,11 +57,9 @@ func (c *CBOR[T]) Encode(m T) (_ []byte, _err error) {
 
 func (c *CBOR[T]) Decode(v []byte, t T) (_err error) {
 	defer func(start time.Time) {
-		if _err != nil {
-			metrics.encodingTime.Record(context.Background(),
-				time.Since(start).Seconds(),
-				metric.WithAttributeSet(attrSetCborDecode))
-		}
+		metrics.encodingTime.Record(context.Background(),
+			time.Since(start).Seconds(),
+			metric.WithAttributes(attrCodecCbor, attrActionDecode, attrSuccessFromErr(_err)))
 	}(time.Now())
 	r := bytes.NewReader(v)
 	return t.UnmarshalCBOR(r)
@@ -100,7 +96,7 @@ func (c *ZSTD[T]) Encode(t T) (_ []byte, _err error) {
 	defer func(start time.Time) {
 		metrics.encodingTime.Record(context.Background(),
 			time.Since(start).Seconds(),
-			metric.WithAttributeSet(attrSetZstdEncode))
+			metric.WithAttributes(attrCodecZstd, attrActionEncode, attrSuccessFromErr(_err)))
 	}(time.Now())
 	decompressed, err := c.cborEncoding.Encode(t)
 	if len(decompressed) > maxDecompressedSize {
@@ -117,11 +113,9 @@ func (c *ZSTD[T]) Encode(t T) (_ []byte, _err error) {
 
 func (c *ZSTD[T]) Decode(compressed []byte, t T) (_err error) {
 	defer func(start time.Time) {
-		if _err != nil {
-			metrics.encodingTime.Record(context.Background(),
-				time.Since(start).Seconds(),
-				metric.WithAttributeSet(attrSetZstdDecode))
-		}
+		metrics.encodingTime.Record(context.Background(),
+			time.Since(start).Seconds(),
+			metric.WithAttributes(attrCodecZstd, attrActionDecode, attrSuccessFromErr(_err)))
 	}(time.Now())
 	buf := bufferPool.Get().(*[]byte)
 	defer bufferPool.Put(buf)

--- a/internal/encoding/metrics.go
+++ b/internal/encoding/metrics.go
@@ -8,14 +8,10 @@ import (
 )
 
 var (
-	attrCodecCbor     = attribute.String("codec", "cbor")
-	attrCodecZstd     = attribute.String("codec", "zstd")
-	attrActionEncode  = attribute.String("action", "encode")
-	attrActionDecode  = attribute.String("action", "decode")
-	attrSetCborEncode = attribute.NewSet(attrCodecCbor, attrActionEncode)
-	attrSetCborDecode = attribute.NewSet(attrCodecCbor, attrActionDecode)
-	attrSetZstdEncode = attribute.NewSet(attrCodecZstd, attrActionEncode)
-	attrSetZstdDecode = attribute.NewSet(attrCodecZstd, attrActionDecode)
+	attrCodecCbor    = attribute.String("codec", "cbor")
+	attrCodecZstd    = attribute.String("codec", "zstd")
+	attrActionEncode = attribute.String("action", "encode")
+	attrActionDecode = attribute.String("action", "decode")
 
 	meter = otel.Meter("f3/internal/encoding")
 
@@ -36,3 +32,7 @@ var (
 		)),
 	}
 )
+
+func attrSuccessFromErr(err error) attribute.KeyValue {
+	return attribute.Bool("success", err == nil)
+}


### PR DESCRIPTION
Tag the encoding time measurements with success/failure.

Fixes inconsistent error check across `defer` statements measuring time.