### PR TITLE
fix(manifest): Ensure Manifest.Equal compares all relevant config fields

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -194,7 +194,8 @@ func (e *EcConfig) Equal(o *EcConfig) bool {
 		e.Finality == o.Finality &&
 		e.DelayMultiplier == o.DelayMultiplier &&
 		e.HeadLookback == o.HeadLookback &&
-		slices.Equal(e.BaseDecisionBackoffTable, o.BaseDecisionBackoffTable)
+		slices.Equal(e.BaseDecisionBackoffTable, o.BaseDecisionBackoffTable) &&
+		e.Finalize == o.Finalize // Added Finalize check
 }
 
 func (e *EcConfig) Validate() error {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -352,8 +352,11 @@ func (m *Manifest) Equal(o *Manifest) bool {
 		m.Gpbft == o.Gpbft &&
 		m.EC.Equal(&o.EC) &&
 		m.CertificateExchange == o.CertificateExchange &&
-		m.ProtocolVersion == o.ProtocolVersion
-
+		m.ProtocolVersion == o.ProtocolVersion &&
+		m.PubSub == o.PubSub && // Added PubSub comparison
+		m.ChainExchange == o.ChainExchange && // Added ChainExchange comparison
+		m.PartialMessageManager == o.PartialMessageManager && // Added PartialMessageManager comparison
+		m.CatchUpAlignment == o.CatchUpAlignment // Added CatchUpAlignment comparison
 }
 
 func (m *Manifest) Validate() error {


### PR DESCRIPTION
fix(manifest): Ensure Manifest.Equal compares all relevant config fields

The Manifest.Equal() method was previously incomplete, failing to compare several key sub-configuration fields: PubSub, ChainExchange (CxConfig), PartialMessageManager, and CatchUpAlignment.

This omission could lead to systems failing to recognize meaningful configuration changes in these areas. Nodes might operate with outdated parameters, potentially causing inconsistent network behavior or difficult-to-diagnose issues.

This commit updates Manifest.Equal() to include direct comparisons for:
- m.PubSub == o.PubSub
- m.ChainExchange == o.ChainExchange
- m.PartialMessageManager == o.PartialMessageManager
- m.CatchUpAlignment == o.CatchUpAlignment

These fields are composed of directly comparable types or are aliases for comparable types (e.g., time.Duration is int64).

This change ensures that updates to these configurations are correctly detected, preventing nodes from operating with stale settings and mitigating risks such as transient consensus failures or impaired transaction propagation.

Addresses: https://gist.github.com/joncode5/738051c0c28eeb56046ab8aef52b5213