### PR TITLE
feat: Add retention size limit for rotated files

### DIFF
--- a/cmd/f3/observer.go
+++ b/cmd/f3/observer.go
@@ -66,6 +66,11 @@ var observerCmd = cli.Command{
 			Usage: "The maximum length of time to keep the rotated files.",
 			Value: 2 * 7 * 24 * time.Hour,
 		},
+		&cli.Int64Flag{
+			Name:  "retentionSize",
+			Usage: "The maximum size of the rotated files in megabytes. If not set, no limit is applied.",
+			Value: 0,
+		},
 		&cli.StringFlag{
 			Name:        "dataSourceName",
 			Usage:       "The observer database DSN",
@@ -144,7 +149,9 @@ var observerCmd = cli.Command{
 			observer.WithMaxBatchSize(cctx.Int("maxBatchSize")),
 			observer.WithMaxBatchDelay(cctx.Duration("maxBatchDelay")),
 			observer.WithChainExchangeMaxMessageAge(cctx.Duration("chainExchangeMaxMessageAge")),
+			observer.WithMaxRetentionSize(cctx.Int64("retentionSize") * 1024 * 1024),
 		}
+
 		var identity crypto.PrivKey
 		if cctx.IsSet("identity") {
 			marshaledKey, err := os.ReadFile(cctx.String("identity"))

--- a/cmd/f3/observer.go
+++ b/cmd/f3/observer.go
@@ -66,7 +66,7 @@ var observerCmd = cli.Command{
 			Usage: "The maximum length of time to keep the rotated files.",
 			Value: 2 * 7 * 24 * time.Hour,
 		},
-		&cli.Int64Flag{
+		&cli.Uint64Flag{
 			Name:  "retentionSize",
 			Usage: "The maximum size of the rotated files in megabytes. If not set, no limit is applied.",
 			Value: 0,
@@ -149,7 +149,7 @@ var observerCmd = cli.Command{
 			observer.WithMaxBatchSize(cctx.Int("maxBatchSize")),
 			observer.WithMaxBatchDelay(cctx.Duration("maxBatchDelay")),
 			observer.WithChainExchangeMaxMessageAge(cctx.Duration("chainExchangeMaxMessageAge")),
-			observer.WithMaxRetentionSize(cctx.Int64("retentionSize") * 1024 * 1024),
+			observer.WithMaxRetentionSize(cctx.Uint64("retentionSize") * 1024 * 1024),
 		}
 
 		var identity crypto.PrivKey

--- a/observer/options.go
+++ b/observer/options.go
@@ -3,6 +3,7 @@ package observer
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/filecoin-project/go-f3/blssig"
@@ -276,9 +277,12 @@ func WithRetention(retention time.Duration) Option {
 // This is weakly enforced, and the directory may grow larger than this
 // size. If the directory grows larger than this size, the oldest files
 // will be deleted until the directory size is below this size.
-func WithMaxRetentionSize(size int64) Option {
+func WithMaxRetentionSize(size uint64) Option {
 	return func(o *options) error {
-		o.maxRetentionSize = size
+		if size > math.MaxInt64 {
+			return fmt.Errorf("max retention size must be less than or equal to %d", math.MaxInt64)
+		}
+		o.maxRetentionSize = int64(size)
 		return nil
 	}
 }

--- a/observer/options.go
+++ b/observer/options.go
@@ -13,7 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
-	"github.com/multiformats/go-multiaddr-dns"
+	madns "github.com/multiformats/go-multiaddr-dns"
 )
 
 type Option func(*options) error
@@ -35,9 +35,10 @@ type options struct {
 	queryServerListenAddress string
 	queryServerReadTimeout   time.Duration
 
-	rotatePath     string
-	rotateInterval time.Duration
-	retention      time.Duration
+	rotatePath       string
+	rotateInterval   time.Duration
+	retention        time.Duration
+	maxRetentionSize int64
 
 	pubSub                  *pubsub.PubSub
 	pubSubValidatorDisabled bool
@@ -81,6 +82,7 @@ func newOptions(opts ...Option) (*options, error) {
 		finalityCertsMaxPollInterval:      2 * time.Minute,
 		chainExchangeBufferSize:           1000,
 		chainExchangeMaxMessageAge:        3 * time.Minute,
+		maxRetentionSize:                  0,
 	}
 	for _, apply := range opts {
 		if err := apply(&opt); err != nil {
@@ -266,6 +268,17 @@ func WithRotateInterval(d time.Duration) Option {
 func WithRetention(retention time.Duration) Option {
 	return func(o *options) error {
 		o.retention = retention
+		return nil
+	}
+}
+
+// WithMaxRetentionSize sets the maximum size of the retention directory.
+// This is weakly enforced, and the directory may grow larger than this
+// size. If the directory grows larger than this size, the oldest files
+// will be deleted until the directory size is below this size.
+func WithMaxRetentionSize(size int64) Option {
+	return func(o *options) error {
+		o.maxRetentionSize = size
 		return nil
 	}
 }


### PR DESCRIPTION
This adds a new flag to the observer command to limit the size of the
rotated files. When the rotated files exceed this size, the oldest files
are deleted.

This is in support of https://github.com/filecoin-project/go-f3/issues/1041