### PR TITLE
Capture chain exchange messages in F3 observer

### DIFF
--- a/cmd/f3/observer.go
+++ b/cmd/f3/observer.go
@@ -125,6 +125,11 @@ var observerCmd = cli.Command{
 			Usage:       "The path to the directory used for intermediary finality certificate certstore. If not set, in-memory backing store will be used.",
 			DefaultText: "in-memory",
 		},
+		&cli.DurationFlag{
+			Name:  "chainExchangeMaxMessageAge",
+			Usage: "The maximum age of the chain exchange messages to observe.",
+			Value: 3 * time.Minute,
+		},
 	},
 
 	Action: func(cctx *cli.Context) error {
@@ -138,6 +143,7 @@ var observerCmd = cli.Command{
 			observer.WithMaxConcurrentConnectionAttempts(cctx.Int("reconnectConcurrency")),
 			observer.WithMaxBatchSize(cctx.Int("maxBatchSize")),
 			observer.WithMaxBatchDelay(cctx.Duration("maxBatchDelay")),
+			observer.WithChainExchangeMaxMessageAge(cctx.Duration("chainExchangeMaxMessageAge")),
 		}
 		var identity crypto.PrivKey
 		if cctx.IsSet("identity") {

--- a/observer/model.go
+++ b/observer/model.go
@@ -70,6 +70,14 @@ type PowerTableDelta struct {
 	SigningKey    []byte `json:"SigningKey"`
 }
 
+type ChainExchange struct {
+	Timestamp    time.Time `json:"Timestamp"`
+	NetworkName  string    `json:"NetworkName"`
+	Instance     uint64    `json:"Instance"`
+	VoteValueKey []byte    `json:"VoteValueKey"`
+	VoteValue    []TipSet  `json:"VoteValue"`
+}
+
 func newMessage(timestamp time.Time, nn string, msg gpbft.PartialGMessage) (*Message, error) {
 	j, err := newJustification(msg.Justification)
 	if err != nil {
@@ -314,4 +322,15 @@ func powerTableDeltaFromGpbft(ptd certs.PowerTableDiff) ([]PowerTableDelta, erro
 		}
 	}
 	return deltas, nil
+}
+
+func newChainExchange(timestamp time.Time, nn gpbft.NetworkName, instance uint64, chain *gpbft.ECChain) *ChainExchange {
+	key := chain.Key()
+	return &ChainExchange{
+		Timestamp:    timestamp,
+		NetworkName:  string(nn),
+		Instance:     instance,
+		VoteValueKey: key[:],
+		VoteValue:    tipsetsFromGpbft(chain),
+	}
 }

--- a/observer/options.go
+++ b/observer/options.go
@@ -55,6 +55,9 @@ type options struct {
 	finalityCertsInitialPollInterval  time.Duration
 	finalityCertsMinPollInterval      time.Duration
 	finalityCertsMaxPollInterval      time.Duration
+
+	chainExchangeBufferSize    int
+	chainExchangeMaxMessageAge time.Duration
 }
 
 func newOptions(opts ...Option) (*options, error) {
@@ -76,6 +79,8 @@ func newOptions(opts ...Option) (*options, error) {
 		finalityCertsInitialPollInterval:  10 * time.Second,
 		finalityCertsMinPollInterval:      30 * time.Second,
 		finalityCertsMaxPollInterval:      2 * time.Minute,
+		chainExchangeBufferSize:           1000,
+		chainExchangeMaxMessageAge:        3 * time.Minute,
 	}
 	for _, apply := range opts {
 		if err := apply(&opt); err != nil {
@@ -369,6 +374,26 @@ func WithFinalityCertsMaxPollInterval(d time.Duration) Option {
 			return fmt.Errorf("finality certs maximum poll interval must be greater than 0")
 		}
 		o.finalityCertsMaxPollInterval = d
+		return nil
+	}
+}
+
+func WithChainExchangeBufferSize(size int) Option {
+	return func(o *options) error {
+		if size < 1 {
+			return fmt.Errorf("chain exchange buffer size must be at least 1")
+		}
+		o.chainExchangeBufferSize = size
+		return nil
+	}
+}
+
+func WithChainExchangeMaxMessageAge(d time.Duration) Option {
+	return func(o *options) error {
+		if d <= 0 {
+			return fmt.Errorf("chain exchange max message age must be greater than 0")
+		}
+		o.chainExchangeMaxMessageAge = d
 		return nil
 	}
 }

--- a/observer/schema.sql
+++ b/observer/schema.sql
@@ -89,3 +89,17 @@ CREATE TABLE IF NOT EXISTS finality_certificates (
   )[],
   PRIMARY KEY (NetworkName, Instance)
 );
+
+CREATE TABLE IF NOT EXISTS chain_exchanges (
+  Timestamp TIMESTAMP,
+  NetworkName VARCHAR,
+  Instance BIGINT,
+  VoteValueKey BLOB,
+  VoteValue STRUCT(
+    Epoch BIGINT,
+    Key BLOB,
+    Commitments BLOB,
+    PowerTable VARCHAR
+  )[],
+  PRIMARY KEY (NetworkName, Instance, VoteValueKey)
+);


### PR DESCRIPTION
Add the ability to capture chain exchange messages via F3 observer and make them queryable via SQL statement.

The captured chain exchange messages offers a mapping of EC chain key to the concrete EC chain value itself, since partial GMessages only contain the EC chain key and not the chain itself.

Fixes #970