### PR TITLE
Infer messages from evidence of justification

### DIFF
--- a/test/drop_test.go
+++ b/test/drop_test.go
@@ -48,7 +48,11 @@ func TestDrop_ReachesConsensusDespiteMessageLoss(t *testing.T) {
 					sim.WithIgnoreConsensusFor(dropAdversaryTarget))
 				sm, err := sim.NewSimulation(opts...)
 				require.NoError(t, err)
-				require.NoErrorf(t, sm.Run(instanceCount, maxRounds), "%s", sm.Describe())
+				// Run the simulation for 1 extra instance to give enough time to the drop
+				// adversary target to complete the instance. Ideally, simulation should take a
+				// function as the condition to stop the simulation. But for now a quick extra
+				// round would do the trick.
+				require.NoErrorf(t, sm.Run(instanceCount+1, maxRounds), "%s", sm.Describe())
 				chain := ecChainGenerator.GenerateECChain(instanceCount-1, &gpbft.TipSet{}, math.MaxUint64)
 				requireConsensusAtInstance(t, sm, instanceCount-1, chain.Head())
 			})


### PR DESCRIPTION
The justification accompanied by most messages in GPBFT is evidence of a strong quorum of some states across the participants. Treat the receipt of such justifications as the receipt of the messages that justified it.

This allows a faster progress towards quorum in the network, and reduces reliance on re-broadcast and majority network state propagation.

Specifically, there are 2 phases that can benefit from the above optimization:

1. PREPARE phase, using justification of PREPARE in:
  * COMMIT messages at the same round.
  * PREPARE messages at the next round.
  * CONVERGE messages at the next round.
2. COMMIT phase, using justification of COMMIT to bottom in:
  * CONVERGE messages at the next round.
  * PREPARE messages at the next round.

The above optimization doesn't matter in CONVERGE and DECIDE phases. Because, CONVERGE by design awaits the phase timeout, and DECIDE is already optimized by `skipToDecide` where the participant rightly so immediately progresses to the final phase using the justification of COMMIT accompanied by the DECIDE message.

Fixes #342