### PR TITLE
Remove finality cert table constraint in observer

### DIFF
--- a/observer/model.go
+++ b/observer/model.go
@@ -57,7 +57,7 @@ type FinalityCertificate struct {
 	Timestamp        time.Time         `json:"Timestamp"`
 	NetworkName      string            `json:"NetworkName"`
 	Instance         uint64            `json:"Instance"`
-	ECChain          []TipSet          `json:"Value"`
+	ECChain          []TipSet          `json:"ECChain"`
 	SupplementalData SupplementalData  `json:"SupplementalData"`
 	Signers          []uint64          `json:"Signers"`
 	Signature        []byte            `json:"Signature"`

--- a/observer/schema.sql
+++ b/observer/schema.sql
@@ -65,7 +65,6 @@ CREATE TABLE IF NOT EXISTS latest_messages (
 ALTER TABLE latest_messages
 ADD COLUMN IF NOT EXISTS VoteValueKey BLOB;
 
-
 CREATE TABLE IF NOT EXISTS finality_certificates (
   Timestamp TIMESTAMP,
   NetworkName VARCHAR,
@@ -87,7 +86,6 @@ CREATE TABLE IF NOT EXISTS finality_certificates (
     PowerDelta BIGINT,
     SigningKey BLOB
   )[],
-  PRIMARY KEY (NetworkName, Instance)
 );
 
 CREATE TABLE IF NOT EXISTS chain_exchanges (


### PR DESCRIPTION
Remove the primary key constraint in finality certs in observer to avoid an edge-case where multiple certs for the same instance may be discovered in conjunction with using duckdb appender to insert them.

Appender does not offer the ability to insert or ignore records. And even if it did, we probably want to capture all and any certs, since certs are validated before insertion.

While at it, also fix a typo in cert JSON struct tags.