### PR TITLE
Change GPBFT topic to avoid message format clash

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -19,7 +19,7 @@ import (
 // ErrNoManifest is returned when no manifest is known.
 var ErrNoManifest = errors.New("no known manifest")
 
-const VersionCapability = 5
+const VersionCapability = 6
 
 var (
 	DefaultCommitteeLookback uint64 = 10
@@ -427,7 +427,7 @@ func (m *Manifest) Cid() (cid.Cid, error) {
 }
 
 func PubSubTopicFromNetworkName(nn gpbft.NetworkName) string {
-	return "/f3/granite/0.0.2/" + string(nn)
+	return "/f3/granite/0.0.3/" + string(nn)
 }
 
 func ChainExchangeTopicFromNetworkName(nn gpbft.NetworkName) string {

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -113,7 +113,7 @@ func TestManifest_NetworkName(t *testing.T) {
 			require.True(t, strings.HasPrefix(gotDsPrefix, "/f3"))
 			require.True(t, strings.HasSuffix(gotDsPrefix, string(test.subject)))
 			gotPubSubTopic := m.PubSubTopic()
-			require.True(t, strings.HasPrefix(gotPubSubTopic, "/f3/granite/0.0.2/"))
+			require.True(t, strings.HasPrefix(gotPubSubTopic, "/f3/granite/0.0.3/"))
 			require.True(t, strings.HasSuffix(gotPubSubTopic, string(test.subject)))
 		})
 	}
@@ -123,8 +123,8 @@ func TestManifest_CID(t *testing.T) {
 	t.Parallel()
 
 	const (
-		wantLocalDevnetCid = "baguqfiheaiqptjzqkzqyu2hskn7ac5fexvjwuxmjec7hjrjug27jkucvmrrtmji"
-		wantAfterUpdateCid = "baguqfiheaiqjxj6otbtvdoitpqtfmjbslqc2o5cnjuipjxxduxiaezomoa44cey"
+		wantLocalDevnetCid = "baguqfiheaiqey5vrjjjqo3wvwpzq2hhan32rat4o5ectjwlqvrwuxddf73ukbya"
+		wantAfterUpdateCid = "baguqfiheaiqjs47hodx7netvag36yxsjh7whrxg7lxxkrwgkfdekhgu7jh6x27q"
 	)
 	subject := manifest.LocalDevnetManifest()
 	// Use a fixed network name for deterministic CID calculation.


### PR DESCRIPTION
Since the introduction of partial GPBFT messages change the topic and bump the manifest version to avoid overlap in having different message formats on the same topic entirely.

Fixes #887