### PR TITLE
Fix bug in chain exchange timestamp validation time unit

### DIFF
--- a/chainexchange/pubsub.go
+++ b/chainexchange/pubsub.go
@@ -245,11 +245,12 @@ func (p *PubSubChainExchange) validatePubSubMessage(ctx context.Context, _ peer.
 			return pubsub.ValidationReject
 		}
 	}
-	now := time.Now().Unix()
-	lowerBound := now - int64(p.maxTimestampAge.Seconds())
+	now := time.Now().UnixMilli()
+	lowerBound := now - p.maxTimestampAge.Milliseconds()
 	if lowerBound > cmsg.Timestamp || cmsg.Timestamp > now {
 		// The timestamp is too old or too far ahead. Ignore the message to avoid
 		// affecting peer scores.
+		log.Debugw("Timestamp too old or too far ahead", "from", msg.GetFrom(), "timestamp", cmsg.Timestamp, "lowerBound", lowerBound)
 		return pubsub.ValidationIgnore
 	}
 


### PR DESCRIPTION
The work in #904 standardized the chain exchange timestamp to millisecond. But the change wasn't bubbled up consistently to chain exchange pubsub validator.

Use millisecond time for comparison, add logging for better visibility.

Fix the tests to reflect the change, and while at it refactor the test into table test.