### PR TITLE
Batch insert observed messages using Duckdb appender

### DIFF
--- a/cmd/f3/observer.go
+++ b/cmd/f3/observer.go
@@ -105,6 +105,16 @@ var observerCmd = cli.Command{
 			Usage: "The connectivity threshold below which peer discovery via Lotus Net Peers is engaged. Disabled if set to zero or no lotusDaemon endpoints are provided.",
 			Value: 100,
 		},
+		&cli.IntFlag{
+			Name:  "maxBatchSize",
+			Usage: "The maximum number of messages to batch together in a single insertion into database.",
+			Value: 1000,
+		},
+		&cli.DurationFlag{
+			Name:  "maxBatchDelay",
+			Usage: "The maximum time to wait before a batch is flushed to the database.",
+			Value: time.Minute,
+		},
 	},
 
 	Action: func(cctx *cli.Context) error {
@@ -116,6 +126,8 @@ var observerCmd = cli.Command{
 			observer.WithRetention(cctx.Duration("retention")),
 			observer.WithDataSourceName(cctx.String("dataSourceName")),
 			observer.WithMaxConcurrentConnectionAttempts(cctx.Int("reconnectConcurrency")),
+			observer.WithMaxBatchSize(cctx.Int("maxBatchSize")),
+			observer.WithMaxBatchDelay(cctx.Duration("maxBatchDelay")),
 		}
 		var identity crypto.PrivKey
 		if cctx.IsSet("identity") {

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -191,8 +191,8 @@ func (o *Observer) createOrReplaceMessagesView(ctx context.Context, includeParqu
 }
 
 func (o *Observer) observe(ctx context.Context) error {
-	rotation := time.NewTimer(o.rotateInterval)
-	flush := time.NewTimer(o.maxBatchDelay)
+	rotation := time.NewTicker(o.rotateInterval)
+	flush := time.NewTicker(o.maxBatchDelay)
 	stopObserverForNetwork, err := o.startObserverFor(ctx, o.networkName)
 	if err != nil {
 		return fmt.Errorf("failed to start observer for network %s: %w", o.networkName, err)

--- a/observer/options.go
+++ b/observer/options.go
@@ -41,6 +41,9 @@ type options struct {
 	pubSubValidatorDisabled bool
 
 	dataSourceName string
+
+	maxBatchSize  int
+	maxBatchDelay time.Duration
 }
 
 func newOptions(opts ...Option) (*options, error) {
@@ -54,6 +57,8 @@ func newOptions(opts ...Option) (*options, error) {
 		rotatePath:                ".",
 		rotateInterval:            10 * time.Minute,
 		retention:                 -1,
+		maxBatchSize:              1000,
+		maxBatchDelay:             time.Minute,
 	}
 	for _, apply := range opts {
 		if err := apply(&opt); err != nil {
@@ -253,6 +258,23 @@ func WithDataSourceName(dataSourceName string) Option {
 func WithPubSub(ps *pubsub.PubSub) Option {
 	return func(o *options) error {
 		o.pubSub = ps
+		return nil
+	}
+}
+
+func WithMaxBatchSize(size int) Option {
+	return func(o *options) error {
+		o.maxBatchSize = size
+		return nil
+	}
+}
+
+func WithMaxBatchDelay(d time.Duration) Option {
+	return func(o *options) error {
+		if d < 0 {
+			return fmt.Errorf("max batch delay must be greater than or equal to 0")
+		}
+		o.maxBatchDelay = d
 		return nil
 	}
 }


### PR DESCRIPTION
For fast batch insertion of messages observed into duckdb, use the native appender to batch the messages based on size or max wait time. Whichever happens first.

Fixes #993