### PR TITLE
Rebroadcast immediately once a round threshold is met

### DIFF
--- a/emulator/driver.go
+++ b/emulator/driver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/stretchr/testify/require"
@@ -104,4 +105,13 @@ func (d *Driver) deliverMessage(msg *gpbft.GMessage) error {
 	} else {
 		return d.subject.ReceiveMessage(ctx, validated)
 	}
+}
+
+// AdvanceTimeBy advances the current time of the driver by the given amount.
+// This allows the driver to simulate the passage of time in the emulated
+// gpbft.Participant. This is useful for testing timeouts and other time-based
+// behavior in the gpbft.Participant in high number of rounds, which
+// exponentially increases the phase timeout.
+func (d *Driver) AdvanceTimeBy(t time.Duration) {
+	d.host.now = d.host.now.Add(t)
 }

--- a/emulator/host.go
+++ b/emulator/host.go
@@ -39,7 +39,9 @@ func (h *driverHost) maybeReceiveAlarm() bool {
 	if h.pendingAlarm == nil {
 		return false
 	}
-	h.now = *h.pendingAlarm
+	if h.now.Before(*h.pendingAlarm) {
+		h.now = *h.pendingAlarm
+	}
 	h.pendingAlarm = nil
 	return true
 }

--- a/gpbft/gpbft.go
+++ b/gpbft/gpbft.go
@@ -997,7 +997,7 @@ func (i *instance) tryRebroadcast() {
 			// trigger before the phase timeout. Override the alarm with rebroadcast timeout
 			// and check for phase timeout in the next cycle of rebroadcast.
 			i.participant.host.SetAlarm(i.rebroadcastTimeout)
-			i.log("scheduled initial rebroadcast at %v before phase timeout at %v", i.rebroadcastTimeout, i.phaseTimeout)
+			i.log("scheduled next rebroadcast at %v before phase timeout at %v", i.rebroadcastTimeout, i.phaseTimeout)
 		} else {
 			// The rebroadcast timeout is set after the phase timeout. Set the alarm for phase timeout instead.
 			i.log("Reverted to phase timeout at %v as it is before the next rebroadcast timeout at %v", i.phaseTimeout, i.rebroadcastTimeout)

--- a/gpbft/options.go
+++ b/gpbft/options.go
@@ -25,9 +25,10 @@ type options struct {
 
 	qualityDeltaMulti float64
 
-	committeeLookback  uint64
-	maxLookaheadRounds uint64
-	rebroadcastAfter   func(int) time.Duration
+	committeeLookback                uint64
+	maxLookaheadRounds               uint64
+	rebroadcastAfter                 func(int) time.Duration
+	rebroadcastImmediatelyAfterRound uint64
 
 	maxCachedInstances           int
 	maxCachedMessagesPerInstance int
@@ -38,13 +39,14 @@ type options struct {
 
 func newOptions(o ...Option) (*options, error) {
 	opts := &options{
-		delta:                        defaultDelta,
-		deltaBackOffExponent:         defaultDeltaBackOffExponent,
-		qualityDeltaMulti:            1.0,
-		committeeLookback:            defaultCommitteeLookback,
-		rebroadcastAfter:             defaultRebroadcastAfter,
-		maxCachedInstances:           defaultMaxCachedInstances,
-		maxCachedMessagesPerInstance: defaultMaxCachedMessagesPerInstance,
+		delta:                            defaultDelta,
+		deltaBackOffExponent:             defaultDeltaBackOffExponent,
+		qualityDeltaMulti:                1.0,
+		committeeLookback:                defaultCommitteeLookback,
+		rebroadcastAfter:                 defaultRebroadcastAfter,
+		rebroadcastImmediatelyAfterRound: 3,
+		maxCachedInstances:               defaultMaxCachedInstances,
+		maxCachedMessagesPerInstance:     defaultMaxCachedMessagesPerInstance,
 	}
 	for _, apply := range o {
 		if err := apply(opts); err != nil {
@@ -139,6 +141,17 @@ func WithMaxCachedMessagesPerInstance(v int) Option {
 func WithCommitteeLookback(lookback uint64) Option {
 	return func(o *options) error {
 		o.committeeLookback = lookback
+		return nil
+	}
+}
+
+// WithRebroadcastImmediatelyAfterRound sets the round after which rebroadcast is
+// scheduled without waiting for phase timeout to expire first.
+//
+// Defaults to 3 if unset.
+func WithRebroadcastImmediatelyAfterRound(round uint64) Option {
+	return func(o *options) error {
+		o.rebroadcastImmediatelyAfterRound = round
 		return nil
 	}
 }


### PR DESCRIPTION
The original GPBFT protocol dictates that the rebroadcast only gets triggered after the phase timeout has expired. This is reasonable for low number of rounds, where the vast majority of instances finalize within a single round. However, there is an edge-case where when an instance enters more than a few rounds the exponential increase of phase timeout results in extended periods of total radio silence.

As a result, the state propagation is hindered greatly, which in turn increases the chances of the instance taking even longer to finalize.

The changes here introduce a threshold at which rebroadcast is scheduled without waiting for phase timeout to expire first (defaulting to 3). In this design, the rebroadcast and successive rebroadcasts work exactly the same way as dictated in GPBFT design, except the trigger is adjsuted to consider rounds larger than the threshold as "insufficient progress".

The implementation reverts back to the vanilla GPBFT phase timeout as the phases progress and resets rebroadcast parameters accordingly

A test is added to assert that when an instance skips to future rounds, rebroadcast is triggered without wait, and continues to do so after phase change.

Fixes #983 