### PR TITLE
Enable zstd compression on gmessage topic by default

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -55,7 +55,7 @@ var (
 	}
 
 	DefaultPubSubConfig = PubSubConfig{
-		CompressionEnabled:             false,
+		CompressionEnabled:             true,
 		ChainCompressionEnabled:        true,
 		GMessageSubscriptionBufferSize: 128,
 		ValidatedMessageBufferSize:     128,

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -124,8 +124,8 @@ func TestManifest_CID(t *testing.T) {
 	t.Parallel()
 
 	const (
-		wantLocalDevnetCid = "baguqfiheaiqh6vtsf7fionpvi2gp3xwz5vbtbkaabcb7gidub2skahnzjclq5wy"
-		wantAfterUpdateCid = "baguqfiheaiqoplbaxrgczvmuiihl3zypbrbqmorvs2yeynm7bcnhkxeq6q2sz2y"
+		wantLocalDevnetCid = "baguqfiheaiqoktbekgcqvdpzlfnxvcocafjj5n6enxsokutvkkfqi6vrowr4gay"
+		wantAfterUpdateCid = "baguqfiheaiqiqtpn555ipnmjfp6ehzfymrtb5p5gyu2gmq74nohxlxwvhy3dx3y"
 	)
 	subject := manifest.LocalDevnetManifest()
 	// Use a fixed network name for deterministic CID calculation.


### PR DESCRIPTION
The data shows average of 1.5x reduction in message size on 2k network for partial gmessage sizes.

Based on the testing, so far it's harmless and beneficial to have compression on gmessage topic enabled.