### PR TITLE
Fix nil pointer return on already validated partial message

### DIFF
--- a/partial_validator.go
+++ b/partial_validator.go
@@ -104,7 +104,7 @@ func (v *cachingPartialValidator) PartiallyValidateMessage(msg *PartialGMessage)
 	} else if alreadyValidated, err := v.cache.Contains(msg.Vote.Instance, messageCacheNamespace, buf.Bytes()); err != nil {
 		log.Errorw("failed to check already validated messages", "err", err)
 	} else if alreadyValidated {
-		return nil, nil
+		return &PartiallyValidatedMessage{PartialGMessage: msg}, nil
 	} else {
 		cacheMessage = true
 	}


### PR DESCRIPTION
Return a partially validated message when the message is present in the validation cache.

* Thanks to @parthshah1 for pointing this issue out 🙏 
* Originally reported by Antithesis.