### PR TITLE
feat: add GetPowerTableByInstance method to F3

### DIFF
--- a/f3.go
+++ b/f3.go
@@ -126,8 +126,8 @@ func (m *F3) GetCert(ctx context.Context, instance uint64) (*certs.FinalityCerti
 	return nil, ErrF3NotRunning
 }
 
-// GetCertPowerTable returns the power table (committee) used to validate the specified instance.
-func (m *F3) GetCertPowerTable(ctx context.Context, instance uint64) (gpbft.PowerEntries, error) {
+// GetPowerTableByInstance returns the power table (committee) used to validate the specified instance.
+func (m *F3) GetPowerTableByInstance(ctx context.Context, instance uint64) (gpbft.PowerEntries, error) {
 	if state := m.state.Load(); state != nil {
 		return state.cs.GetPowerTable(ctx, instance)
 	}


### PR DESCRIPTION
Adds a method to get the power table (committee) used to validate
the specified instance.

Part of: https://github.com/filecoin-project/lotus/issues/13081