### PR TITLE
Parameterise F3 runner pusub constants into manifest

### DIFF
--- a/host.go
+++ b/host.go
@@ -636,16 +636,12 @@ func (h *gpbftRunner) startPubsub() (<-chan gpbft.ValidatedMessage, error) {
 		return nil, err
 	}
 
-	const (
-		subBufferSize      = 128
-		msgQueueBufferSize = 128
-	)
-	sub, err := h.topic.Subscribe(pubsub.WithBufferSize(subBufferSize))
+	sub, err := h.topic.Subscribe(pubsub.WithBufferSize(h.manifest.PubSub.GMessageSubscriptionBufferSize))
 	if err != nil {
 		return nil, fmt.Errorf("could not subscribe to pubsub topic: %s: %w", h.topic, err)
 	}
 
-	messageQueue := make(chan gpbft.ValidatedMessage, msgQueueBufferSize)
+	messageQueue := make(chan gpbft.ValidatedMessage, h.manifest.PubSub.ValidatedMessageBufferSize)
 	h.errgrp.Go(func() error {
 		defer func() {
 			sub.Cancel()

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -55,8 +55,10 @@ var (
 	}
 
 	DefaultPubSubConfig = PubSubConfig{
-		CompressionEnabled:      false,
-		ChainCompressionEnabled: true,
+		CompressionEnabled:             false,
+		ChainCompressionEnabled:        true,
+		GMessageSubscriptionBufferSize: 128,
+		ValidatedMessageBufferSize:     128,
 	}
 
 	DefaultChainExchangeConfig = ChainExchangeConfig{
@@ -220,9 +222,21 @@ func (e *EcConfig) Validate() error {
 type PubSubConfig struct {
 	CompressionEnabled      bool
 	ChainCompressionEnabled bool
+
+	GMessageSubscriptionBufferSize int
+	ValidatedMessageBufferSize     int
 }
 
-func (p *PubSubConfig) Validate() error { return nil }
+func (p *PubSubConfig) Validate() error {
+	switch {
+	case p.GMessageSubscriptionBufferSize < 1:
+		return fmt.Errorf("pubsub gmessage subscription buffer size must be at least 1, got: %d", p.GMessageSubscriptionBufferSize)
+	case p.ValidatedMessageBufferSize < 1:
+		return fmt.Errorf("pubsub validated gmessage buffer size must be at least 1, got: %d", p.ValidatedMessageBufferSize)
+	default:
+		return nil
+	}
+}
 
 type ChainExchangeConfig struct {
 	SubscriptionBufferSize         int

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -123,8 +123,8 @@ func TestManifest_CID(t *testing.T) {
 	t.Parallel()
 
 	const (
-		wantLocalDevnetCid = "baguqfiheaiqhcftyuzforpx5txjognkby4jkct6cfqbu7ffpv5tyec4g75fcixa"
-		wantAfterUpdateCid = "baguqfiheaiqe24zlmhle7wgs5xpzatshnbvxlkax5uttegmhwhouyia52hzqtjy"
+		wantLocalDevnetCid = "baguqfiheaiqhdjxmvlkbk3d4uapd4eibmybbpozvo6ul4warivcml3psthtmd3a"
+		wantAfterUpdateCid = "baguqfiheaiqhe2kchdb4whu3ek4fxxh5jombejiwsnufyti5dpfzlue7xp7xqoq"
 	)
 	subject := manifest.LocalDevnetManifest()
 	// Use a fixed network name for deterministic CID calculation.


### PR DESCRIPTION
Parameterise the buffer size for the gmessage subscription passed to pubsub, and the channel of validated messages to which messages are written for processing by gpbft.

This is to cover all the corners in prep for mainnet passive testing, since in the past we have had to bump thes values due to slow processing of messages in specific cases.