### PR TITLE
Parameterise all partial message manager config in manifest

### DIFF
--- a/f3_test.go
+++ b/f3_test.go
@@ -353,10 +353,11 @@ var base = manifest.Manifest{
 		HeadLookback:             4,
 		Finalize:                 true,
 	},
-	CertificateExchange: manifest.DefaultCxConfig,
-	CatchUpAlignment:    5 * time.Second,
-	PubSub:              manifest.DefaultPubSubConfig,
-	ChainExchange:       manifest.DefaultChainExchangeConfig,
+	CertificateExchange:   manifest.DefaultCxConfig,
+	CatchUpAlignment:      5 * time.Second,
+	PubSub:                manifest.DefaultPubSubConfig,
+	ChainExchange:         manifest.DefaultChainExchangeConfig,
+	PartialMessageManager: manifest.DefaultPartialMessageManagerConfig,
 }
 
 type testNode struct {

--- a/host.go
+++ b/host.go
@@ -152,7 +152,7 @@ func newRunner(
 		return nil, fmt.Errorf("creating partial message manager: %w", err)
 	}
 
-	runner.pmCache = caching.NewGroupedSet(int(m.CommitteeLookback), 25_000)
+	runner.pmCache = caching.NewGroupedSet(int(m.CommitteeLookback), m.PartialMessageManager.MaxCachedValidatedMessagesPerInstance)
 	obfuscatedHost := (*gpbftHost)(runner)
 	runner.pmv = newCachingPartialValidator(obfuscatedHost, runner.Progress, runner.pmCache, m.CommitteeLookback)
 

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -50,9 +50,10 @@ var base = manifest.Manifest{
 		MinimumPollInterval:  30 * time.Second,
 		MaximumPollInterval:  2 * time.Minute,
 	},
-	PubSub:           manifest.DefaultPubSubConfig,
-	ChainExchange:    manifest.DefaultChainExchangeConfig,
-	CatchUpAlignment: 0,
+	PubSub:                manifest.DefaultPubSubConfig,
+	ChainExchange:         manifest.DefaultChainExchangeConfig,
+	PartialMessageManager: manifest.DefaultPartialMessageManagerConfig,
+	CatchUpAlignment:      0,
 }
 
 func TestManifest_Validation(t *testing.T) {
@@ -123,8 +124,8 @@ func TestManifest_CID(t *testing.T) {
 	t.Parallel()
 
 	const (
-		wantLocalDevnetCid = "baguqfiheaiqhdjxmvlkbk3d4uapd4eibmybbpozvo6ul4warivcml3psthtmd3a"
-		wantAfterUpdateCid = "baguqfiheaiqhe2kchdb4whu3ek4fxxh5jombejiwsnufyti5dpfzlue7xp7xqoq"
+		wantLocalDevnetCid = "baguqfiheaiqnp422v5xrqg4uhvtlx3zm3ojwnvy3ut23wwficlr66uj6sy2k2ka"
+		wantAfterUpdateCid = "baguqfiheaiqplz22vi4qeofnpdskhnu34cocktadeumyg3i2jy27fs7htcxrc5y"
 	)
 	subject := manifest.LocalDevnetManifest()
 	// Use a fixed network name for deterministic CID calculation.


### PR DESCRIPTION
Just to make sure we have inverted the control to change these at runtime via passive testing, parameterize all the constants in partial message manager in manifest.

This should allow us to investigate any potential effect of congestion that could result in dropping messages.

Part of #893 