### PR TITLE
fix: improve performance of ApplyPowerTableDiffs in ImportSnapshotToDatastore

### DIFF
--- a/certstore/snapshot.go
+++ b/certstore/snapshot.go
@@ -19,7 +19,10 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
-var ErrUnknownLatestCertificate = errors.New("latest certificate is not known")
+var (
+	ErrUnknownLatestCertificate = errors.New("latest certificate is not known")
+	ErrNoCertificateExtracted   = errors.New("no certificate is found in the snapshot")
+)
 
 // ExportLatestSnapshot exports an F3 snapshot that includes the finality certificate chain until the current `latestCertificate`.
 //
@@ -151,6 +154,14 @@ func importSnapshotToDatastoreWithTestingPowerTableFrequency(ctx context.Context
 				return err
 			}
 		}
+	}
+
+	if latestCert == nil {
+		return ErrNoCertificateExtracted
+	}
+
+	if latestCert.GPBFTInstance != header.LatestInstance {
+		return fmt.Errorf("extracted latest instance %d, but %d is expected", latestCert.GPBFTInstance, header.LatestInstance)
 	}
 
 	pt := certs.PowerTableMapToArray(ptm)

--- a/certstore/snapshot.go
+++ b/certstore/snapshot.go
@@ -110,7 +110,7 @@ func importSnapshotToDatastoreWithTestingPowerTableFrequency(ctx context.Context
 	if err != nil {
 		return err
 	}
-	pt := header.InitialPowerTable
+	ptm := certs.PowerTableArrayToMap(header.InitialPowerTable)
 	for {
 		certBytes, err := readSnapshotBlockBytes(snapshot)
 		if err == io.EOF {
@@ -123,10 +123,11 @@ func importSnapshotToDatastoreWithTestingPowerTableFrequency(ctx context.Context
 		if err = cs.Put(ctx, &cert); err != nil {
 			return err
 		}
-		if pt, err = certs.ApplyPowerTableDiffs(pt, cert.PowerTableDelta); err != nil {
+		if ptm, err = certs.ApplyPowerTableDiffsToMap(ptm, cert.PowerTableDelta); err != nil {
 			return err
 		}
 		if (cert.GPBFTInstance+1)%cs.powerTableFrequency == 0 {
+			pt := certs.PowerTableMapToArray(ptm)
 			if err := cs.putPowerTable(ctx, cert.GPBFTInstance+1, pt); err != nil {
 				return err
 			}


### PR DESCRIPTION
The `sort` operation in `ApplyPowerTableDiffs` turns out to be expensive. 
This PR introduces another `func ApplyPowerTableDiffsToMap(powerTableMap map[gpbft.ActorID]gpbft.PowerEntry, diffs ...PowerTableDiff) (map[gpbft.ActorID]gpbft.PowerEntry, error)` to avoid sorting.

It also adds more validations against first instance, latest instance and powertable cid.

Perf stats of importing a mainnet F3 snapshot on my laptop show ~99% perf gain

```
# PR
0.884s
0.773s
0.864s

# main
86.547s
88.422s
86.998s
```