### PR TITLE
Operation `Silence of the Certs`

### DIFF
--- a/host.go
+++ b/host.go
@@ -65,6 +65,8 @@ type roundPhase struct {
 	phase gpbft.Phase
 }
 
+// Lack of progress patches in mainnet at instance 6017
+
 func newRunner(
 	ctx context.Context,
 	cs *certstore.Store,


### PR DESCRIPTION
To write strategic software to aid the progress and observability of F3 on mainnet for instance 6017.

Branched off from main before cleanup of F3 to avoid any potential cleanup side-effects.