### PR TITLE
merkle: further hashing opimizations

### DIFF
--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -174,7 +174,6 @@ func BatchTree(values [][]byte) []Digest {
 				// this should not happen if initial depth calculation is correct
 				panic(fmt.Sprintf("buildTreeMemoized: targetDepth 0 but values count %d != 1", numValues))
 			}
-			// compute leaf hash directly (memoizing leaves adds overhead with little benefit)
 			return leafHashes[startIndex]
 		}
 
@@ -205,12 +204,7 @@ func BatchTree(values [][]byte) []Digest {
 	}
 
 	for k := 1; k <= n; k++ {
-		depthForPrefixK := 0
-		if k > 1 {
-			depthForPrefixK = depth(k)
-		} else {
-			depthForPrefixK = 0 // Single leaf tree has depth 0
-		}
+		depthForPrefixK := depth(k)
 
 		if k == 1 {
 			roots[k] = leafHashes[0]

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -173,8 +173,10 @@ func BatchTree(values [][]byte) []Digest {
 			return leafHash(values[startIndex], hasher)
 		}
 
-		key := memoKey{targetDepth, startIndex, endIndex}
-		if cachedDigest, ok := memo[key]; ok {
+		// only memoize if it is a power of two tree, otherwise it won't be reused used
+		cached := bits.OnesCount64(uint64(numValues)) == 1
+		key := memoKey{depth: targetDepth, startIndex: startIndex, endIndex: endIndex}
+		if cachedDigest, ok := memo[key]; cached && ok {
 			return cachedDigest
 		}
 
@@ -190,6 +192,9 @@ func BatchTree(values [][]byte) []Digest {
 		rightHash := buildTreeMemoized(targetDepth-1, splitIndex, endIndex, hasher) // Handles padding
 
 		result := internalHash(leftHash, rightHash, hasher)
+		if !cached {
+			return result
+		}
 		memo[key] = result
 		return result
 	}

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -153,7 +153,6 @@ func BatchTree(values [][]byte) []Digest {
 	memo := make(map[memoKey]Digest)
 
 	hasher := sha3.NewLegacyKeccak256()
-	defer hasher.Reset()
 
 	// buildTreeMemoized computes the Merkle root for values[startIndex:endIndex]
 	// at the specified targetDepth

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -153,7 +153,6 @@ func BatchTree(values [][]byte) []Digest {
 	memo := make(map[memoKey]Digest)
 
 	hasher := sha3.NewLegacyKeccak256()
-	defer hasher.Reset()
 
 	leafHashes := make([]Digest, n)
 	for i := 0; i < n; i++ {

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -1,6 +1,7 @@
 package merkle
 
 import (
+	"fmt"
 	"io"
 	"math"
 	"math/bits"
@@ -19,7 +20,7 @@ var ZeroDigest Digest
 // TreeWithProofs returns a the root of the merkle-tree of the given values, along with merkle-proofs for
 // each leaf.
 func TreeWithProofs(values [][]byte) (Digest, [][]Digest) {
-	depth := depth(values)
+	depth := depth(len(values))
 	proofs := make([][]Digest, len(values))
 	for i := range proofs {
 		proofs[i] = make([]Digest, 0, depth)
@@ -29,7 +30,7 @@ func TreeWithProofs(values [][]byte) (Digest, [][]Digest) {
 
 // Tree returns a the root of the merkle-tree of the given values.
 func Tree(values [][]byte) Digest {
-	return buildTree(depth(values), values, nil)
+	return buildTree(depth(len(values)), values, nil)
 }
 
 // VerifyProof verifies that the given value maps to the given index in the merkle-tree with the
@@ -63,8 +64,8 @@ var internalMarker = []byte{0}
 var leafMarker = []byte{1}
 
 // returns the depth (path length) of a merkle-tree with the given values.
-func depth(values [][]byte) int {
-	return bits.Len(uint(len(values)) - 1)
+func depth(length int) int {
+	return bits.Len(uint(length) - 1)
 }
 
 // returns the keccak256 hash of the given values concatenated.
@@ -124,28 +125,89 @@ func buildTree(depth int, values [][]byte, proofs [][]Digest) Digest {
 	return internalHash(leftHash, rightHash)
 }
 
+// Key for memoization map
+type memoKey struct {
+	depth      int
+	startIndex int
+	endIndex   int // endIndex is needed because padding depends on it
+}
+
 // BatchTree creates a batch of prefixes of values: [[0], [0, 1], [0, 1, 2], ...]
 // and provides digests for all of them.
 func BatchTree(values [][]byte) []Digest {
+	// this implementation uses memoization to optimize the computation
 	n := len(values)
-	roots := make([]Digest, n+1) // roots[0] is empty
+	if n == 0 {
+		return []Digest{}
+	}
+	roots := make([]Digest, n+1) // roots[0] is unused (or holds zeroDigest)
+
+	memo := make(map[memoKey]Digest)
+
+	// buildTreeMemoized computes the Merkle root for values[startIndex:endIndex]
+	// at the specified targetDepth
+	var buildTreeMemoized func(targetDepth int, startIndex int, endIndex int) Digest
+	buildTreeMemoized = func(targetDepth int, startIndex int, endIndex int) Digest {
+		numValues := endIndex - startIndex
+		if numValues == 0 {
+			// Base case: No values for this branch, return zero digest (padding)
+			return Digest{}
+		}
+		if targetDepth == 0 {
+			// Base case: Leaf node depth
+			if numValues != 1 {
+				// this should not happen if initial depth calculation is correct
+				panic(fmt.Sprintf("buildTreeMemoized: targetDepth 0 but values count %d != 1", numValues))
+			}
+			// compute leaf hash directly (memoizing leaves adds overhead with little benefit)
+			return leafHash(values[startIndex])
+		}
+
+		key := memoKey{targetDepth, startIndex, endIndex}
+		if cachedDigest, ok := memo[key]; ok {
+			return cachedDigest
+		}
+
+		// Calculate split point based on the capacity of the left subtree at targetDepth-1
+		leftCapacity := 1 << (targetDepth - 1)
+		// Determine the actual index where the split occurs within values[startIndex:endIndex]
+		splitIndex := startIndex + leftCapacity
+		if splitIndex > endIndex {
+			splitIndex = endIndex // Don't split beyond available values
+		}
+
+		leftHash := buildTreeMemoized(targetDepth-1, startIndex, splitIndex)
+		rightHash := buildTreeMemoized(targetDepth-1, splitIndex, endIndex) // Handles padding
+
+		result := internalHash(leftHash, rightHash)
+		memo[key] = result
+		return result
+	}
 
 	for k := 1; k <= n; k++ {
+		depthForPrefixK := 0
+		if k > 1 {
+			depthForPrefixK = depth(k)
+		} else {
+			depthForPrefixK = 0 // Single leaf tree has depth 0
+		}
+
 		if k == 1 {
 			roots[k] = leafHash(values[0])
 			continue
 		}
 
-		depth := bits.Len(uint(k - 1))
-		split := 1 << (depth - 1)
+		// determine the split point (size of the left subtree) based on the depth
+		// the left subtree corresponds to a perfect tree of depth `depthForPrefixK - 1`
+		splitSize := 1 << (depthForPrefixK - 1) // size = 2^(depth-1)
 
-		// Reuse left subtree root from previous computation
-		leftRoot := roots[split]
+		// reuse the root of the left subtree (size `splitSize`) computed earlier.
+		// this root `roots[splitSize]` was computed to the correct depth.
+		leftRoot := roots[splitSize]
 
-		// compute right subtree root
-		// this could be made more optimal but leads to more messy code
-		rightValues := values[split:k]
-		rightRoot := buildTree(depth-1, rightValues, nil)
+		// compute the root of the right subtree using the memoized function.
+		// values: values[splitSize:k], Target Depth: depthForPrefixK - 1
+		rightRoot := buildTreeMemoized(depthForPrefixK-1, splitSize, k)
 
 		roots[k] = internalHash(leftRoot, rightRoot)
 	}

--- a/merkle/merkle_test.go
+++ b/merkle/merkle_test.go
@@ -24,7 +24,7 @@ func TestHashTree(t *testing.T) {
 			root2 := Tree(test)
 			require.Equal(t, root, root2)
 			require.Equal(t, len(test), len(paths))
-			assert.Equal(t, len(paths[0]), depth(test))
+			assert.Equal(t, len(paths[0]), depth(len(test)))
 
 			for i, path := range paths {
 				valid, more := VerifyProof(root, i, test[i], path)


### PR DESCRIPTION
Implement memoization and propoage hashers manually.
Overall improvement:
```
name                         old time/op    new time/op    delta
Prefixes/IndividualPrefix-8    9.91ms ± 7%    8.17ms ± 6%  -17.56%  (p=0.000 n=10+10)
Prefixes/BatchPrefix-8         3.43ms ± 6%    0.64ms ± 3%  -81.26%  (p=0.000 n=10+10)

name                         old alloc/op   new alloc/op   delta
Prefixes/IndividualPrefix-8    4.54MB ± 0%    1.11MB ± 0%  -75.66%  (p=0.000 n=10+10)
Prefixes/BatchPrefix-8         1.61MB ± 0%    0.22MB ± 0%  -86.65%  (p=0.000 n=8+10)

name                         old allocs/op  new allocs/op  delta
Prefixes/IndividualPrefix-8     33.4k ± 0%     33.7k ± 0%   +0.95%  (p=0.000 n=10+10)
Prefixes/BatchPrefix-8          11.8k ± 0%      2.5k ± 0%  -78.73%  (p=0.000 n=10+10)
```

Highlights: 81% CPU for batch hashing, ~80% reduced allocations