### PR TITLE
refactor(pmsg): consolidate CompleteMessage short-circuit predicate

### DIFF
--- a/gpbft/types.go
+++ b/gpbft/types.go
@@ -234,3 +234,10 @@ type PartialGMessage struct {
 	*GMessage
 	VoteValueKey ECChainKey `cborgen:"maxlen=32"`
 }
+
+// HasChainValue reports whether the partial message carries a chain value that
+// must be resolved via chainexchange before it can be fully validated. Messages
+// with a zero VoteValueKey (e.g. COMMIT for bottom) have no chain to resolve.
+func (p *PartialGMessage) HasChainValue() bool {
+	return p != nil && p.GMessage != nil && !p.VoteValueKey.IsZero()
+}

--- a/pmsg/partial_msg.go
+++ b/pmsg/partial_msg.go
@@ -395,9 +395,8 @@ func (pmm *PartialMessageManager) CompleteMessage(ctx context.Context, pgmsg *gp
 		// For sanity assert that the message isn't nil.
 		return nil, false
 	}
-	if pgmsg.VoteValueKey.IsZero() {
-		// A zero VoteValueKey indicates that there's no partial chain value, for
-		// example, COMMIT for bottom. Return the message as is.
+	if !pgmsg.HasChainValue() {
+		// for example COMMIT for bottom
 		return pgmsg.GMessage, true
 	}
 

--- a/pmsg/partial_msg_test.go
+++ b/pmsg/partial_msg_test.go
@@ -1,11 +1,52 @@
 package pmsg
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/filecoin-project/go-f3/gpbft"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCompleteMessage(t *testing.T) {
+	// chainex is unused by the cases below; cases requiring resolution are
+	// exercised through the integration/emulator tests.
+	pmm := &PartialMessageManager{}
+	ctx := context.Background()
+
+	commitForBottom := &gpbft.GMessage{
+		Sender: 1,
+		Vote: gpbft.Payload{
+			Instance: 42,
+			Phase:    gpbft.COMMIT_PHASE,
+			Value:    &gpbft.ECChain{},
+		},
+	}
+
+	for _, tc := range []struct {
+		name          string
+		pgmsg         *gpbft.PartialGMessage
+		wantMsg       *gpbft.GMessage
+		wantCompleted bool
+	}{
+		{
+			name: "nil input",
+		},
+		{
+			name:          "COMMIT for bottom",
+			pgmsg:         &gpbft.PartialGMessage{GMessage: commitForBottom},
+			wantMsg:       commitForBottom,
+			wantCompleted: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMsg, gotCompleted := pmm.CompleteMessage(ctx, tc.pgmsg)
+			require.Equal(t, tc.wantCompleted, gotCompleted)
+			require.Same(t, tc.wantMsg, gotMsg)
+		})
+	}
+}
 
 func Test_roundDownToUnixTime(t *testing.T) {
 	someTime, err := time.Parse(time.RFC3339Nano, "2024-03-07T15:06:20.522847852Z")


### PR DESCRIPTION
Introduce a PartialGMessage.HasChainValue helper that reports whether a
partial message carries a chain value to resolve via chainexchange, and
use it in CompleteMessage in place of the inline VoteValueKey.IsZero
check.