### PR TITLE
fix early start of F3 in case of delayed bootstrap tipset

### DIFF
--- a/bootstrap_delay_test.go
+++ b/bootstrap_delay_test.go
@@ -64,7 +64,7 @@ func TestComputeBootstrapDelay(t *testing.T) {
 			name: "out of sync - way after bootstrap",
 			time: genesis.Add(time.Duration(bootstrapEpoch+100)*period + 1*time.Second),
 			ts:   tipset{genesis: genesis, epoch: int64(bootstrapEpoch - 100), period: period},
-			want: 0 * time.Second,
+			want: 1 * time.Nanosecond, // we don't start immediately as the tipset we need is not available yet
 		},
 		{
 			name: "out of sync - way before bootstrap",


### PR DESCRIPTION
If bootstrap tipset is delayed, we don't want to start immediately
instead we want to ensure that this tipset first exists