### PR TITLE
Add metrics to measure partial validation cache hit/miss

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -12,6 +12,11 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+var attrCacheHit = attribute.String("cache", "hit")
+var attrCacheMiss = attribute.String("cache", "miss")
+var attrCacheKindMessage = attribute.String("kind", "message")
+var attrCacheKindJustification = attribute.String("kind", "justification")
+
 var meter = otel.Meter("f3")
 var samples = struct {
 	messages       *measurements.SampleSet
@@ -48,6 +53,7 @@ var metrics = struct {
 	partialMessageDuplicates metric.Int64Counter
 	partialMessagesDropped   metric.Int64Counter
 	partialMessageInstances  metric.Int64UpDownCounter
+	partialValidationCache   metric.Int64Counter
 }{
 	headDiverged:      measurements.Must(meter.Int64Counter("f3_head_diverged", metric.WithDescription("Number of times we encountered the head has diverged from base scenario."))),
 	reconfigured:      measurements.Must(meter.Int64Counter("f3_reconfigured", metric.WithDescription("Number of times we reconfigured due to new manifest being delivered."))),
@@ -72,11 +78,13 @@ var metrics = struct {
 	partialMessages: measurements.Must(meter.Int64UpDownCounter("f3_partial_messages",
 		metric.WithDescription("Number of partial GPBFT messages pending fulfilment."))),
 	partialMessageDuplicates: measurements.Must(meter.Int64Counter("f3_partial_message_duplicates",
-		metric.WithDescription("Number of partial GPBFT messages recieved that already have an unfulfilled message for the same instance, sender, round and phase."))),
+		metric.WithDescription("Number of partial GPBFT messages received that already have an unfulfilled message for the same instance, sender, round and phase."))),
 	partialMessagesDropped: measurements.Must(meter.Int64Counter("f3_partial_messages_dropped",
 		metric.WithDescription("Number of partial GPBFT messages or chain broadcasts were dropped due to consumers being too slow."))),
 	partialMessageInstances: measurements.Must(meter.Int64UpDownCounter("f3_partial_message_instances",
 		metric.WithDescription("Number of instances with partial GPBFT messages pending fulfilment."))),
+	partialValidationCache: measurements.Must(meter.Int64Counter("f3_partial_validation_cache",
+		metric.WithDescription("The number of times partial validation cache resulted in hit or miss."))),
 }
 
 func recordValidatedMessage(ctx context.Context, msg gpbft.ValidatedMessage) {


### PR DESCRIPTION
Add metrics to measure the partial validation cache hit vs miss for messages and justifications.