### PR TITLE
Fix chain broadcast interval timestamp calculation

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -246,8 +246,13 @@ func (cx *ChainExchangeConfig) Validate() error {
 		return fmt.Errorf("chain exchange max discovered chains per instance must be at least 1, got: %d", cx.MaxDiscoveredChainsPerInstance)
 	case cx.MaxWantedChainsPerInstance < 1:
 		return fmt.Errorf("chain exchange max wanted chains per instance must be at least 1, got: %d", cx.MaxWantedChainsPerInstance)
-	case cx.RebroadcastInterval < 1*time.Millisecond: // 1 ms is a made-up minimum to avoid accidental hot-loop of chain rebroadcast.
+	case cx.RebroadcastInterval < 1*time.Millisecond:
+		// The timestamp precision is set to milliseconds. Therefore, the rebroadcast interval must not be less than a millisecond.
 		return fmt.Errorf("chain exchange rebroadcast interval cannot be less than 1ms, got: %s", cx.RebroadcastInterval)
+	case cx.MaxTimestampAge < 4*cx.RebroadcastInterval:
+		// The 4X is made up, but the idea is that the max timestamp age should give enough time for message propagation across at least a pair of nodes.
+		return fmt.Errorf("chain exchange max timestamp age must be at least 4x the rebroadcast interval (%s), got: %s", cx.RebroadcastInterval, cx.MaxTimestampAge)
+
 	default:
 		return nil
 	}

--- a/partial_msg_test.go
+++ b/partial_msg_test.go
@@ -1,0 +1,52 @@
+package f3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_roundDownToUnixTime(t *testing.T) {
+	someTime, err := time.Parse(time.RFC3339Nano, "2024-03-07T15:06:20.522847852Z")
+	require.NoError(t, err)
+
+	for _, test := range []struct {
+		name     string
+		at       time.Time
+		interval time.Duration
+		want     int64
+	}{
+		{
+			name:     "millisecond",
+			at:       someTime,
+			interval: time.Millisecond * 200,
+			want:     1709823980400, // 2024-03-07 15:06:20.4
+		},
+		{
+			name:     "second",
+			at:       someTime,
+			interval: time.Second * 7,
+			want:     1709823976000, // 2024-03-07 15:06:16
+		},
+		{
+			name:     "bigBang",
+			at:       time.Unix(0, 0),
+			interval: time.Second * 7,
+			want:     0,
+		},
+		{
+			name:     "justAfterBigBang",
+			at:       time.Unix(5, 0),
+			interval: time.Second * 5,
+			want:     5000,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := roundDownToUnixMilliTime(test.at, test.interval)
+			require.Equal(t, test.want, got)
+			require.GreaterOrEqual(t, got, time.Microsecond.Milliseconds())
+			require.LessOrEqual(t, got, test.at.UnixMilli())
+		})
+	}
+}


### PR DESCRIPTION
Fix a bug where timestamp calculation was not respecting the time precision, and using unit inconsistently.

Consistently use millisecond time precision and add tests.

While at it fix the missing manifest validation for interval and age.

Part of : #893 