### PR TITLE
feat: batch computation of ECChain Keys in chainexchange

### DIFF
--- a/chainexchange/options.go
+++ b/chainexchange/options.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/internal/clock"
 	"github.com/filecoin-project/go-f3/internal/psutil"
 	"github.com/filecoin-project/go-f3/manifest"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -25,6 +26,7 @@ type options struct {
 	listener                       Listener
 	maxTimestampAge                time.Duration
 	compression                    bool
+	clk                            clock.Clock
 }
 
 func newOptions(o ...Option) (*options, error) {
@@ -35,6 +37,7 @@ func newOptions(o ...Option) (*options, error) {
 		maxInstanceLookahead:           manifest.DefaultCommitteeLookback,
 		maxDiscoveredChainsPerInstance: 1000,
 		maxWantedChainsPerInstance:     1000,
+		clk:                            clock.RealClock,
 	}
 	for _, apply := range o {
 		if err := apply(opts); err != nil {
@@ -160,6 +163,16 @@ func WithMaxTimestampAge(max time.Duration) Option {
 			return errors.New("max timestamp age cannot be negative")
 		}
 		o.maxTimestampAge = max
+		return nil
+	}
+}
+
+func WithClock(clk clock.Clock) Option {
+	return func(o *options) error {
+		if clk == nil {
+			return errors.New("clock cannot be nil")
+		}
+		o.clk = clk
 		return nil
 	}
 }

--- a/chainexchange/pubsub_test.go
+++ b/chainexchange/pubsub_test.go
@@ -88,7 +88,7 @@ func TestPubSubChainExchange_Broadcast(t *testing.T) {
 				chain, found = subject.GetChainByInstance(ctx, instance, key)
 				return found
 			}, time.Second, 100*time.Millisecond)
-			require.Equal(t, ecChain, chain)
+			require.EqualExportedValues(t, ecChain, chain)
 
 			baseChain := ecChain.BaseChain()
 			baseKey := baseChain.Key()
@@ -96,7 +96,7 @@ func TestPubSubChainExchange_Broadcast(t *testing.T) {
 				chain, found = subject.GetChainByInstance(ctx, instance, baseKey)
 				return found
 			}, time.Second, 100*time.Millisecond)
-			require.Equal(t, baseChain, chain)
+			require.EqualExportedValues(t, baseChain, chain)
 
 			// Assert that we have received 2 notifications, because ecChain has 2 tipsets.
 			// First should be the ecChain, second should be the baseChain.
@@ -104,9 +104,9 @@ func TestPubSubChainExchange_Broadcast(t *testing.T) {
 			notifications := testListener.getNotifications()
 			require.Len(t, notifications, 2)
 			require.Equal(t, instance, notifications[1].instance)
-			require.Equal(t, baseChain, notifications[1].chain)
+			require.EqualExportedValues(t, baseChain, notifications[1].chain)
 			require.Equal(t, instance, notifications[0].instance)
-			require.Equal(t, ecChain, notifications[0].chain)
+			require.EqualExportedValues(t, ecChain, notifications[0].chain)
 
 			require.NoError(t, subject.Shutdown(ctx))
 		})

--- a/gpbft/chain.go
+++ b/gpbft/chain.go
@@ -438,7 +438,7 @@ func (c *ECChain) KeysForPrefixes() []ECChainKey {
 
 	batch := merkle.BatchTree(values)
 	res := make([]ECChainKey, c.Len())
-	for i := 0; i < c.Len(); i++ {
+	for i := range c.Len() {
 		res[i] = batch[i]
 	}
 	return res
@@ -457,7 +457,7 @@ func (c *ECChain) AllPrefixes() []*ECChain {
 	batch := merkle.BatchTree(values)
 
 	res := make([]*ECChain, len(c.TipSets))
-	for i := 0; i < len(c.TipSets); i++ {
+	for i := range len(c.TipSets) {
 		var prefix ECChain
 		prefix.TipSets = c.TipSets[: i+1 : i+1]
 

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -234,6 +234,7 @@ func TestECChainAllPrefixes(t *testing.T) {
 		expected := chain.Prefix(i)
 		require.True(t, expected.Eq(prefix))
 		require.Equal(t, expected.Key(), prefix.Key())
+		require.NotSame(t, expected, prefix)
 	}
 }
 

--- a/gpbft/chain_test.go
+++ b/gpbft/chain_test.go
@@ -189,6 +189,54 @@ func TestECChain(t *testing.T) {
 	})
 }
 
+func TestECChainKeysForPrefixes(t *testing.T) {
+	t.Parallel()
+
+	pt1Cid := gpbft.MakeCid([]byte("pt1"))
+	pt2Cid := gpbft.MakeCid([]byte("pt2"))
+	pt3Cid := gpbft.MakeCid([]byte("pt3"))
+	tipSets := []*gpbft.TipSet{
+		{Epoch: 0, Key: []byte{0}, PowerTable: pt1Cid},
+		{Epoch: 1, Key: []byte{1}, PowerTable: pt2Cid},
+		{Epoch: 2, Key: []byte{2}, PowerTable: pt3Cid},
+	}
+
+	chain := &gpbft.ECChain{TipSets: tipSets}
+	keys := chain.KeysForPrefixes()
+
+	require.Equal(t, len(keys), len(tipSets), "KeysForPrefixes should return a key for each prefix")
+
+	for i, key := range keys {
+		prefixChain := chain.Prefix(i)
+		require.Equal(t, key, prefixChain.Key(), "Key for prefix %d should match", i)
+	}
+}
+
+func TestECChainAllPrefixes(t *testing.T) {
+	t.Parallel()
+
+	pt1Cid := gpbft.MakeCid([]byte("pt1"))
+	pt2Cid := gpbft.MakeCid([]byte("pt2"))
+	pt3Cid := gpbft.MakeCid([]byte("pt3"))
+	tipSets := []*gpbft.TipSet{
+		{Epoch: 0, Key: []byte{0}, PowerTable: pt1Cid},
+		{Epoch: 1, Key: []byte{1}, PowerTable: pt2Cid},
+		{Epoch: 2, Key: []byte{2}, PowerTable: pt3Cid},
+	}
+
+	chain := &gpbft.ECChain{TipSets: tipSets}
+	prefixes := chain.AllPrefixes()
+
+	require.Equal(t, len(prefixes), len(tipSets), "AllPrefixes should return a prefix for each tipset")
+
+	for i, prefix := range prefixes {
+		require.Equal(t, prefix.Len(), i+1, "Prefix %d should have length %d", i, i+1)
+		expected := chain.Prefix(i)
+		require.True(t, expected.Eq(prefix))
+		require.Equal(t, expected.Key(), prefix.Key())
+	}
+}
+
 func TestECChain_Eq(t *testing.T) {
 	t.Parallel()
 	var (

--- a/host.go
+++ b/host.go
@@ -500,14 +500,6 @@ func (h *gpbftRunner) BroadcastMessage(ctx context.Context, msg *gpbft.GMessage)
 		return fmt.Errorf("encoding GMessage for broadcast: %w", err)
 	}
 
-	_, err = h.participant.ValidateMessage(msg)
-	if err != nil {
-		log.Errorf("full message validation failed: %+v", err)
-	}
-	_, err = h.pmv.PartiallyValidateMessage(pmsg)
-	if err != nil {
-		log.Errorf("partial message validation failed: %+v", err)
-	}
 	err = h.topic.Publish(ctx, encoded)
 	if err != nil {
 		return fmt.Errorf("publishing message: %w", err)

--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -26,13 +26,13 @@ func WithMockClock(ctx context.Context) (context.Context, *Mock) {
 	return context.WithValue(ctx, clockKey, (Clock)(clk)), clk
 }
 
-var realClock = clock.New()
+var RealClock = clock.New()
 
 // GetClock either retrieves a mock clock from the context or returns a realtime clock.
 func GetClock(ctx context.Context) Clock {
 	clk := ctx.Value(clockKey)
 	if clk == nil {
-		return realClock
+		return RealClock
 	}
 	return clk.(Clock)
 }

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -133,22 +133,21 @@ func TestHashTreeGolden(t *testing.T) {
 	assert.Equal(t, expectedHex, batchResHash)
 }
 
-func BenchmarkIndividualPrefix(b *testing.B) {
+func BenchmarkPrefixes(b *testing.B) {
 	K := 128
 	inputs := generateInputs("golden", K)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		for i := 1; i < len(inputs); i++ {
-			runtime.KeepAlive(Tree(inputs[:i+1]))
+	b.Run("IndividualPrefix", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			for i := range len(inputs) {
+				runtime.KeepAlive(Tree(inputs[:i+1]))
+			}
 		}
-	}
-}
-
-func BenchmarkBatchPrefix(b *testing.B) {
-	K := 128
-	inputs := generateInputs("golden", K)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		runtime.KeepAlive(BatchTree(inputs))
-	}
+	})
+	b.Run("BatchPrefix", func(b *testing.B) {
+		b.ReportAllocs()
+		for range b.N {
+			runtime.KeepAlive(BatchTree(inputs))
+		}
+	})
 }

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -1,7 +1,9 @@
 package merkle
 
 import (
+	"encoding/hex"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,4 +66,89 @@ func TestHashZero(t *testing.T) {
 	// Bad proof
 	valid, _ := VerifyProof(root, 0, nil, nil)
 	assert.False(t, valid)
+}
+
+func generateInputs(dst string, N int) [][]byte {
+	var res [][]byte
+	for i := 0; i < N; i++ {
+		res = append(res, []byte(dst+fmt.Sprintf("%09d", i)))
+	}
+	return res
+}
+
+func TestHashBatch(t *testing.T) {
+	for N := 1; N < 300; {
+		inputs := generateInputs(fmt.Sprintf("batch-%d", N), N)
+		expected := make([]Digest, 0, N-1)
+
+		for i := 0; i < N; i++ {
+			expected = append(expected, Tree(inputs[0:i+1]))
+		}
+
+		batchRes := BatchTree(inputs)
+		require.Equal(t, expected, batchRes, "failed at size %d", N)
+		if N < 32 {
+			N++
+		} else {
+			N += 13
+		}
+	}
+}
+
+func TestHashTreeGolden(t *testing.T) {
+	expectedHex := []string{
+		"3d4395573ce4d2acbce4fe8a4be67ca5e7cdfb8ee2e85b2f6733c16b24c3b175",
+		"91b7c899421ca7f3228e10265c6970a03bc2ccba44367b1d44a9d8597b20a32e",
+		"69abe78dc2390b4666b60d0582e1799e73e48766f6e502c515e79d6cd2ae3c45",
+		"bc4ce8dbf993eb2e87c02bbf19cd4faeb3a0672188bc6be6c8d867cef9b08917",
+		"538cfd0c1f6b7ab4c3d20466d4e01b438972212fe5257eae213ae0a040da977f",
+		"e28aa108b0263820dfe2c7f051ddc8794ab48ebd3c1813db28bf9f06bedc52f3",
+		"875cb1d5027522b344b8adc62cd6bd110d97eaedd40a35bcb2fe142a9cb4612b",
+		"63804e8b6cb16993d5d43d9d7faf17ba967365dac141a4afbce1d794157a1b8e",
+		"07105bd8716bebc90036c8ebfe23a92bd775c09664b076ffa1d9a29d30647f91",
+		"960b7eb6440789f76f5d53965e8b208e34777bc4aab78edf6827d71c7eea4933",
+		"d55e07222c786722e1ad1b5bcc2ebaf04b2b4e92c07f3f7b61b0fbf0fd78fb9b",
+		"ee5a34dfae748e088a1b99386274158266f44ceeb2c5190f4e9bbc39cd8a4d26",
+		"15def4fc077ccfb0e48b32bc07ea3b91acecc5b73ed9caf13b10adf17052c371",
+		"07cfe4ec2efa9075763f921e9f29794ec6b945694e41cc19911101270d8b1087",
+		"84cdf541cbb3b9b3f26dbdeb9ca3a2721d15447a8b47074c3b08b560f79e5d85",
+		"af8e9fc2f15aaedadb96da1afb339b93e3174661327dcc6aad70ea67e183369d",
+	}
+	var results []string
+	N := 16
+	for i := 0; i < N; i++ {
+		inputs := generateInputs("golden", i+1)
+		res := Tree(inputs)
+		resHex := hex.EncodeToString(res[:])
+		assert.Equal(t, expectedHex[i], resHex)
+		results = append(results, resHex)
+	}
+	t.Logf("results: %#v", results)
+
+	batchRes := BatchTree(generateInputs("golden", N))
+	batchResHash := make([]string, N)
+	for i := 0; i < N; i++ {
+		batchResHash[i] = hex.EncodeToString(batchRes[i][:])
+	}
+	assert.Equal(t, expectedHex, batchResHash)
+}
+
+func BenchmarkIndividualPrefix(b *testing.B) {
+	K := 128
+	inputs := generateInputs("golden", K)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for i := 1; i < len(inputs); i++ {
+			runtime.KeepAlive(Tree(inputs[:i+1]))
+		}
+	}
+}
+
+func BenchmarkBatchPrefix(b *testing.B) {
+	K := 128
+	inputs := generateInputs("golden", K)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime.KeepAlive(BatchTree(inputs))
+	}
 }

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -91,44 +91,8 @@ func (s *FakeBackend) Aggregate(keys []gpbft.PubKey) (gpbft.Aggregate, error) {
 }
 
 func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Payload) []byte {
+	//TODO: remove this whole facility
 	return p.MarshalForSigning(nn)
-	length := len(gpbft.DomainSeparationTag) + 2 + len(nn)
-	length += 1 + 8 + 8 // phase + round + instance
-	length += 4         // len(p.Value)
-	if !p.Value.IsZero() {
-		for i := range p.Value.TipSets {
-			ts := p.Value.TipSets[i]
-			length += 8 // epoch
-			length += len(ts.Key)
-			length += len(ts.Commitments)
-			length += ts.PowerTable.ByteLen()
-		}
-	}
-
-	var buf bytes.Buffer
-	buf.Grow(length)
-	buf.WriteString(gpbft.DomainSeparationTag)
-	buf.WriteString(":")
-	buf.WriteString(string(nn))
-	buf.WriteString(":")
-
-	_ = binary.Write(&buf, binary.BigEndian, p.Phase)
-	_ = binary.Write(&buf, binary.BigEndian, p.Round)
-	_ = binary.Write(&buf, binary.BigEndian, p.Instance)
-	_, _ = buf.Write(p.SupplementalData.Commitments[:])
-	_, _ = buf.Write(p.SupplementalData.PowerTable.Bytes())
-	_ = binary.Write(&buf, binary.BigEndian, uint32(p.Value.Len()))
-	if !p.Value.IsZero() {
-		for i := range p.Value.TipSets {
-			ts := p.Value.TipSets[i]
-
-			_ = binary.Write(&buf, binary.BigEndian, ts.Epoch)
-			_, _ = buf.Write(ts.Commitments[:])
-			_, _ = buf.Write(ts.PowerTable.Bytes())
-			_, _ = buf.Write(ts.Key)
-		}
-	}
-	return buf.Bytes()
 }
 
 type fakeAggregate struct {

--- a/sim/signing/fake.go
+++ b/sim/signing/fake.go
@@ -91,6 +91,7 @@ func (s *FakeBackend) Aggregate(keys []gpbft.PubKey) (gpbft.Aggregate, error) {
 }
 
 func (v *FakeBackend) MarshalPayloadForSigning(nn gpbft.NetworkName, p *gpbft.Payload) []byte {
+	return p.MarshalForSigning(nn)
 	length := len(gpbft.DomainSeparationTag) + 2 + len(nn)
 	length += 1 + 8 + 8 // phase + round + instance
 	length += 4         // len(p.Value)


### PR DESCRIPTION
Adjust the for loop not to repeat the full chain
The EqualExportedValues is required as we never call explicit Key these
values, leaving cached key empty.

Resolves #831 