### PR TITLE
fix: Ensure containers are tagged by release tag

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -6,10 +6,10 @@ on:
       - 'main'
     tags:
       - 'v*'
-    workflow_run:
-      workflows: [ Releaser ]
-      types:
-        - completed
+  workflow_run:
+    workflows: [ Releaser ]
+    types:
+      - completed
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This commit fixes issue #934 where the container publishing CI workflow only tagged containers by commit SHA and not by the release tag.

The primary issue was an incorrect nesting of the `workflow_run` trigger within the `push` trigger in the `.github/workflows/publish-ghcr.yml` file. This prevented the workflow from being correctly triggered upon the completion of the `Releaser` workflow, which is responsible for creating Git tags and GitHub releases.

This change corrects the workflow trigger syntax, ensuring that the container build and publish workflow runs after a release is made, allowing it to use the semantic version tag for the container image.