### PR TITLE
Bump version in prep for release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.7.3"
+  "version": "v0.8.0"
 }


### PR DESCRIPTION
Considering F3 has been running on butterflynet for a while and to unblock the Lotus bubble-up PR cutting a release pre-emptively.

There will most likely be further go-f3 releases prior to calibnet and mainnet upgrades.

Bumped the version straight to `v0.8.0` considering the breadth of changes in chain exchange, and partial message propagation.