### PR TITLE
Bump manifest compatibility version to 7

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -19,7 +19,7 @@ import (
 // ErrNoManifest is returned when no manifest is known.
 var ErrNoManifest = errors.New("no known manifest")
 
-const VersionCapability = 6
+const VersionCapability = 7
 
 var (
 	DefaultCommitteeLookback uint64 = 10

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -124,8 +124,8 @@ func TestManifest_CID(t *testing.T) {
 	t.Parallel()
 
 	const (
-		wantLocalDevnetCid = "baguqfiheaiqnp422v5xrqg4uhvtlx3zm3ojwnvy3ut23wwficlr66uj6sy2k2ka"
-		wantAfterUpdateCid = "baguqfiheaiqplz22vi4qeofnpdskhnu34cocktadeumyg3i2jy27fs7htcxrc5y"
+		wantLocalDevnetCid = "baguqfiheaiqh6vtsf7fionpvi2gp3xwz5vbtbkaabcb7gidub2skahnzjclq5wy"
+		wantAfterUpdateCid = "baguqfiheaiqoplbaxrgczvmuiihl3zypbrbqmorvs2yeynm7bcnhkxeq6q2sz2y"
 	)
 	subject := manifest.LocalDevnetManifest()
 	// Use a fixed network name for deterministic CID calculation.


### PR DESCRIPTION
Considering the set of newly added params, bump the compatibility version to avoid accidental manifest acceptance by old code.