### PR TITLE
Capture finality certificates with F3 Observer

### DIFF
--- a/observer/schema.sql
+++ b/observer/schema.sql
@@ -64,3 +64,28 @@ CREATE TABLE IF NOT EXISTS latest_messages (
 -- Add Key column to latest_messages table to accommodate partial messages.
 ALTER TABLE latest_messages
 ADD COLUMN IF NOT EXISTS VoteValueKey BLOB;
+
+
+CREATE TABLE IF NOT EXISTS finality_certificates (
+  Timestamp TIMESTAMP,
+  NetworkName VARCHAR,
+  Instance BIGINT,
+  ECChain STRUCT(
+    Epoch BIGINT,
+    Key BLOB,
+    Commitments BLOB,
+    PowerTable VARCHAR
+  )[],
+  SupplementalData STRUCT(
+    Commitments BLOB,
+    PowerTable VARCHAR
+  ),
+  Signers BIGINT[],
+  Signature BLOB,
+  PowerTableDelta STRUCT(
+    ParticipantID BIGINT,
+    PowerDelta BIGINT,
+    SigningKey BLOB
+  )[],
+  PRIMARY KEY (NetworkName, Instance)
+);


### PR DESCRIPTION
Expand the ability of observer to capture and store all finality certificates, and make them available for query over SQL.

Fixes #745 