### PR TITLE
Revert "ci: uci/update-go (#1048)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-bullseye AS build
+FROM golang:1.23-bullseye AS build
 
 WORKDIR /go/src/f3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/filecoin-project/go-f3
 
-go 1.24
+go 1.23.7
 
 require (
 	github.com/consensys/gnark-crypto v0.12.1


### PR DESCRIPTION
This reverts commit f6bae221d349fb00210fa2501e90373f14090b57.
We need go.mod with 1.23 for Lotus