### PR TITLE
Implement lag awareness in aider based on current progress

### DIFF
--- a/internal/lotus/net.go
+++ b/internal/lotus/net.go
@@ -4,60 +4,38 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
+	"github.com/filecoin-project/go-f3/gpbft"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 var logger = logging.Logger("lotus")
 
+type resultOrError[R any] struct {
+	Result R `json:"result"`
+	Error  *struct {
+		Message string `json:"message"`
+	}
+}
+
 func ListAllPeers(ctx context.Context, apiEndpoints ...string) []peer.AddrInfo {
 	if len(apiEndpoints) == 0 {
 		return nil
 	}
-
-	const netPeersJsonRpc = `{"method":"Filecoin.NetPeers","params":[],"id":2,"jsonrpc":"2.0"}`
-	type resultOrError struct {
-		Result []peer.AddrInfo `json:"result"`
-		Error  *struct {
-			Message string `json:"message"`
-		}
-	}
+	const netPeers = `{"method":"Filecoin.NetPeers","params":[],"id":2,"jsonrpc":"2.0"}`
 	var addrs []peer.AddrInfo
 	seen := make(map[string]struct{})
 	for _, endpoint := range apiEndpoints {
-		body := bytes.NewReader([]byte(netPeersJsonRpc))
-		req, err := http.NewRequestWithContext(ctx, "POST", endpoint, body)
+		peers, err := doJsonRpcRequest[[]peer.AddrInfo](ctx, endpoint, netPeers)
 		if err != nil {
-			logger.Errorf("failed construct request to discover peers from: %s :%w", endpoint, err)
+			logger.Errorw("failed to get net peers from endpoint", "endpoint", endpoint, "err", err)
 			continue
 		}
-		req.Header.Set("Content-Type", `application/json`)
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			logger.Errorf("failed to discover peers from lotus daemon %s: %w", endpoint, err)
-			continue
-		}
-		defer func() { _ = resp.Body.Close() }()
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			logger.Errorf("failed to read response body from lotus daemon %s: %w", endpoint, err)
-			continue
-		}
-		var roe resultOrError
-		if err := json.Unmarshal(respBody, &roe); err != nil {
-			logger.Errorf("failed to unmarshal response from lotus daemon %s: %s: %w", endpoint, string(respBody), err)
-			continue
-		}
-		if roe.Error != nil {
-			logger.Errorf("failed to discover peers from lotus daemon %s: %s", endpoint, roe.Error.Message)
-			continue
-		}
-
-		for _, addr := range roe.Result {
+		for _, addr := range peers {
 			k := addr.ID.String()
 			if _, found := seen[k]; !found {
 				addrs = append(addrs, addr)
@@ -66,4 +44,52 @@ func ListAllPeers(ctx context.Context, apiEndpoints ...string) []peer.AddrInfo {
 		}
 	}
 	return addrs
+}
+
+func GetF3Progress(ctx context.Context, apiEndpoints ...string) []gpbft.InstanceProgress {
+	if len(apiEndpoints) == 0 {
+		return nil
+	}
+	const getF3Progress = `{"method":"Filecoin.F3GetProgress","params":[],"id":2,"jsonrpc":"2.0"}`
+	progresses := make([]gpbft.InstanceProgress, 0, len(apiEndpoints))
+	for _, endpoint := range apiEndpoints {
+		progress, err := doJsonRpcRequest[gpbft.InstanceProgress](ctx, endpoint, getF3Progress)
+		if err != nil {
+			logger.Errorw("failed to get F3 progress from endpoint", "endpoint", endpoint, "err", err)
+			continue
+		}
+		progresses = append(progresses, progress)
+	}
+	return progresses
+}
+
+func doJsonRpcRequest[R any](ctx context.Context, endpoint string, body string) (R, error) {
+	var zeroResult R
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader([]byte(body)))
+	if err != nil {
+		return zeroResult, fmt.Errorf("failed to construct request: %w", err)
+	}
+	req.Header.Set("Content-Type", `application/json`)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return zeroResult, fmt.Errorf("failed to execute the request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return zeroResult, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return zeroResult, fmt.Errorf("unsuccessful response status %d: %s", resp.StatusCode, string(respBody))
+	}
+	var roe resultOrError[R]
+	if err := json.Unmarshal(respBody, &roe); err != nil {
+		return zeroResult, fmt.Errorf("failed to unmarshal response as json: %s", string(respBody))
+	}
+	if roe.Error != nil {
+		logger.Errorf("failed to discover peers from lotus daemon %s: %s", endpoint, roe.Error.Message)
+		return zeroResult, fmt.Errorf("json rpc error: %s", roe.Error.Message)
+	}
+	return roe.Result, nil
 }


### PR DESCRIPTION
Determine if F3 is lagging and if so engage rebroadcast aid with resilience against failure cases. The lag determination strategy uses both lotus daemon and observer as sources to determine the current F3 progress. It then decides if F3 is lagging behind based on:
 * number of rounds
 * distance from head
 * elapsed time since instance ID changed.
 * last successful lag determination

The combination of above assures that both in cases of failure or less than perfect information aid is attempted. The only case where aid can't be attempted is when no initial F3 state is determinable.

Fixes #988