### PR TITLE
Retract 0.8.5 release due to #1014

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/filecoin-project/go-f3
 
 go 1.23.7
 
+retract v0.8.5
+
 require (
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/filecoin-project/go-bitfield v0.2.4


### PR DESCRIPTION
This commit retracts 0.8.5 (a brand new release) due to anomaly in
metrics caused by #1010 (reverted in #1014).
The 0.8.5 release is not used by any implementation at the time of
retraction.
Follow up release 0.8.6 is on its way.