### PR TITLE
Refactor fake EC to take clock as option

### DIFF
--- a/certchain/certchain_test.go
+++ b/certchain/certchain_test.go
@@ -35,7 +35,8 @@ func TestCertChain_GenerateAndVerify(t *testing.T) {
 	}
 	initialPowerTable := generatePowerTable(t, rng, generatePublicKey, nil)
 
-	ec := consensus.NewFakeEC(ctx,
+	ec := consensus.NewFakeEC(
+		consensus.WithClock(clk),
 		consensus.WithSeed(seed*13),
 		consensus.WithBootstrapEpoch(m.BootstrapEpoch),
 		consensus.WithECPeriod(m.EC.Period),

--- a/cmd/f3/run.go
+++ b/cmd/f3/run.go
@@ -97,7 +97,7 @@ var runCmd = cli.Command{
 		id := c.Uint64("id")
 		signingBackend.Allow(int(id))
 
-		ec := consensus.NewFakeEC(ctx,
+		ec := consensus.NewFakeEC(
 			consensus.WithBootstrapEpoch(m.BootstrapEpoch),
 			consensus.WithECPeriod(m.EC.Period),
 			consensus.WithInitialPowerTable(initialPowerTable),

--- a/ec/powerdelta_test.go
+++ b/ec/powerdelta_test.go
@@ -30,7 +30,7 @@ var powerTableC = gpbft.PowerEntries{
 }
 
 func TestReplacePowerTable(t *testing.T) {
-	backend := consensus.NewFakeEC(context.Background(), consensus.WithInitialPowerTable(powerTableA))
+	backend := consensus.NewFakeEC(consensus.WithInitialPowerTable(powerTableA))
 	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, true)
 
 	head, err := modifiedBackend.GetHead(context.Background())
@@ -43,7 +43,7 @@ func TestReplacePowerTable(t *testing.T) {
 }
 
 func TestModifyPowerTable(t *testing.T) {
-	backend := consensus.NewFakeEC(context.Background(), consensus.WithInitialPowerTable(powerTableA))
+	backend := consensus.NewFakeEC(consensus.WithInitialPowerTable(powerTableA))
 	modifiedBackend := ec.WithModifiedPower(backend, powerTableB, false)
 
 	head, err := modifiedBackend.GetHead(context.Background())
@@ -55,7 +55,7 @@ func TestModifyPowerTable(t *testing.T) {
 }
 
 func TestBypassModifiedPowerTable(t *testing.T) {
-	backend := consensus.NewFakeEC(context.Background(), consensus.WithInitialPowerTable(powerTableA))
+	backend := consensus.NewFakeEC(consensus.WithInitialPowerTable(powerTableA))
 	modifiedBackend := ec.WithModifiedPower(backend, nil, false)
 	require.Equal(t, backend, modifiedBackend)
 }

--- a/f3_test.go
+++ b/f3_test.go
@@ -222,7 +222,8 @@ func TestF3EpochFinalizedWithChainExchange(t *testing.T) {
 		})
 	}
 
-	env.ec = consensus.NewFakeEC(env.testCtx,
+	env.ec = consensus.NewFakeEC(
+		consensus.WithClock(env.clock),
 		consensus.WithSeed(1413),
 		consensus.WithBootstrapEpoch(env.manifest.BootstrapEpoch),
 		consensus.WithMaxLookback(2*env.manifest.EC.Finality),
@@ -232,7 +233,8 @@ func TestF3EpochFinalizedWithChainExchange(t *testing.T) {
 		consensus.WithForkAfterEpochs(10),
 	)
 
-	env.nodes[0].ec = consensus.NewFakeEC(env.testCtx,
+	env.nodes[0].ec = consensus.NewFakeEC(
+		consensus.WithClock(env.clock),
 		consensus.WithSeed(1413),
 		consensus.WithBootstrapEpoch(env.manifest.BootstrapEpoch),
 		consensus.WithMaxLookback(2*env.manifest.EC.Finality),
@@ -586,7 +588,8 @@ func (e *testEnv) initialize() *testEnv {
 			})
 		}
 
-		e.ec = consensus.NewFakeEC(e.testCtx,
+		e.ec = consensus.NewFakeEC(
+			consensus.WithClock(e.clock),
 			consensus.WithSeed(1413),
 			consensus.WithBootstrapEpoch(e.manifest.BootstrapEpoch),
 			consensus.WithMaxLookback(2*e.manifest.EC.Finality),

--- a/internal/consensus/options.go
+++ b/internal/consensus/options.go
@@ -1,0 +1,105 @@
+package consensus
+
+import (
+	"time"
+
+	"github.com/filecoin-project/go-f3/gpbft"
+	"github.com/filecoin-project/go-f3/internal/clock"
+)
+
+type fakeECOptions struct {
+	clock                 clock.Clock
+	seed                  int64
+	initialPowerTable     gpbft.PowerEntries
+	evolvePowerTable      PowerTableMutator
+	bootstrapEpoch        int64
+	ecPeriod              time.Duration
+	ecMaxLookback         int64
+	nullTipsetProbability float64
+	forkAfterEpochs       int64
+	forkSeed              int64
+}
+
+type FakeECOption func(*fakeECOptions)
+type PowerTableMutator func(epoch int64, pt gpbft.PowerEntries) gpbft.PowerEntries
+
+func newFakeECOptions(o ...FakeECOption) *fakeECOptions {
+	opts := &fakeECOptions{
+		clock:                 clock.RealClock,
+		ecPeriod:              30 * time.Second,
+		seed:                  time.Now().UnixNano(),
+		forkSeed:              time.Now().UnixNano() / 2,
+		nullTipsetProbability: 0.015,
+	}
+	for _, apply := range o {
+		apply(opts)
+	}
+	return opts
+}
+
+func WithBootstrapEpoch(epoch int64) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.bootstrapEpoch = epoch
+	}
+}
+
+func WithSeed(seed int64) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.seed = seed
+	}
+}
+
+func WithInitialPowerTable(initialPowerTable gpbft.PowerEntries) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.initialPowerTable = initialPowerTable
+	}
+}
+
+func WithECPeriod(ecPeriod time.Duration) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.ecPeriod = ecPeriod
+	}
+}
+
+func WithMaxLookback(distance int64) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.ecMaxLookback = distance
+	}
+}
+
+func WithEvolvingPowerTable(fn PowerTableMutator) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.evolvePowerTable = fn
+	}
+}
+
+// WithClock sets the clock used to determine the current time. This is
+// useful for testing purposes, as it allows you to control the time
+// progression of the EC. The default clock is the system clock.
+func WithClock(clock clock.Clock) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.clock = clock
+	}
+}
+
+// WithForkSeed sets the seed used to generate fork chains. For this option to
+// take effect, WithForkAfterEpochs must be set to a value greater than 0.
+func WithForkSeed(e int64) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.forkSeed = e
+	}
+}
+
+// WithForkAfterEpochs sets the minimum number of epochs from the latest
+// finalized tipset key after which this EC may fork away.
+func WithForkAfterEpochs(e int64) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.forkAfterEpochs = e
+	}
+}
+
+func WithNullTipsetProbability(p float64) FakeECOption {
+	return func(ec *fakeECOptions) {
+		ec.nullTipsetProbability = p
+	}
+}

--- a/internal/consensus/tipset.go
+++ b/internal/consensus/tipset.go
@@ -1,0 +1,32 @@
+package consensus
+
+import (
+	"time"
+
+	"github.com/filecoin-project/go-f3/ec"
+	"github.com/filecoin-project/go-f3/gpbft"
+	mbase "github.com/multiformats/go-multibase"
+)
+
+var _ ec.TipSet = (*tipset)(nil)
+
+type tipset struct {
+	tsk       []byte
+	epoch     int64
+	timestamp time.Time
+	beacon    []byte
+}
+
+func (ts *tipset) Key() gpbft.TipSetKey { return ts.tsk }
+func (ts *tipset) Epoch() int64         { return ts.epoch }
+func (ts *tipset) Beacon() []byte       { return ts.beacon }
+func (ts *tipset) Timestamp() time.Time { return ts.timestamp }
+
+func (ts *tipset) String() string {
+	res, _ := mbase.Encode(mbase.Base32, ts.tsk[:gpbft.CidMaxLen])
+	for i := 1; i*gpbft.CidMaxLen < len(ts.tsk); i++ {
+		enc, _ := mbase.Encode(mbase.Base32, ts.tsk[gpbft.CidMaxLen*i:gpbft.CidMaxLen*(i+1)])
+		res += "," + enc
+	}
+	return res
+}

--- a/internal/powerstore/powerstore_test.go
+++ b/internal/powerstore/powerstore_test.go
@@ -34,8 +34,9 @@ func TestPowerStore(t *testing.T) {
 
 	m := manifest.LocalDevnetManifest()
 
-	ec := consensus.NewFakeEC(ctx,
-		consensus.WithNullTipsetProbablity(0),
+	ec := consensus.NewFakeEC(
+		consensus.WithClock(clk),
+		consensus.WithNullTipsetProbability(0),
 		consensus.WithMaxLookback(2*m.EC.Finality),
 		consensus.WithBootstrapEpoch(m.BootstrapEpoch),
 		consensus.WithECPeriod(m.EC.Period),


### PR DESCRIPTION
Refactor fake EC to use the existing options it has to take a fake clock with fallback to a real clock if none is specified.

Separate the code in different files to reduce LOC in the core fake ec logic.